### PR TITLE
新增 GitHub Actions 用於線上打包

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -1,0 +1,51 @@
+name: Build and Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Release Tag Name (e.g., v5.6.2603241200)'
+        required: true
+        default: 'v5.6.debug'
+      release_name:
+        description: 'Release Name'
+        required: false
+        default: 'Manual Release'
+
+jobs:
+  build:
+    runs-on: windows-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v2
+
+      - name: Setup NuGet
+        uses: NuGet/setup-nuget@v2
+
+      - name: Restore NuGet Packages
+        run: nuget restore Beanfun.sln
+
+      - name: Build Solution
+        run: msbuild Beanfun.sln /p:Configuration=Release /p:Platform="Any CPU"
+
+      - name: Create Zip Archive
+        shell: pwsh
+        run: |
+          Compress-Archive -Path "Build/Release/*" -DestinationPath "Beanfun-${{ github.event.inputs.tag_name }}.zip"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event.inputs.tag_name }}
+          name: ${{ github.event.inputs.release_name || github.event.inputs.tag_name }}
+          files: Beanfun-${{ github.event.inputs.tag_name }}.zip
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -34,17 +34,12 @@ jobs:
       - name: Build Solution
         run: msbuild Beanfun.sln /p:Configuration=Release /p:Platform="Any CPU"
 
-      - name: Create Zip Archive
-        shell: pwsh
-        run: |
-          Compress-Archive -Path "Build/Release/*" -DestinationPath "Beanfun-${{ github.event.inputs.tag_name }}.zip"
-
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.event.inputs.tag_name }}
           name: ${{ github.event.inputs.release_name || github.event.inputs.tag_name }}
-          files: Beanfun-${{ github.event.inputs.tag_name }}.zip
+          files: Build/Release/Beanfun.exe
           draft: false
           prerelease: false
         env:


### PR DESCRIPTION
建立GitHub Actions打包流程
過往的打包看起來都是作者自己上傳，不過既然有Github Actions可以用就寫了個打包流程

（使用Gemini 3.1 flash寫的）