### PR TITLE
分离LoginNoProcessLoginV2JSON这种情况的提示语句

### DIFF
--- a/Beanfun/Lang/zh-Hans.xaml
+++ b/Beanfun/Lang/zh-Hans.xaml
@@ -272,6 +272,7 @@
     <system:String x:Key="LoginNoViewstateGenerator">登录失败，未找到ViewstateGenerator信息，请检查网络连接。</system:String>
     <system:String x:Key="LoginNoSamplecaptcha">登录失败，未找到Samplecaptcha信息，请检查网络连接。</system:String>
     <system:String x:Key="LoginNoAkey">登录失败，账号或密码错误。</system:String>
+    <system:String x:Key="LoginNoProcessLoginV2JSON">登录失败，没有正确的获取到账号信息，可能是账号或密码错误，也有可能是ip地址被锁定（这很有可能是因为多个人共同使用同一个加速器ip地址造成的，请更换加速器节点）</system:String>
     <system:String x:Key="LoginNoAccountMatch">登录失败，无法获取账号列表。</system:String>
     <system:String x:Key="LoginNoWebtoken">登录失败，登录后无法获取bfWebToken Cookie。</system:String>
     <system:String x:Key="LoginUnknown">登录失败，请稍后再试</system:String>

--- a/Beanfun/Lang/zh.xaml
+++ b/Beanfun/Lang/zh.xaml
@@ -296,6 +296,7 @@
     <system:String x:Key="LoginNoViewstateGenerator">登入失敗，未找到ViewstateGenerator訊息，請檢查網絡連線。</system:String>
     <system:String x:Key="LoginNoSamplecaptcha">登入失敗，未找到Samplecaptcha訊息，請檢查網絡連線。</system:String>
     <system:String x:Key="LoginNoAkey">登入失敗，帳號或密碼錯誤。</system:String>
+    <system:String x:Key="LoginNoProcessLoginV2JSON">登錄失敗，沒有正確的獲取到賬號信息，可能是賬號或密碼錯誤，也有可能是ip地址被鎖定（這很有可能是因為多個人共同使用同一個加速器ip地址造成的，請更換加速器節點）</system:String>
     <system:String x:Key="LoginNoAccountMatch">登入失敗，無法取得帳號列表。</system:String>
     <system:String x:Key="LoginNoWebtoken">登入失敗，登入後無法取得bfWebToken Cookie。</system:String>
     <system:String x:Key="LoginUnknown">登入失敗，請稍後再試</system:String>

--- a/Beanfun/MainWindow.xaml.cs
+++ b/Beanfun/MainWindow.xaml.cs
@@ -968,8 +968,10 @@ namespace Beanfun
                     method = 0;
                     break;
                 case "LoginNoAkey":
-                case "LoginNoProcessLoginV2JSON":
                     msg = $"{ TryFindResource("LoginNoAkey") as string }({ msg })";
+                    break;
+                case "LoginNoProcessLoginV2JSON":
+                    msg = $"{ TryFindResource("LoginNoProcessLoginV2JSON") as string }({ msg })";
                     break;
                 case "LoginNoAccountMatch":
                 case "LoginGetAccountErr":


### PR DESCRIPTION
使用加速期的公共节点时，经常会爆出账号密码错误，但实际上并不是账号密码错误，而是因为很多人使用同一个节点，导致同一个ip地址访问beanfun过于频繁，ip被beanfun封禁了