### PR TITLE
修復台灣地區登入問題、內建舊版資料升級機制

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -141,7 +141,7 @@ jobs:
           Write-Host "Updated $($assemblyInfoFile.Name) to version $newAssemblyVersion"
 
       - name: Publish Application
-        run: dotnet publish Beanfun/Beanfun.csproj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -o publish
+        run: dotnet publish Beanfun/Beanfun.csproj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -p:IncludeAllContentForSelfExtract=true -p:EnableCompressionInSingleFile=true -p:DebugType=none -o publish
 
       - name: Get Version from Compiled EXE and Convert to Timestamp
         id: get_exe_version

--- a/Beanfun/App.xaml.cs
+++ b/Beanfun/App.xaml.cs
@@ -131,7 +131,8 @@ namespace Beanfun
 
         public static int ReleaseResource(string file)
         {
-            string path = string.Format("{0}\\{1}", Environment.CurrentDirectory, file);
+            string baseDir = Path.GetDirectoryName(System.Diagnostics.Process.GetCurrentProcess().MainModule.FileName);
+            string path = Path.Combine(baseDir, file);
             using (Stream stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(file))
             {
                 if (stream != null)

--- a/Beanfun/App.xaml.cs
+++ b/Beanfun/App.xaml.cs
@@ -139,30 +139,26 @@ namespace Beanfun
             {
                 if (stream != null)
                 {
-                    string md5 = GetMD5HashFromStream(stream);
+                    // Fast path: if file exists and size matches, skip MD5 comparison
                     if (File.Exists(path))
                     {
-                        if (md5.ToUpper().Equals(GetMD5HashFromFile(path).ToUpper()))
-                        {
+                        var fileInfo = new FileInfo(path);
+                        if (fileInfo.Length == stream.Length)
                             return 0;
-                        }
-                        else
+
+                        try
                         {
-                            try
-                            {
-                                File.Delete(path);
-                            }
-                            catch
-                            {
-                                return -1;
-                            }
+                            File.Delete(path);
+                        }
+                        catch
+                        {
+                            return -1;
                         }
                     }
+
                     string dir = Path.GetDirectoryName(path);
                     if (!Directory.Exists(dir))
-                    {
                         Directory.CreateDirectory(dir);
-                    }
 
                     stream.Position = 0;
                     File.WriteAllBytes(

--- a/Beanfun/App.xaml.cs
+++ b/Beanfun/App.xaml.cs
@@ -131,7 +131,9 @@ namespace Beanfun
 
         public static int ReleaseResource(string file)
         {
-            string baseDir = Path.GetDirectoryName(System.Diagnostics.Process.GetCurrentProcess().MainModule.FileName);
+            string baseDir = Path.GetDirectoryName(
+                System.Diagnostics.Process.GetCurrentProcess().MainModule.FileName
+            );
             string path = Path.Combine(baseDir, file);
             using (Stream stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(file))
             {

--- a/Beanfun/Beanfun.csproj
+++ b/Beanfun/Beanfun.csproj
@@ -17,9 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ini-parser" Version="2.5.2">
-      <NoWarn>NU1701</NoWarn>
-    </PackageReference>
+    <PackageReference Include="ini-parser-netstandard" Version="2.5.2" />
     <PackageReference Include="log4net" Version="2.0.12" />
     <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.1343.22" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/Beanfun/Helper/AccountManager.cs
+++ b/Beanfun/Helper/AccountManager.cs
@@ -23,7 +23,10 @@ namespace Beanfun
     [Serializable]
     class AccountRecords
     {
-        public List<string> regionList = null, accountList = null, passwdList = null, verifyList = null;
+        public List<string> regionList = null,
+            accountList = null,
+            passwdList = null,
+            verifyList = null;
         public List<int> methodList = null;
         public List<bool> autoLoginList = null;
     }
@@ -31,7 +34,11 @@ namespace Beanfun
     [Serializable]
     class Records
     {
-        public List<string> regionList = null, accountList = null, accountNameList = null, passwdList = null, verifyList = null;
+        public List<string> regionList = null,
+            accountList = null,
+            accountNameList = null,
+            passwdList = null,
+            verifyList = null;
         public List<int> methodList = null;
         public List<bool> autoLoginList = null;
 
@@ -54,10 +61,14 @@ namespace Beanfun
 
     public class AccountManager
     {
-        private static readonly log4net.ILog log = log4net.LogManager.GetLogger(typeof(AccountManager));
+        private static readonly log4net.ILog log = log4net.LogManager.GetLogger(
+            typeof(AccountManager)
+        );
 
         private Records accountRecords = null;
-        private string dataPath = System.Environment.GetFolderPath(System.Environment.SpecialFolder.ApplicationData) + "\\Beanfun\\Users.dat";
+        private string dataPath =
+            System.Environment.GetFolderPath(System.Environment.SpecialFolder.ApplicationData)
+            + "\\Beanfun\\Users.dat";
 
         public bool init()
         {
@@ -67,59 +78,91 @@ namespace Beanfun
         #region helper function
         private void accRecInit()
         {
-            if (accountRecords == null) accountRecords = new Records();
+            if (accountRecords == null)
+                accountRecords = new Records();
 
-            if (accountRecords.accountList == null) accountRecords.accountList = new List<string>();
+            if (accountRecords.accountList == null)
+                accountRecords.accountList = new List<string>();
 
-            if (accountRecords.regionList == null) accountRecords.regionList = new List<string>();
+            if (accountRecords.regionList == null)
+                accountRecords.regionList = new List<string>();
             if (accountRecords.regionList.Count < accountRecords.accountList.Count)
             {
-                for (int i = accountRecords.regionList.Count; i < accountRecords.accountList.Count; i++)
+                for (
+                    int i = accountRecords.regionList.Count;
+                    i < accountRecords.accountList.Count;
+                    i++
+                )
                 {
                     accountRecords.regionList.Add("TW");
                 }
             }
 
-            if (accountRecords.accountNameList == null) accountRecords.accountNameList = new List<string>();
+            if (accountRecords.accountNameList == null)
+                accountRecords.accountNameList = new List<string>();
             if (accountRecords.accountNameList.Count < accountRecords.accountList.Count)
             {
-                for (int i = accountRecords.accountNameList.Count; i < accountRecords.accountList.Count; i++)
+                for (
+                    int i = accountRecords.accountNameList.Count;
+                    i < accountRecords.accountList.Count;
+                    i++
+                )
                 {
                     accountRecords.accountNameList.Add("");
                 }
             }
 
-            if (accountRecords.passwdList == null) accountRecords.passwdList = new List<string>();
+            if (accountRecords.passwdList == null)
+                accountRecords.passwdList = new List<string>();
             if (accountRecords.passwdList.Count < accountRecords.accountList.Count)
             {
-                for (int i = accountRecords.passwdList.Count; i < accountRecords.accountList.Count; i++)
+                for (
+                    int i = accountRecords.passwdList.Count;
+                    i < accountRecords.accountList.Count;
+                    i++
+                )
                 {
                     accountRecords.passwdList.Add("");
                 }
             }
 
-            if (accountRecords.verifyList == null) accountRecords.verifyList = new List<string>();
+            if (accountRecords.verifyList == null)
+                accountRecords.verifyList = new List<string>();
             if (accountRecords.verifyList.Count < accountRecords.accountList.Count)
             {
-                for (int i = accountRecords.verifyList.Count; i < accountRecords.accountList.Count; i++)
+                for (
+                    int i = accountRecords.verifyList.Count;
+                    i < accountRecords.accountList.Count;
+                    i++
+                )
                 {
                     accountRecords.verifyList.Add("");
                 }
             }
 
-            if (accountRecords.methodList == null) accountRecords.methodList = new List<int>();
+            if (accountRecords.methodList == null)
+                accountRecords.methodList = new List<int>();
             if (accountRecords.methodList.Count < accountRecords.accountList.Count)
             {
-                for (int i = accountRecords.methodList.Count; i < accountRecords.accountList.Count; i++)
+                for (
+                    int i = accountRecords.methodList.Count;
+                    i < accountRecords.accountList.Count;
+                    i++
+                )
                 {
                     accountRecords.methodList.Add(0);
                 }
             }
 
-            if (accountRecords.autoLoginList == null) accountRecords.autoLoginList = new List<bool>();
+            if (accountRecords.autoLoginList == null)
+                accountRecords.autoLoginList = new List<bool>();
             if (accountRecords.autoLoginList.Count < accountRecords.accountList.Count)
             {
-                for (int i = accountRecords.autoLoginList.Count; i < accountRecords.accountList.Count; i++)
+                for (
+                    int i = accountRecords.autoLoginList.Count;
+                    i < accountRecords.accountList.Count;
+                    i++
+                )
                 {
                     accountRecords.autoLoginList.Add(false);
                 }
@@ -173,7 +216,11 @@ namespace Beanfun
                         ModifyRegistry myRegistry = new ModifyRegistry();
                         myRegistry.BaseRegistryKey = Microsoft.Win32.Registry.CurrentUser;
                         string entropy = myRegistry.Read("Entropy");
-                        byte[] plaintext = ProtectedData.Unprotect(cipher, Encoding.UTF8.GetBytes(entropy), DataProtectionScope.CurrentUser);
+                        byte[] plaintext = ProtectedData.Unprotect(
+                            cipher,
+                            Encoding.UTF8.GetBytes(entropy),
+                            DataProtectionScope.CurrentUser
+                        );
                         return Encoding.UTF8.GetString(plaintext);
                     }
                     catch
@@ -200,7 +247,9 @@ namespace Beanfun
             {
                 var chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
                 var random = new Random();
-                string entropy = new string(Enumerable.Repeat(chars, 8).Select(s => s[random.Next(s.Length)]).ToArray());
+                string entropy = new string(
+                    Enumerable.Repeat(chars, 8).Select(s => s[random.Next(s.Length)]).ToArray()
+                );
 
                 ModifyRegistry myRegistry = new ModifyRegistry();
                 myRegistry.BaseRegistryKey = Microsoft.Win32.Registry.CurrentUser;
@@ -219,12 +268,29 @@ namespace Beanfun
         #endregion
 
         #region Interface
-        public bool addAccount(string region, string account, string name, string password, string verify, int method, bool autoLogin)
+        public bool addAccount(
+            string region,
+            string account,
+            string name,
+            string password,
+            string verify,
+            int method,
+            bool autoLogin
+        )
         {
             return addAccount(-1, region, account, name, password, verify, method, autoLogin);
         }
 
-        public bool addAccount(int index, string region, string account, string name, string password, string verify, int method, bool autoLogin)
+        public bool addAccount(
+            int index,
+            string region,
+            string account,
+            string name,
+            string password,
+            string verify,
+            int method,
+            bool autoLogin
+        )
         {
             bool isExists = false;
             List<int> regionIndex = new List<int>();
@@ -287,7 +353,10 @@ namespace Beanfun
         {
             for (int i = 0; i < accountRecords.accountList.Count; ++i)
             {
-                if (account == accountRecords.accountList[i] && region == accountRecords.regionList[i])
+                if (
+                    account == accountRecords.accountList[i]
+                    && region == accountRecords.regionList[i]
+                )
                 {
                     return accountRecords.accountNameList[i];
                 }
@@ -299,7 +368,10 @@ namespace Beanfun
         {
             for (int i = 0; i < accountRecords.accountList.Count; ++i)
             {
-                if (account == accountRecords.accountList[i] && region == accountRecords.regionList[i])
+                if (
+                    account == accountRecords.accountList[i]
+                    && region == accountRecords.regionList[i]
+                )
                 {
                     return accountRecords.passwdList[i];
                 }
@@ -311,7 +383,10 @@ namespace Beanfun
         {
             for (int i = 0; i < accountRecords.accountList.Count; ++i)
             {
-                if (account == accountRecords.accountList[i] && region == accountRecords.regionList[i])
+                if (
+                    account == accountRecords.accountList[i]
+                    && region == accountRecords.regionList[i]
+                )
                 {
                     return accountRecords.verifyList[i];
                 }
@@ -323,7 +398,10 @@ namespace Beanfun
         {
             for (int i = 0; i < accountRecords.accountList.Count; ++i)
             {
-                if (account == accountRecords.accountList[i] && region == accountRecords.regionList[i])
+                if (
+                    account == accountRecords.accountList[i]
+                    && region == accountRecords.regionList[i]
+                )
                 {
                     return accountRecords.methodList[i];
                 }
@@ -335,7 +413,10 @@ namespace Beanfun
         {
             for (int i = 0; i < accountRecords.accountList.Count; ++i)
             {
-                if (account == accountRecords.accountList[i] && region == accountRecords.regionList[i])
+                if (
+                    account == accountRecords.accountList[i]
+                    && region == accountRecords.regionList[i]
+                )
                 {
                     return accountRecords.autoLoginList[i];
                 }
@@ -347,7 +428,10 @@ namespace Beanfun
         {
             for (int i = 0; i < accountRecords.accountList.Count; ++i)
             {
-                if (account == accountRecords.accountList[i] && region == accountRecords.regionList[i])
+                if (
+                    account == accountRecords.accountList[i]
+                    && region == accountRecords.regionList[i]
+                )
                 {
                     accountRecords.regionList.RemoveAt(i);
                     accountRecords.accountList.RemoveAt(i);
@@ -417,7 +501,8 @@ namespace Beanfun
                     // 忽略編譯器針對 BinaryFormatter 的安全性警告
                     // 注意：此類別極度不安全，僅限於此處讀取舊版資料使用，新代碼嚴禁使用！
 #pragma warning disable SYSLIB0011
-                    var bformatter = new System.Runtime.Serialization.Formatters.Binary.BinaryFormatter();
+                    var bformatter =
+                        new System.Runtime.Serialization.Formatters.Binary.BinaryFormatter();
                     object oldRecords = bformatter.Deserialize(stream);
 #pragma warning restore SYSLIB0011
 

--- a/Beanfun/Helper/AccountManager.cs
+++ b/Beanfun/Helper/AccountManager.cs
@@ -517,10 +517,14 @@ namespace Beanfun
                             accRecInit();
                             storeRecord(); // 立即將轉換後的資料以最新 JSON 格式寫入，覆寫舊檔
 
-                            log.Info("偵測到舊版帳號資料，已成功自動升級至 JSON 格式。");
+                            log.Info("Legacy account data auto-migrated to JSON format.");
                             System.Windows.MessageBox.Show(
-                                "系統已成功將您的舊版帳號資料自動升級至新格式！\n您現在可以正常使用所有帳號。",
-                                "資料轉換成功",
+                                System.Windows.Application.Current.TryFindResource(
+                                    "LegacyDataMigrateSuccess"
+                                ) as string,
+                                System.Windows.Application.Current.TryFindResource(
+                                    "LegacyDataMigrateTitle"
+                                ) as string,
                                 System.Windows.MessageBoxButton.OK,
                                 System.Windows.MessageBoxImage.Information
                             );
@@ -532,7 +536,7 @@ namespace Beanfun
             catch (Exception ex)
             {
                 // 若因 .NET 版本限制或資料損毀導致轉換失敗，則記錄錯誤，並讓 accRecInit 建立新的空白紀錄
-                log.Error($"自動轉換舊版資料失敗: {ex.Message}");
+                log.Error($"Auto-migration of legacy data failed: {ex.Message}");
             }
 
             return false;

--- a/Beanfun/Helper/AccountManager.cs
+++ b/Beanfun/Helper/AccountManager.cs
@@ -406,6 +406,7 @@ namespace Beanfun
 
         #region Legacy format migration
         // Fix #182: 實作內建的舊版資料自動升級機制，取代原先會導致 404 的外部轉換工具
+        // TODO: 此升級機制僅為過渡用途。建議於發布幾個版本後，確認多數活躍玩家皆已轉換至 JSON 格式時，將此方法徹底移除。
         private bool TryAutoMigrateLegacyData(string raw)
         {
             try

--- a/Beanfun/Helper/AccountManager.cs
+++ b/Beanfun/Helper/AccountManager.cs
@@ -23,10 +23,7 @@ namespace Beanfun
     [Serializable]
     class AccountRecords
     {
-        public List<string> regionList = null,
-            accountList = null,
-            passwdList = null,
-            verifyList = null;
+        public List<string> regionList = null, accountList = null, passwdList = null, verifyList = null;
         public List<int> methodList = null;
         public List<bool> autoLoginList = null;
     }
@@ -34,11 +31,7 @@ namespace Beanfun
     [Serializable]
     class Records
     {
-        public List<string> regionList = null,
-            accountList = null,
-            accountNameList = null,
-            passwdList = null,
-            verifyList = null;
+        public List<string> regionList = null, accountList = null, accountNameList = null, passwdList = null, verifyList = null;
         public List<int> methodList = null;
         public List<bool> autoLoginList = null;
 
@@ -61,17 +54,10 @@ namespace Beanfun
 
     public class AccountManager
     {
-        private static readonly log4net.ILog log = log4net.LogManager.GetLogger(
-            typeof(AccountManager)
-        );
-
-        private const string MigrationToolUrl =
-            "https://github.com/pungin/Beanfun/releases/tag/account-migrator";
+        private static readonly log4net.ILog log = log4net.LogManager.GetLogger(typeof(AccountManager));
 
         private Records accountRecords = null;
-        private string dataPath =
-            System.Environment.GetFolderPath(System.Environment.SpecialFolder.ApplicationData)
-            + "\\Beanfun\\Users.dat";
+        private string dataPath = System.Environment.GetFolderPath(System.Environment.SpecialFolder.ApplicationData) + "\\Beanfun\\Users.dat";
 
         public bool init()
         {
@@ -81,91 +67,59 @@ namespace Beanfun
         #region helper function
         private void accRecInit()
         {
-            if (accountRecords == null)
-                accountRecords = new Records();
+            if (accountRecords == null) accountRecords = new Records();
 
-            if (accountRecords.accountList == null)
-                accountRecords.accountList = new List<string>();
+            if (accountRecords.accountList == null) accountRecords.accountList = new List<string>();
 
-            if (accountRecords.regionList == null)
-                accountRecords.regionList = new List<string>();
+            if (accountRecords.regionList == null) accountRecords.regionList = new List<string>();
             if (accountRecords.regionList.Count < accountRecords.accountList.Count)
             {
-                for (
-                    int i = accountRecords.regionList.Count;
-                    i < accountRecords.accountList.Count;
-                    i++
-                )
+                for (int i = accountRecords.regionList.Count; i < accountRecords.accountList.Count; i++)
                 {
                     accountRecords.regionList.Add("TW");
                 }
             }
 
-            if (accountRecords.accountNameList == null)
-                accountRecords.accountNameList = new List<string>();
+            if (accountRecords.accountNameList == null) accountRecords.accountNameList = new List<string>();
             if (accountRecords.accountNameList.Count < accountRecords.accountList.Count)
             {
-                for (
-                    int i = accountRecords.accountNameList.Count;
-                    i < accountRecords.accountList.Count;
-                    i++
-                )
+                for (int i = accountRecords.accountNameList.Count; i < accountRecords.accountList.Count; i++)
                 {
                     accountRecords.accountNameList.Add("");
                 }
             }
 
-            if (accountRecords.passwdList == null)
-                accountRecords.passwdList = new List<string>();
+            if (accountRecords.passwdList == null) accountRecords.passwdList = new List<string>();
             if (accountRecords.passwdList.Count < accountRecords.accountList.Count)
             {
-                for (
-                    int i = accountRecords.passwdList.Count;
-                    i < accountRecords.accountList.Count;
-                    i++
-                )
+                for (int i = accountRecords.passwdList.Count; i < accountRecords.accountList.Count; i++)
                 {
                     accountRecords.passwdList.Add("");
                 }
             }
 
-            if (accountRecords.verifyList == null)
-                accountRecords.verifyList = new List<string>();
+            if (accountRecords.verifyList == null) accountRecords.verifyList = new List<string>();
             if (accountRecords.verifyList.Count < accountRecords.accountList.Count)
             {
-                for (
-                    int i = accountRecords.verifyList.Count;
-                    i < accountRecords.accountList.Count;
-                    i++
-                )
+                for (int i = accountRecords.verifyList.Count; i < accountRecords.accountList.Count; i++)
                 {
                     accountRecords.verifyList.Add("");
                 }
             }
 
-            if (accountRecords.methodList == null)
-                accountRecords.methodList = new List<int>();
+            if (accountRecords.methodList == null) accountRecords.methodList = new List<int>();
             if (accountRecords.methodList.Count < accountRecords.accountList.Count)
             {
-                for (
-                    int i = accountRecords.methodList.Count;
-                    i < accountRecords.accountList.Count;
-                    i++
-                )
+                for (int i = accountRecords.methodList.Count; i < accountRecords.accountList.Count; i++)
                 {
                     accountRecords.methodList.Add(0);
                 }
             }
 
-            if (accountRecords.autoLoginList == null)
-                accountRecords.autoLoginList = new List<bool>();
+            if (accountRecords.autoLoginList == null) accountRecords.autoLoginList = new List<bool>();
             if (accountRecords.autoLoginList.Count < accountRecords.accountList.Count)
             {
-                for (
-                    int i = accountRecords.autoLoginList.Count;
-                    i < accountRecords.accountList.Count;
-                    i++
-                )
+                for (int i = accountRecords.autoLoginList.Count; i < accountRecords.accountList.Count; i++)
                 {
                     accountRecords.autoLoginList.Add(false);
                 }
@@ -179,16 +133,14 @@ namespace Beanfun
             {
                 try
                 {
+                    // 嘗試以新版 JSON 格式讀取資料
                     accountRecords = JsonConvert.DeserializeObject<Records>(raw);
                 }
                 catch
                 {
                     accountRecords = null;
-                    if (IsLegacyFormat(raw))
-                    {
-                        log.Warn("Detected legacy BinaryFormatter account data");
-                        ShowLegacyFormatWarning();
-                    }
+                    // 解析失敗時，自動視為舊版 BinaryFormatter 格式並嘗試進行無縫轉換
+                    TryAutoMigrateLegacyData(raw);
                 }
             }
             accRecInit();
@@ -221,12 +173,8 @@ namespace Beanfun
                         ModifyRegistry myRegistry = new ModifyRegistry();
                         myRegistry.BaseRegistryKey = Microsoft.Win32.Registry.CurrentUser;
                         string entropy = myRegistry.Read("Entropy");
-                        byte[] plaintext = ProtectedData.Unprotect(
-                            cipher,
-                            Encoding.UTF8.GetBytes(entropy),
-                            DataProtectionScope.CurrentUser
-                        );
-                        return System.Text.Encoding.UTF8.GetString(plaintext);
+                        byte[] plaintext = ProtectedData.Unprotect(cipher, Encoding.UTF8.GetBytes(entropy), DataProtectionScope.CurrentUser);
+                        return Encoding.UTF8.GetString(plaintext);
                     }
                     catch
                     {
@@ -250,12 +198,9 @@ namespace Beanfun
         {
             using (BinaryWriter writer = new BinaryWriter(File.Open(dataPath, FileMode.Create)))
             {
-                // Create random entropy of 8 characters.
                 var chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
                 var random = new Random();
-                string entropy = new string(
-                    Enumerable.Repeat(chars, 8).Select(s => s[random.Next(s.Length)]).ToArray()
-                );
+                string entropy = new string(Enumerable.Repeat(chars, 8).Select(s => s[random.Next(s.Length)]).ToArray());
 
                 ModifyRegistry myRegistry = new ModifyRegistry();
                 myRegistry.BaseRegistryKey = Microsoft.Win32.Registry.CurrentUser;
@@ -274,29 +219,12 @@ namespace Beanfun
         #endregion
 
         #region Interface
-        public bool addAccount(
-            string region,
-            string account,
-            string name,
-            string password,
-            string verify,
-            int method,
-            bool autoLogin
-        )
+        public bool addAccount(string region, string account, string name, string password, string verify, int method, bool autoLogin)
         {
             return addAccount(-1, region, account, name, password, verify, method, autoLogin);
         }
 
-        public bool addAccount(
-            int index,
-            string region,
-            string account,
-            string name,
-            string password,
-            string verify,
-            int method,
-            bool autoLogin
-        )
+        public bool addAccount(int index, string region, string account, string name, string password, string verify, int method, bool autoLogin)
         {
             bool isExists = false;
             List<int> regionIndex = new List<int>();
@@ -359,10 +287,7 @@ namespace Beanfun
         {
             for (int i = 0; i < accountRecords.accountList.Count; ++i)
             {
-                if (
-                    account == accountRecords.accountList[i]
-                    && region == accountRecords.regionList[i]
-                )
+                if (account == accountRecords.accountList[i] && region == accountRecords.regionList[i])
                 {
                     return accountRecords.accountNameList[i];
                 }
@@ -374,10 +299,7 @@ namespace Beanfun
         {
             for (int i = 0; i < accountRecords.accountList.Count; ++i)
             {
-                if (
-                    account == accountRecords.accountList[i]
-                    && region == accountRecords.regionList[i]
-                )
+                if (account == accountRecords.accountList[i] && region == accountRecords.regionList[i])
                 {
                     return accountRecords.passwdList[i];
                 }
@@ -389,15 +311,11 @@ namespace Beanfun
         {
             for (int i = 0; i < accountRecords.accountList.Count; ++i)
             {
-                if (
-                    account == accountRecords.accountList[i]
-                    && region == accountRecords.regionList[i]
-                )
+                if (account == accountRecords.accountList[i] && region == accountRecords.regionList[i])
                 {
                     return accountRecords.verifyList[i];
                 }
             }
-
             return null;
         }
 
@@ -405,15 +323,11 @@ namespace Beanfun
         {
             for (int i = 0; i < accountRecords.accountList.Count; ++i)
             {
-                if (
-                    account == accountRecords.accountList[i]
-                    && region == accountRecords.regionList[i]
-                )
+                if (account == accountRecords.accountList[i] && region == accountRecords.regionList[i])
                 {
                     return accountRecords.methodList[i];
                 }
             }
-
             return -1;
         }
 
@@ -421,15 +335,11 @@ namespace Beanfun
         {
             for (int i = 0; i < accountRecords.accountList.Count; ++i)
             {
-                if (
-                    account == accountRecords.accountList[i]
-                    && region == accountRecords.regionList[i]
-                )
+                if (account == accountRecords.accountList[i] && region == accountRecords.regionList[i])
                 {
                     return accountRecords.autoLoginList[i];
                 }
             }
-
             return false;
         }
 
@@ -437,10 +347,7 @@ namespace Beanfun
         {
             for (int i = 0; i < accountRecords.accountList.Count; ++i)
             {
-                if (
-                    account == accountRecords.accountList[i]
-                    && region == accountRecords.regionList[i]
-                )
+                if (account == accountRecords.accountList[i] && region == accountRecords.regionList[i])
                 {
                     accountRecords.regionList.RemoveAt(i);
                     accountRecords.accountList.RemoveAt(i);
@@ -454,7 +361,6 @@ namespace Beanfun
                     return true;
                 }
             }
-
             return false;
         }
 
@@ -483,17 +389,13 @@ namespace Beanfun
                 accountRecords = JsonConvert.DeserializeObject<Records>(raw);
                 accRecInit();
                 storeRecord();
+                return true;
             }
             catch
             {
-                if (IsLegacyFormat(raw))
-                {
-                    ShowLegacyFormatWarning();
-                }
-                return false;
+                // 匯入失敗時，嘗試將其視為舊版格式進行轉換
+                return TryAutoMigrateLegacyData(raw);
             }
-
-            return true;
         }
 
         public string exportRecord()
@@ -503,35 +405,51 @@ namespace Beanfun
         #endregion
 
         #region Legacy format migration
-        private static bool IsLegacyFormat(string raw)
+        // Fix #182: 實作內建的舊版資料自動升級機制，取代原先會導致 404 的外部轉換工具
+        private bool TryAutoMigrateLegacyData(string raw)
         {
-            if (string.IsNullOrWhiteSpace(raw))
-                return false;
-            var trimmed = raw.TrimStart();
-            return !trimmed.StartsWith("{") && !trimmed.StartsWith("[");
-        }
-
-        private static void ShowLegacyFormatWarning()
-        {
-            var result = System.Windows.MessageBox.Show(
-                "偵測到舊版帳號資料格式（BinaryFormatter），此格式在新版中不再支援。\n\n"
-                    + "是否前往下載帳號資料轉換工具？\n"
-                    + "轉換完成後重新啟動程式即可恢復帳號資料。",
-                "帳號資料格式不相容",
-                System.Windows.MessageBoxButton.YesNo,
-                System.Windows.MessageBoxImage.Warning
-            );
-
-            if (result == System.Windows.MessageBoxResult.Yes)
+            try
             {
-                System.Diagnostics.Process.Start(
-                    new System.Diagnostics.ProcessStartInfo
+                byte[] cipher = Convert.FromBase64String(raw);
+                using (var stream = new MemoryStream(cipher))
+                {
+                    // 忽略編譯器針對 BinaryFormatter 的安全性警告
+                    // 注意：此類別極度不安全，僅限於此處讀取舊版資料使用，新代碼嚴禁使用！
+#pragma warning disable SYSLIB0011
+                    var bformatter = new System.Runtime.Serialization.Formatters.Binary.BinaryFormatter();
+                    object oldRecords = bformatter.Deserialize(stream);
+#pragma warning restore SYSLIB0011
+
+                    if (oldRecords != null)
                     {
-                        FileName = MigrationToolUrl,
-                        UseShellExecute = true,
+                        // 透過 JSON 序列化作為中介，避免類別轉型 (Casting) 發生例外狀況
+                        string tempJson = JsonConvert.SerializeObject(oldRecords);
+                        accountRecords = JsonConvert.DeserializeObject<Records>(tempJson);
+
+                        if (accountRecords != null)
+                        {
+                            accRecInit();
+                            storeRecord(); // 立即將轉換後的資料以最新 JSON 格式寫入，覆寫舊檔
+
+                            log.Info("偵測到舊版帳號資料，已成功自動升級至 JSON 格式。");
+                            System.Windows.MessageBox.Show(
+                                "系統已成功將您的舊版帳號資料自動升級至新格式！\n您現在可以正常使用所有帳號。",
+                                "資料轉換成功",
+                                System.Windows.MessageBoxButton.OK,
+                                System.Windows.MessageBoxImage.Information
+                            );
+                            return true;
+                        }
                     }
-                );
+                }
             }
+            catch (Exception ex)
+            {
+                // 若因 .NET 版本限制或資料損毀導致轉換失敗，則記錄錯誤，並讓 accRecInit 建立新的空白紀錄
+                log.Error($"自動轉換舊版資料失敗: {ex.Message}");
+            }
+
+            return false;
         }
         #endregion
     }

--- a/Beanfun/Lang/en.xaml
+++ b/Beanfun/Lang/en.xaml
@@ -512,4 +512,13 @@
   <system:String x:Key="AdvanceCheckFillEmailAndCaptcha"
     >Please fill in both email and captcha code.</system:String
   >
+  <system:String x:Key="GamePassLogin">GamePass Login</system:String>
+  <system:String x:Key="GamePassWaiting">Waiting for GamePass authentication...</system:String>
+  <system:String x:Key="GamePassOpen">Open GamePass Login</system:String>
+  <system:String x:Key="SessionKeyFailed"
+    >Unable to get SessionKey. Please try again later.</system:String
+  >
+  <system:String x:Key="ConnectionFailed"
+    >Connection failed. Please check your network.</system:String
+  >
 </ResourceDictionary>

--- a/Beanfun/Lang/en.xaml
+++ b/Beanfun/Lang/en.xaml
@@ -521,4 +521,8 @@
   <system:String x:Key="ConnectionFailed"
     >Connection failed. Please check your network.</system:String
   >
+  <system:String x:Key="LegacyDataMigrateSuccess"
+    >Your legacy account data has been successfully upgraded to the new format!&#x0a;You can now use all your accounts normally.</system:String
+  >
+  <system:String x:Key="LegacyDataMigrateTitle">Data Migration Successful</system:String>
 </ResourceDictionary>

--- a/Beanfun/Lang/en.xaml
+++ b/Beanfun/Lang/en.xaml
@@ -497,4 +497,19 @@
   <system:String x:Key="CopyDeeplinkNotReady"
     >Deeplink is not ready yet. Please wait for the QR Code to load.</system:String
   >
+  <system:String x:Key="AdvanceCheckSuccessRetry"
+    >Verification successful! Please enter your password again to log in.</system:String
+  >
+  <system:String x:Key="AdvanceCheckAccountAbnormal"
+    >Account status is abnormal. Please log in via browser to check (may need to contact support).</system:String
+  >
+  <system:String x:Key="AdvanceCheckNoCaptchaId"
+    >Unable to retrieve captcha ID. Account may be in an abnormal state.</system:String
+  >
+  <system:String x:Key="AdvanceCheckCaptchaLoadFailed"
+    >Unable to load captcha image (session may have expired).</system:String
+  >
+  <system:String x:Key="AdvanceCheckFillEmailAndCaptcha"
+    >Please fill in both email and captcha code.</system:String
+  >
 </ResourceDictionary>

--- a/Beanfun/Lang/en.xaml
+++ b/Beanfun/Lang/en.xaml
@@ -525,4 +525,11 @@
     >Your legacy account data has been successfully upgraded to the new format!&#x0a;You can now use all your accounts normally.</system:String
   >
   <system:String x:Key="LegacyDataMigrateTitle">Data Migration Successful</system:String>
+  <system:String x:Key="AdvanceCheckTitle">Advanced Verification</system:String>
+  <system:String x:Key="AdvanceCheckHintPrefix">Hint: </system:String>
+  <system:String x:Key="AdvanceCheckInputEmail">Enter verification Email:</system:String>
+  <system:String x:Key="AdvanceCheckInputPhone">Enter verification phone number:</system:String>
+  <system:String x:Key="AdvanceCheckCaptchaLabel">Captcha:</system:String>
+  <system:String x:Key="AdvanceCheckConfirm">Confirm</system:String>
+  <system:String x:Key="AdvanceCheckCancel">Cancel</system:String>
 </ResourceDictionary>

--- a/Beanfun/Lang/zh-Hans.xaml
+++ b/Beanfun/Lang/zh-Hans.xaml
@@ -428,4 +428,11 @@
     >系统已成功将您的旧版帐号资料自动升级至新格式！&#x0a;您现在可以正常使用所有帐号。</system:String
   >
   <system:String x:Key="LegacyDataMigrateTitle">资料转换成功</system:String>
+  <system:String x:Key="AdvanceCheckTitle">进阶验证</system:String>
+  <system:String x:Key="AdvanceCheckHintPrefix">提示：</system:String>
+  <system:String x:Key="AdvanceCheckInputEmail">请输入认证 Email：</system:String>
+  <system:String x:Key="AdvanceCheckInputPhone">请输入认证电话号码：</system:String>
+  <system:String x:Key="AdvanceCheckCaptchaLabel">图形验证码：</system:String>
+  <system:String x:Key="AdvanceCheckConfirm">确定</system:String>
+  <system:String x:Key="AdvanceCheckCancel">取消</system:String>
 </ResourceDictionary>

--- a/Beanfun/Lang/zh-Hans.xaml
+++ b/Beanfun/Lang/zh-Hans.xaml
@@ -419,4 +419,9 @@
     >无法载入验证码图片（Session 可能已过期）</system:String
   >
   <system:String x:Key="AdvanceCheckFillEmailAndCaptcha">请填写 Email 和验证码</system:String>
+  <system:String x:Key="GamePassLogin">GamePass 登录</system:String>
+  <system:String x:Key="GamePassWaiting">正在等待 GamePass 认证...</system:String>
+  <system:String x:Key="GamePassOpen">开启 GamePass 登录</system:String>
+  <system:String x:Key="SessionKeyFailed">无法取得 SessionKey，请稍后再试</system:String>
+  <system:String x:Key="ConnectionFailed">连接失败，请检查网络连接</system:String>
 </ResourceDictionary>

--- a/Beanfun/Lang/zh-Hans.xaml
+++ b/Beanfun/Lang/zh-Hans.xaml
@@ -424,4 +424,8 @@
   <system:String x:Key="GamePassOpen">开启 GamePass 登录</system:String>
   <system:String x:Key="SessionKeyFailed">无法取得 SessionKey，请稍后再试</system:String>
   <system:String x:Key="ConnectionFailed">连接失败，请检查网络连接</system:String>
+  <system:String x:Key="LegacyDataMigrateSuccess"
+    >系统已成功将您的旧版帐号资料自动升级至新格式！&#x0a;您现在可以正常使用所有帐号。</system:String
+  >
+  <system:String x:Key="LegacyDataMigrateTitle">资料转换成功</system:String>
 </ResourceDictionary>

--- a/Beanfun/Lang/zh-Hans.xaml
+++ b/Beanfun/Lang/zh-Hans.xaml
@@ -408,4 +408,15 @@
   <system:String x:Key="CopyDeeplinkNotReady"
     >Deeplink 尚未取得，请等待二维码加载完成。</system:String
   >
+  <system:String x:Key="AdvanceCheckSuccessRetry">验证成功！请再次输入密码登录游戏。</system:String>
+  <system:String x:Key="AdvanceCheckAccountAbnormal"
+    >帐号状态异常，请先使用浏览器登录官网确认（可能需联络客服）</system:String
+  >
+  <system:String x:Key="AdvanceCheckNoCaptchaId"
+    >无法取得验证码编号，帐号可能处于异常状态</system:String
+  >
+  <system:String x:Key="AdvanceCheckCaptchaLoadFailed"
+    >无法载入验证码图片（Session 可能已过期）</system:String
+  >
+  <system:String x:Key="AdvanceCheckFillEmailAndCaptcha">请填写 Email 和验证码</system:String>
 </ResourceDictionary>

--- a/Beanfun/Lang/zh.xaml
+++ b/Beanfun/Lang/zh.xaml
@@ -441,4 +441,9 @@
     >無法載入驗證碼圖片（Session 可能已過期）</system:String
   >
   <system:String x:Key="AdvanceCheckFillEmailAndCaptcha">請填寫 Email 同驗證碼</system:String>
+  <system:String x:Key="GamePassLogin">GamePass 登入</system:String>
+  <system:String x:Key="GamePassWaiting">正在等待 GamePass 認證...</system:String>
+  <system:String x:Key="GamePassOpen">開啟 GamePass 登入</system:String>
+  <system:String x:Key="SessionKeyFailed">無法取得 SessionKey，請稍後再試</system:String>
+  <system:String x:Key="ConnectionFailed">連線失敗，請檢查網路連線</system:String>
 </ResourceDictionary>

--- a/Beanfun/Lang/zh.xaml
+++ b/Beanfun/Lang/zh.xaml
@@ -450,4 +450,11 @@
     >系統已成功將您的舊版帳號資料自動升級至新格式！&#x0a;您現在可以正常使用所有帳號。</system:String
   >
   <system:String x:Key="LegacyDataMigrateTitle">資料轉換成功</system:String>
+  <system:String x:Key="AdvanceCheckTitle">進階驗證</system:String>
+  <system:String x:Key="AdvanceCheckHintPrefix">提示：</system:String>
+  <system:String x:Key="AdvanceCheckInputEmail">請輸入認證 Email：</system:String>
+  <system:String x:Key="AdvanceCheckInputPhone">請輸入認證電話號碼：</system:String>
+  <system:String x:Key="AdvanceCheckCaptchaLabel">圖形驗證碼：</system:String>
+  <system:String x:Key="AdvanceCheckConfirm">確定</system:String>
+  <system:String x:Key="AdvanceCheckCancel">取消</system:String>
 </ResourceDictionary>

--- a/Beanfun/Lang/zh.xaml
+++ b/Beanfun/Lang/zh.xaml
@@ -430,4 +430,15 @@
   <system:String x:Key="CopyDeeplinkNotReady"
     >Deeplink 尚未取得，請等待 QR Code 載入完成。</system:String
   >
+  <system:String x:Key="AdvanceCheckSuccessRetry">驗證成功！請再次輸入密碼登入遊戲。</system:String>
+  <system:String x:Key="AdvanceCheckAccountAbnormal"
+    >帳號狀態異常，請先使用瀏覽器登入官網確認（可能需聯絡客服）</system:String
+  >
+  <system:String x:Key="AdvanceCheckNoCaptchaId"
+    >無法取得驗證碼編號，帳號可能處於異常狀態</system:String
+  >
+  <system:String x:Key="AdvanceCheckCaptchaLoadFailed"
+    >無法載入驗證碼圖片（Session 可能已過期）</system:String
+  >
+  <system:String x:Key="AdvanceCheckFillEmailAndCaptcha">請填寫 Email 同驗證碼</system:String>
 </ResourceDictionary>

--- a/Beanfun/Lang/zh.xaml
+++ b/Beanfun/Lang/zh.xaml
@@ -446,4 +446,8 @@
   <system:String x:Key="GamePassOpen">開啟 GamePass 登入</system:String>
   <system:String x:Key="SessionKeyFailed">無法取得 SessionKey，請稍後再試</system:String>
   <system:String x:Key="ConnectionFailed">連線失敗，請檢查網路連線</system:String>
+  <system:String x:Key="LegacyDataMigrateSuccess"
+    >系統已成功將您的舊版帳號資料自動升級至新格式！&#x0a;您現在可以正常使用所有帳號。</system:String
+  >
+  <system:String x:Key="LegacyDataMigrateTitle">資料轉換成功</system:String>
 </ResourceDictionary>

--- a/Beanfun/MainWindow.xaml.cs
+++ b/Beanfun/MainWindow.xaml.cs
@@ -1155,10 +1155,12 @@ namespace Beanfun
 
         public bool errexit(string msg, int method, string title = null)
         {
-            string originalMsg = msg;
-
             switch (msg)
             {
+                case "AdvanceCheckSuccessRetry":
+                    msg = "驗證成功！請再次輸入密碼登入遊戲。";
+                    method = 1;
+                    break;
                 case "LoginNoResponse":
                 case "LoginNoSkey":
                 case "LoginNoOTP1":
@@ -1190,41 +1192,55 @@ namespace Beanfun
                 default:
                     if (msg.StartsWith("OTPNoLongPollingKey:"))
                     {
-                        msg = msg.Replace("OTPNoLongPollingKey:", "");
-                        if (msg == "")
+                        string otpDetail = msg.Substring("OTPNoLongPollingKey:".Length);
+                        if (string.IsNullOrEmpty(otpDetail))
                             msg = TryFindResource("GetOtpInitError") as string;
-                        else if (msg.Contains("很抱歉，需先完成進階認證"))
+                        else if (otpDetail.Contains("很抱歉，需先完成進階認證"))
                             msg = TryFindResource("NeedAuthToPlayGame") as string;
                         else if (
-                            msg.Contains("尚未登入，請重新登入") || msg.Contains("無法認證登入狀態")
+                            otpDetail.Contains("尚未登入，請重新登入")
+                            || otpDetail.Contains("無法認證登入狀態")
                         )
                         {
                             msg = TryFindResource("DisconnectedFromServer") as string;
                             method = 1;
                         }
-                        ;
                     }
                     else
                     {
-                        string res = null;
+                        string localized = null;
                         try
                         {
-                            res = TryFindResource(msg) as string;
+                            localized = TryFindResource(msg) as string;
                         }
                         catch { }
-                        if (res != null)
-                            msg = res;
+                        if (localized != null)
+                            msg = localized;
                     }
                     break;
             }
 
-            MessageBox.Show(Regex.Unescape(I18n.ToSimplified(msg)), title);
+            string displayMsg = I18n.ToSimplified(msg);
+            try
+            {
+                if (
+                    !string.IsNullOrEmpty(displayMsg)
+                    && displayMsg.Contains("\\u")
+                    && !displayMsg.Contains(":\\")
+                )
+                    displayMsg = Regex.Unescape(displayMsg);
+            }
+            catch { }
+
+            MessageBox.Show(displayMsg, title ?? TryFindResource("Error") as string);
+
             if (method == 0)
                 App.Current.Shutdown();
             else if (method == 1)
             {
                 loginMethodChanged();
-                accountList.t_Password.Text = "";
+                if (accountList?.t_Password != null)
+                    accountList.t_Password.Text = "";
                 NavigateLoginPage();
             }
 
@@ -1241,6 +1257,93 @@ namespace Beanfun
         public void ResumeWork()
         {
             isCancelRequested = false;
+        }
+
+        private void OnLoginCompleted()
+        {
+            ConfigAppSettings.SetValue("loginMethod", App.LoginMethod.ToString());
+
+            SaveLoginCredentials();
+            ShowAccountListPage();
+        }
+
+        private void SaveLoginCredentials()
+        {
+            bool isAccountLogin =
+                App.LoginRegion != "TW" || App.LoginMethod != (int)LoginMethod.QRCode;
+            if (!isAccountLogin)
+            {
+                ConfigAppSettings.SetValue("AccountID", null);
+                return;
+            }
+
+            var idPassForm = loginPage.id_pass;
+            string accountId = idPassForm.t_AccountID.Text;
+            LastLoginAccountID = accountId;
+
+            ConfigAppSettings.SetValue(
+                "AccountID",
+                string.IsNullOrWhiteSpace(accountId) ? null : accountId
+            );
+
+            if (string.IsNullOrWhiteSpace(accountId))
+                return;
+
+            bool shouldSavePwd =
+                !string.IsNullOrEmpty(idPassForm.t_Password.Password)
+                && idPassForm.checkBox_RememberPWD.IsEnabled
+                && (bool)idPassForm.checkBox_RememberPWD.IsChecked;
+
+            bool shouldAutoLogin = shouldSavePwd && (bool)idPassForm.checkBox_AutoLogin.IsChecked;
+
+            string savedVerify = (bool)verifyPage.checkBoxRememberVerify.IsChecked
+                ? verifyPage.t_Verify.Text
+                : "";
+
+            accountManager.addAccount(
+                App.LoginRegion,
+                accountId,
+                "",
+                shouldSavePwd ? idPassForm.t_Password.Password : "",
+                savedVerify,
+                App.LoginMethod,
+                shouldAutoLogin
+            );
+
+            loginMethodInit();
+        }
+
+        private void ShowAccountListPage()
+        {
+            try
+            {
+                frame.Content = accountList;
+                btn_Region.Visibility = Visibility.Collapsed;
+
+                redrawSAccountList();
+
+                if (!this.pingWorker.IsBusy)
+                    this.pingWorker.RunWorkerAsync();
+
+                updateRemainPoint(this.bfClient.remainPoint);
+
+                accountList.list_Account.Focus();
+
+                bool hasAccounts = this.bfClient.accountList.Count() > 0;
+                bool wantsAutoStart = (bool)settingPage.autoStartGame.IsChecked && hasAccounts;
+                if (wantsAutoStart)
+                {
+                    bool useTradLogin =
+                        (bool)settingPage.tradLogin.IsChecked && login_action_type == 1;
+                    if (useTradLogin || login_action_type == 0)
+                        runGame();
+                    accountList.btnGetOtp_Click(null, null);
+                }
+            }
+            catch
+            {
+                errexit(TryFindResource("LoginNoAccountMatch") as string, 1);
+            }
         }
 
         // Login do work.
@@ -1367,61 +1470,7 @@ namespace Beanfun
                 return;
             }
 
-            ConfigAppSettings.SetValue("loginMethod", App.LoginMethod.ToString());
-            if (App.LoginRegion != "TW" || App.LoginMethod != (int)LoginMethod.QRCode)
-            {
-                LastLoginAccountID = loginPage.id_pass.t_AccountID.Text;
-                ConfigAppSettings.SetValue("AccountID", LastLoginAccountID);
-                accountManager.addAccount(
-                    App.LoginRegion,
-                    loginPage.id_pass.t_AccountID.Text,
-                    "",
-                    loginPage.id_pass.checkBox_RememberPWD.IsEnabled
-                    && (bool)loginPage.id_pass.checkBox_RememberPWD.IsChecked
-                        ? loginPage.id_pass.t_Password.Password
-                        : "",
-                    (bool)verifyPage.checkBoxRememberVerify.IsChecked
-                        ? verifyPage.t_Verify.Text
-                        : "",
-                    App.LoginMethod,
-                    (bool)loginPage.id_pass.checkBox_AutoLogin.IsChecked
-                );
-
-                loginMethodInit();
-            }
-            else
-                ConfigAppSettings.SetValue("AccountID", null);
-
-            try
-            {
-                frame.Content = accountList;
-                btn_Region.Visibility = Visibility.Collapsed;
-
-                redrawSAccountList();
-
-                if (!this.pingWorker.IsBusy)
-                    this.pingWorker.RunWorkerAsync();
-
-                updateRemainPoint(this.bfClient.remainPoint);
-
-                accountList.list_Account.Focus();
-                if (
-                    (bool)settingPage.autoStartGame.IsChecked
-                    && this.bfClient.accountList.Count() > 0
-                )
-                {
-                    if (
-                        ((bool)settingPage.tradLogin.IsChecked && login_action_type == 1)
-                        || login_action_type == 0
-                    )
-                        runGame();
-                    accountList.btnGetOtp_Click(null, null);
-                }
-            }
-            catch
-            {
-                errexit(TryFindResource("LoginNoAccountMatch") as string, 1);
-            }
+            OnLoginCompleted();
         }
 
         // totp do work.
@@ -1534,61 +1583,7 @@ namespace Beanfun
                 return;
             }
 
-            ConfigAppSettings.SetValue("loginMethod", App.LoginMethod.ToString());
-            if (App.LoginRegion != "TW" || App.LoginMethod != (int)LoginMethod.QRCode)
-            {
-                LastLoginAccountID = loginPage.id_pass.t_AccountID.Text;
-                ConfigAppSettings.SetValue("AccountID", LastLoginAccountID);
-                accountManager.addAccount(
-                    App.LoginRegion,
-                    loginPage.id_pass.t_AccountID.Text,
-                    "",
-                    loginPage.id_pass.checkBox_RememberPWD.IsEnabled
-                    && (bool)loginPage.id_pass.checkBox_RememberPWD.IsChecked
-                        ? loginPage.id_pass.t_Password.Password
-                        : "",
-                    (bool)verifyPage.checkBoxRememberVerify.IsChecked
-                        ? verifyPage.t_Verify.Text
-                        : "",
-                    App.LoginMethod,
-                    (bool)loginPage.id_pass.checkBox_AutoLogin.IsChecked
-                );
-
-                loginMethodInit();
-            }
-            else
-                ConfigAppSettings.SetValue("AccountID", null);
-
-            try
-            {
-                frame.Content = accountList;
-                btn_Region.Visibility = Visibility.Collapsed;
-
-                redrawSAccountList();
-
-                if (!this.pingWorker.IsBusy)
-                    this.pingWorker.RunWorkerAsync();
-
-                updateRemainPoint(this.bfClient.remainPoint);
-
-                accountList.list_Account.Focus();
-                if (
-                    (bool)settingPage.autoStartGame.IsChecked
-                    && this.bfClient.accountList.Count() > 0
-                )
-                {
-                    if (
-                        ((bool)settingPage.tradLogin.IsChecked && login_action_type == 1)
-                        || login_action_type == 0
-                    )
-                        runGame();
-                    accountList.btnGetOtp_Click(null, null);
-                }
-            }
-            catch
-            {
-                errexit(TryFindResource("LoginNoAccountMatch") as string, 1);
-            }
+            OnLoginCompleted();
         }
 
         private void redrawSAccountList()

--- a/Beanfun/MainWindow.xaml.cs
+++ b/Beanfun/MainWindow.xaml.cs
@@ -1274,6 +1274,24 @@ namespace Beanfun
             ShowAccountListPage();
         }
 
+        public void GamePassLoginCompleted(
+            string webToken,
+            System.Collections.Generic.List<System.Net.Cookie> cookies
+        )
+        {
+            bfClient.GamePassLogin(webToken, cookies, service_code, service_region);
+
+            if (bfClient.errmsg != null)
+            {
+                errexit(bfClient.errmsg, 1);
+                return;
+            }
+
+            App.LoginMethod = (int)LoginMethod.GamePass;
+            ConfigAppSettings.SetValue("loginMethod", App.LoginMethod.ToString());
+            ShowAccountListPage();
+        }
+
         private void SaveLoginCredentials()
         {
             bool isAccountLogin =

--- a/Beanfun/MainWindow.xaml.cs
+++ b/Beanfun/MainWindow.xaml.cs
@@ -1858,7 +1858,7 @@ namespace Beanfun
                     {
                         var proc = new Process();
                         proc.StartInfo.FileName =
-                            System.Environment.CurrentDirectory + "\\LRProc.exe";
+                            Path.Combine(Path.GetDirectoryName(System.Diagnostics.Process.GetCurrentProcess().MainModule.FileName), "LRProc.exe");
                         proc.StartInfo.Arguments =
                             "ef3e7b42-a87c-4c07-ae3e-eeebeef12762 " + commandLine;
                         proc.StartInfo.WorkingDirectory = Path.GetDirectoryName(path);

--- a/Beanfun/MainWindow.xaml.cs
+++ b/Beanfun/MainWindow.xaml.cs
@@ -1857,8 +1857,12 @@ namespace Beanfun
                     try
                     {
                         var proc = new Process();
-                        proc.StartInfo.FileName =
-                            Path.Combine(Path.GetDirectoryName(System.Diagnostics.Process.GetCurrentProcess().MainModule.FileName), "LRProc.exe");
+                        proc.StartInfo.FileName = Path.Combine(
+                            Path.GetDirectoryName(
+                                System.Diagnostics.Process.GetCurrentProcess().MainModule.FileName
+                            ),
+                            "LRProc.exe"
+                        );
                         proc.StartInfo.Arguments =
                             "ef3e7b42-a87c-4c07-ae3e-eeebeef12762 " + commandLine;
                         proc.StartInfo.WorkingDirectory = Path.GetDirectoryName(path);

--- a/Beanfun/MainWindow.xaml.cs
+++ b/Beanfun/MainWindow.xaml.cs
@@ -1269,7 +1269,8 @@ namespace Beanfun
 
         private void SaveLoginCredentials()
         {
-            bool isAccountLogin = App.LoginRegion != "TW" || App.LoginMethod != (int)LoginMethod.QRCode;
+            bool isAccountLogin =
+                App.LoginRegion != "TW" || App.LoginMethod != (int)LoginMethod.QRCode;
             if (!isAccountLogin)
             {
                 ConfigAppSettings.SetValue("AccountID", null);
@@ -1289,9 +1290,7 @@ namespace Beanfun
                 && (bool)idPassForm.checkBox_RememberPWD.IsChecked
                     ? idPassForm.t_Password.Password
                     : "",
-                (bool)verifyPage.checkBoxRememberVerify.IsChecked
-                    ? verifyPage.t_Verify.Text
-                    : "",
+                (bool)verifyPage.checkBoxRememberVerify.IsChecked ? verifyPage.t_Verify.Text : "",
                 App.LoginMethod,
                 (bool)idPassForm.checkBox_AutoLogin.IsChecked
             );

--- a/Beanfun/MainWindow.xaml.cs
+++ b/Beanfun/MainWindow.xaml.cs
@@ -26,6 +26,7 @@ namespace Beanfun
     {
         Regular = 0,
         QRCode = 1,
+        GamePass = 2,
     };
 
     enum GameStartMode : int
@@ -364,8 +365,8 @@ namespace Beanfun
                 );
                 if (loginMethod < (int)LoginMethod.Regular)
                     loginMethod = int.Parse(ConfigAppSettings.GetValue("loginMethod", "0"));
-                if (loginMethod > (int)LoginMethod.QRCode)
-                    loginMethod = (int)LoginMethod.QRCode;
+                if (loginMethod > (int)LoginMethod.GamePass)
+                    loginMethod = (int)LoginMethod.GamePass;
 
                 loginMethodInit();
                 reLoadGameInfo();
@@ -979,6 +980,7 @@ namespace Beanfun
 
             if (App.LoginRegion == "TW")
             {
+                loginPage.id_pass.btn_GamePass.Visibility = Visibility.Visible;
                 switch (App.LoginMethod)
                 {
                     case (int)LoginMethod.QRCode:
@@ -989,6 +991,10 @@ namespace Beanfun
                             loginPage == null || loginPage.qr == null ? false : true
                         );
                         break;
+                    case (int)LoginMethod.GamePass:
+                        btn_Region.IsEnabled = false;
+                        loginPage.login_form.Content = loginPage.gamepass;
+                        break;
                     default:
                         loginPage.login_form.Content = loginPage.id_pass;
                         break;
@@ -996,6 +1002,7 @@ namespace Beanfun
             }
             else
             {
+                loginPage.id_pass.btn_GamePass.Visibility = Visibility.Collapsed;
                 loginPage.login_form.Content = loginPage.id_pass;
                 App.LoginMethod = (int)LoginMethod.Regular;
             }

--- a/Beanfun/MainWindow.xaml.cs
+++ b/Beanfun/MainWindow.xaml.cs
@@ -1269,8 +1269,7 @@ namespace Beanfun
 
         private void SaveLoginCredentials()
         {
-            bool isAccountLogin =
-                App.LoginRegion != "TW" || App.LoginMethod != (int)LoginMethod.QRCode;
+            bool isAccountLogin = App.LoginRegion != "TW" || App.LoginMethod != (int)LoginMethod.QRCode;
             if (!isAccountLogin)
             {
                 ConfigAppSettings.SetValue("AccountID", null);
@@ -1280,34 +1279,21 @@ namespace Beanfun
             var idPassForm = loginPage.id_pass;
             string accountId = idPassForm.t_AccountID.Text;
             LastLoginAccountID = accountId;
-
-            ConfigAppSettings.SetValue(
-                "AccountID",
-                string.IsNullOrWhiteSpace(accountId) ? null : accountId
-            );
-
-            if (string.IsNullOrWhiteSpace(accountId))
-                return;
-
-            bool shouldSavePwd =
-                !string.IsNullOrEmpty(idPassForm.t_Password.Password)
-                && idPassForm.checkBox_RememberPWD.IsEnabled
-                && (bool)idPassForm.checkBox_RememberPWD.IsChecked;
-
-            bool shouldAutoLogin = shouldSavePwd && (bool)idPassForm.checkBox_AutoLogin.IsChecked;
-
-            string savedVerify = (bool)verifyPage.checkBoxRememberVerify.IsChecked
-                ? verifyPage.t_Verify.Text
-                : "";
+            ConfigAppSettings.SetValue("AccountID", accountId);
 
             accountManager.addAccount(
                 App.LoginRegion,
                 accountId,
                 "",
-                shouldSavePwd ? idPassForm.t_Password.Password : "",
-                savedVerify,
+                idPassForm.checkBox_RememberPWD.IsEnabled
+                && (bool)idPassForm.checkBox_RememberPWD.IsChecked
+                    ? idPassForm.t_Password.Password
+                    : "",
+                (bool)verifyPage.checkBoxRememberVerify.IsChecked
+                    ? verifyPage.t_Verify.Text
+                    : "",
                 App.LoginMethod,
-                shouldAutoLogin
+                (bool)idPassForm.checkBox_AutoLogin.IsChecked
             );
 
             loginMethodInit();

--- a/Beanfun/MainWindow.xaml.cs
+++ b/Beanfun/MainWindow.xaml.cs
@@ -1158,7 +1158,7 @@ namespace Beanfun
             switch (msg)
             {
                 case "AdvanceCheckSuccessRetry":
-                    msg = "驗證成功！請再次輸入密碼登入遊戲。";
+                    msg = TryFindResource("AdvanceCheckSuccessRetry") as string;
                     method = 1;
                     break;
                 case "LoginNoResponse":

--- a/Beanfun/Pages/AdvanceCheckDialog.xaml
+++ b/Beanfun/Pages/AdvanceCheckDialog.xaml
@@ -5,7 +5,7 @@
   xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
   xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
   mc:Ignorable="d"
-  Title="進階驗證"
+  Title="{DynamicResource AdvanceCheckTitle}"
   Height="280"
   Width="400"
   WindowStartupLocation="CenterScreen"
@@ -14,16 +14,25 @@
   <StackPanel Margin="20">
     <TextBlock x:Name="lblHint" Margin="0,0,0,10" TextWrapping="Wrap" />
 
-    <TextBlock Text="請輸入認證 Email：" Margin="0,0,0,4" />
+    <TextBlock x:Name="lblVerifyInput" Margin="0,0,0,4" />
     <TextBox x:Name="txtEmail" Margin="0,0,0,12" />
 
-    <TextBlock Text="圖形驗證碼：" Margin="0,0,0,4" />
+    <TextBlock Text="{DynamicResource AdvanceCheckCaptchaLabel}" Margin="0,0,0,4" />
     <Image x:Name="imgCaptcha" Height="40" Margin="0,0,0,8" HorizontalAlignment="Left" />
     <TextBox x:Name="txtCaptcha" Margin="0,0,0,16" />
 
     <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-      <Button Content="確定" Width="80" Margin="0,0,10,0" Click="btnOK_Click" />
-      <Button Content="取消" Width="80" Click="btnCancel_Click" />
+      <Button
+        Content="{DynamicResource AdvanceCheckConfirm}"
+        Width="80"
+        Margin="0,0,10,0"
+        Click="btnOK_Click"
+      />
+      <Button
+        Content="{DynamicResource AdvanceCheckCancel}"
+        Width="80"
+        Click="btnCancel_Click"
+      />
     </StackPanel>
   </StackPanel>
 </Window>

--- a/Beanfun/Pages/AdvanceCheckDialog.xaml
+++ b/Beanfun/Pages/AdvanceCheckDialog.xaml
@@ -28,11 +28,7 @@
         Margin="0,0,10,0"
         Click="btnOK_Click"
       />
-      <Button
-        Content="{DynamicResource AdvanceCheckCancel}"
-        Width="80"
-        Click="btnCancel_Click"
-      />
+      <Button Content="{DynamicResource AdvanceCheckCancel}" Width="80" Click="btnCancel_Click" />
     </StackPanel>
   </StackPanel>
 </Window>

--- a/Beanfun/Pages/AdvanceCheckDialog.xaml
+++ b/Beanfun/Pages/AdvanceCheckDialog.xaml
@@ -1,0 +1,29 @@
+<Window
+  x:Class="Beanfun.AdvanceCheckDialog"
+  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+  mc:Ignorable="d"
+  Title="進階驗證"
+  Height="280"
+  Width="400"
+  WindowStartupLocation="CenterScreen"
+  ResizeMode="NoResize"
+>
+  <StackPanel Margin="20">
+    <TextBlock x:Name="lblHint" Margin="0,0,0,10" TextWrapping="Wrap" />
+
+    <TextBlock Text="請輸入認證 Email：" Margin="0,0,0,4" />
+    <TextBox x:Name="txtEmail" Margin="0,0,0,12" />
+
+    <TextBlock Text="圖形驗證碼：" Margin="0,0,0,4" />
+    <Image x:Name="imgCaptcha" Height="40" Margin="0,0,0,8" HorizontalAlignment="Left" />
+    <TextBox x:Name="txtCaptcha" Margin="0,0,0,16" />
+
+    <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+      <Button Content="確定" Width="80" Margin="0,0,10,0" Click="btnOK_Click" />
+      <Button Content="取消" Width="80" Click="btnCancel_Click" />
+    </StackPanel>
+  </StackPanel>
+</Window>

--- a/Beanfun/Pages/AdvanceCheckDialog.xaml.cs
+++ b/Beanfun/Pages/AdvanceCheckDialog.xaml.cs
@@ -23,10 +23,12 @@ namespace Beanfun
             // Determine input label based on hint content (email or phone)
             bool isPhone =
                 emailHint != null
-                && (emailHint.Contains("手機") || emailHint.Contains("電話") || emailHint.Contains("phone"));
-            string labelKey = isPhone
-                ? "AdvanceCheckInputPhone"
-                : "AdvanceCheckInputEmail";
+                && (
+                    emailHint.Contains("手機")
+                    || emailHint.Contains("電話")
+                    || emailHint.Contains("phone")
+                );
+            string labelKey = isPhone ? "AdvanceCheckInputPhone" : "AdvanceCheckInputEmail";
             lblVerifyInput.Text =
                 Application.Current.TryFindResource(labelKey) as string
                 ?? (isPhone ? "請輸入認證電話號碼：" : "請輸入認證 Email：");

--- a/Beanfun/Pages/AdvanceCheckDialog.xaml.cs
+++ b/Beanfun/Pages/AdvanceCheckDialog.xaml.cs
@@ -1,0 +1,53 @@
+﻿using System.IO;
+using System.Windows;
+using System.Windows.Media.Imaging;
+
+namespace Beanfun
+{
+    /// <summary>
+    /// AdvanceCheckDialog.xaml 的交互逻辑
+    /// </summary>
+    public partial class AdvanceCheckDialog : Window
+    {
+        public string Email { get; private set; }
+        public string CaptchaCode { get; private set; }
+
+        public AdvanceCheckDialog(string emailHint, byte[] captchaImageBytes)
+        {
+            InitializeComponent();
+
+            lblHint.Text = $"提示：{emailHint}";
+
+            if (captchaImageBytes != null)
+            {
+                using (var ms = new MemoryStream(captchaImageBytes))
+                {
+                    var bitmap = new BitmapImage();
+                    bitmap.BeginInit();
+                    bitmap.CacheOption = BitmapCacheOption.OnLoad;
+                    bitmap.StreamSource = ms;
+                    bitmap.EndInit();
+                    imgCaptcha.Source = bitmap;
+                }
+            }
+        }
+
+        private void btnOK_Click(object sender, RoutedEventArgs e)
+        {
+            Email = txtEmail.Text.Trim();
+            CaptchaCode = txtCaptcha.Text.Trim();
+
+            if (string.IsNullOrEmpty(Email) || string.IsNullOrEmpty(CaptchaCode))
+            {
+                MessageBox.Show("請填寫 Email 同驗證碼");
+                return;
+            }
+            DialogResult = true;
+        }
+
+        private void btnCancel_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+        }
+    }
+}

--- a/Beanfun/Pages/AdvanceCheckDialog.xaml.cs
+++ b/Beanfun/Pages/AdvanceCheckDialog.xaml.cs
@@ -16,7 +16,20 @@ namespace Beanfun
         {
             InitializeComponent();
 
-            lblHint.Text = $"提示：{emailHint}";
+            string hintPrefix =
+                Application.Current.TryFindResource("AdvanceCheckHintPrefix") as string ?? "提示：";
+            lblHint.Text = $"{hintPrefix}{emailHint}";
+
+            // Determine input label based on hint content (email or phone)
+            bool isPhone =
+                emailHint != null
+                && (emailHint.Contains("手機") || emailHint.Contains("電話") || emailHint.Contains("phone"));
+            string labelKey = isPhone
+                ? "AdvanceCheckInputPhone"
+                : "AdvanceCheckInputEmail";
+            lblVerifyInput.Text =
+                Application.Current.TryFindResource(labelKey) as string
+                ?? (isPhone ? "請輸入認證電話號碼：" : "請輸入認證 Email：");
 
             if (captchaImageBytes != null)
             {

--- a/Beanfun/Pages/AdvanceCheckDialog.xaml.cs
+++ b/Beanfun/Pages/AdvanceCheckDialog.xaml.cs
@@ -39,7 +39,9 @@ namespace Beanfun
 
             if (string.IsNullOrEmpty(Email) || string.IsNullOrEmpty(CaptchaCode))
             {
-                MessageBox.Show("請填寫 Email 同驗證碼");
+                MessageBox.Show(
+                    Application.Current.TryFindResource("AdvanceCheckFillEmailAndCaptcha") as string
+                );
                 return;
             }
             DialogResult = true;

--- a/Beanfun/Pages/LoginPage.xaml.cs
+++ b/Beanfun/Pages/LoginPage.xaml.cs
@@ -12,6 +12,7 @@ namespace Beanfun
     {
         public id_pass_form id_pass = new id_pass_form();
         public qr_form qr = new qr_form();
+        public gamepass_form gamepass = new gamepass_form();
 
         public LoginPage()
         {

--- a/Beanfun/Pages/gamepass_form.xaml
+++ b/Beanfun/Pages/gamepass_form.xaml
@@ -1,0 +1,74 @@
+<Page
+  x:Class="Beanfun.gamepass_form"
+  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+  mc:Ignorable="d"
+  Title="gamepass_form"
+>
+  <Page.Resources>
+    <ResourceDictionary>
+      <Style TargetType="{x:Type Button}">
+        <Setter Property="Background" Value="#7FF5F5F5" />
+        <Setter Property="Foreground" Value="Black" />
+      </Style>
+      <Style TargetType="{x:Type TextBox}" />
+      <Style TargetType="{x:Type ListBox}" />
+    </ResourceDictionary>
+  </Page.Resources>
+
+  <Grid Margin="0 20 0 0">
+    <Grid>
+      <Grid.RowDefinitions>
+        <RowDefinition Height="Auto" />
+        <RowDefinition Height="*" />
+      </Grid.RowDefinitions>
+      <StackPanel Height="160">
+        <StackPanel.Background>
+          <LinearGradientBrush EndPoint="0,1" StartPoint="0,0">
+            <GradientStop Color="#00FFFFFF" Offset="0.0" />
+            <GradientStop Color="#AAFFFFFF" Offset="1.0" />
+          </LinearGradientBrush>
+        </StackPanel.Background>
+      </StackPanel>
+      <StackPanel Grid.Row="1" Background="#AAFFFFFF" />
+    </Grid>
+    <DockPanel Margin="0 26 0 0">
+      <Grid x:Name="SideBarLeft" MinWidth="40" />
+      <StackPanel VerticalAlignment="Center">
+        <TextBlock
+          x:Name="lblStatus"
+          Text="正在等待 GamePass 認證..."
+          HorizontalAlignment="Center"
+          FontSize="14"
+          Margin="0 20 0 10"
+        />
+        <Button
+          x:Name="btn_OpenGamePass"
+          Content="開啟 GamePass 登入"
+          Height="30"
+          Width="250"
+          FontWeight="Bold"
+          Margin="0 10 0 0"
+          Background="#7FF5F5F5"
+          Foreground="Black"
+          Click="btn_OpenGamePass_Click"
+        />
+        <Button
+          x:Name="btn_back"
+          Content="{DynamicResource BackRegularLogin}"
+          Height="30"
+          Width="250"
+          FontWeight="Bold"
+          Margin="0 10 0 20"
+          IsDefault="True"
+          Background="#7FF5F5F5"
+          Foreground="Black"
+          Click="btn_back_Click"
+        />
+      </StackPanel>
+      <Grid MinWidth="{Binding MinWidth, ElementName=SideBarLeft}" />
+    </DockPanel>
+  </Grid>
+</Page>

--- a/Beanfun/Pages/gamepass_form.xaml
+++ b/Beanfun/Pages/gamepass_form.xaml
@@ -39,14 +39,14 @@
       <StackPanel VerticalAlignment="Center">
         <TextBlock
           x:Name="lblStatus"
-          Text="正在等待 GamePass 認證..."
+          Text="{DynamicResource GamePassWaiting}"
           HorizontalAlignment="Center"
           FontSize="14"
           Margin="0 20 0 10"
         />
         <Button
           x:Name="btn_OpenGamePass"
-          Content="開啟 GamePass 登入"
+          Content="{DynamicResource GamePassOpen}"
           Height="30"
           Width="250"
           FontWeight="Bold"

--- a/Beanfun/Pages/gamepass_form.xaml.cs
+++ b/Beanfun/Pages/gamepass_form.xaml.cs
@@ -21,15 +21,19 @@ namespace Beanfun
                 string skey = client.GetSessionkey();
                 if (string.IsNullOrEmpty(skey))
                 {
-                    MessageBox.Show("無法取得 SessionKey，請稍後再試");
+                    MessageBox.Show(
+                        Application.Current.TryFindResource("SessionKeyFailed") as string
+                    );
                     return;
                 }
                 App.MainWnd.bfClient = client;
-                new WebBrowser($"https://login.beanfun.com/Login/GoGamaPassRequest?pSKey={skey}").Show();
+                new WebBrowser(
+                    $"https://login.beanfun.com/Login/GoGamaPassRequest?pSKey={skey}"
+                ).Show();
             }
             catch
             {
-                MessageBox.Show("連線失敗，請檢查網路連線");
+                MessageBox.Show(Application.Current.TryFindResource("ConnectionFailed") as string);
             }
         }
 

--- a/Beanfun/Pages/gamepass_form.xaml.cs
+++ b/Beanfun/Pages/gamepass_form.xaml.cs
@@ -1,0 +1,42 @@
+using System.Windows;
+using System.Windows.Controls;
+
+namespace Beanfun
+{
+    /// <summary>
+    /// gamepass_form.xaml 的交互逻辑
+    /// </summary>
+    public partial class gamepass_form : Page
+    {
+        public gamepass_form()
+        {
+            InitializeComponent();
+        }
+
+        private void btn_OpenGamePass_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                var client = new BeanfunClient();
+                string skey = client.GetSessionkey();
+                if (string.IsNullOrEmpty(skey))
+                {
+                    MessageBox.Show("無法取得 SessionKey，請稍後再試");
+                    return;
+                }
+                App.MainWnd.bfClient = client;
+                new WebBrowser($"https://login.beanfun.com/Login/GoGamaPassRequest?pSKey={skey}").Show();
+            }
+            catch
+            {
+                MessageBox.Show("連線失敗，請檢查網路連線");
+            }
+        }
+
+        private void btn_back_Click(object sender, RoutedEventArgs e)
+        {
+            App.LoginMethod = (int)LoginMethod.Regular;
+            App.MainWnd.loginMethodChanged();
+        }
+    }
+}

--- a/Beanfun/Pages/id-pass_form.xaml
+++ b/Beanfun/Pages/id-pass_form.xaml
@@ -644,6 +644,78 @@
       <Grid MinWidth="{Binding MinWidth, ElementName=SideBarLeft}">
         <StackPanel VerticalAlignment="Bottom">
           <Button
+            x:Name="btn_GamePass"
+            Margin="10,10,10,0"
+            Width="22"
+            Height="22"
+            HorizontalAlignment="Right"
+            Visibility="Collapsed"
+            ToolTip="GamePass Login"
+            Click="btn_GamePass_Click"
+          >
+            <Button.Resources>
+              <Style TargetType="{x:Type Button}">
+                <Setter
+                  Property="Foreground"
+                  Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"
+                />
+                <Setter Property="Padding" Value="0" />
+                <Setter Property="BorderThickness" Value="0" />
+                <Setter Property="Background" Value="Transparent" />
+                <Setter Property="BorderBrush" Value="{x:Null}" />
+                <Setter Property="HorizontalAlignment" Value="Center" />
+                <Setter Property="VerticalAlignment" Value="Center" />
+                <Setter Property="HorizontalContentAlignment" Value="Center" />
+                <Setter Property="VerticalContentAlignment" Value="Center" />
+                <Setter Property="Template">
+                  <Setter.Value>
+                    <ControlTemplate TargetType="{x:Type Button}">
+                      <TextBlock>
+                        <Path
+                          x:Name="Path"
+                          Fill="{TemplateBinding Foreground}"
+                          Stretch="Uniform"
+                          Data="M30,0c16.6,0,30,13.4,30,30s-.7,7.5-2,10.9c-1.6-.2-3.3.5-4.6,1.4-1.2.8-2.3,1.8-3.3,2.8-1.5,1.5-2.9,3.2-4.4,4.7-.5.5-1.3,1.2-1.8.8-.6-.4,0-1.3.4-1.9,1.1-1.4,2.2-2.7,3.5-4.1,2.8-2.8,4.6-7.7,2.8-11.4-1.2-2.5-3.5-3.5-6-4.3.3-1.1.6-2.2.9-3.4-1.5,0-2.8,0-4.2.1,0,1.3-.1,2.4-.2,3.5-5.4,1.7-10.5,6.6-9.9,12.6.6,5.7,6.2,7.9,11.3,6.5-.4.8-.8,1.5-1.2,2.3-.6,1.5-.7,2.8.4,3.6,1.1.8,2.4.7,3.9-.3,1.4-1,2.7-2.3,3.9-3.5,1.4-1.5,2.8-3.4,4.5-4.5.7-.4,1.4-.7,2-.7-5.2,8.9-14.9,14.9-25.9,14.9C13.4,60,0,46.6,0,30,0,13.4,13.4,0,30,0Z M37.5,35.2c1.3-1.4,3.6-2.4,5.8-1.7,2,.6,2.9,2.4,3.1,2.6.2.4.5,1.2.6,2.1,0,1.4-.4,2.5-.7,3-.6,1.1-1.4,1.8-1.6,2h0c-.4.4-1.7,1.4-3.6,1.4-.4,0-1.7,0-3.1-.9-1.3-.9-1.8-2.1-1.9-2.5-.8-2-.2-4.5,1.4-6.2Z"
+                        />
+                      </TextBlock>
+                      <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                          <Setter
+                            Property="Foreground"
+                            Value="{StaticResource Button.Static.MouseOver}"
+                          />
+                          <Setter
+                            TargetName="Path"
+                            Property="Fill"
+                            Value="{StaticResource Button.Static.MouseOver}"
+                          />
+                        </Trigger>
+                        <Trigger Property="IsPressed" Value="True">
+                          <Setter
+                            Property="Foreground"
+                            Value="{StaticResource Button.Static.Pressed}"
+                          />
+                          <Setter
+                            TargetName="Path"
+                            Property="Fill"
+                            Value="{StaticResource Button.Static.Pressed}"
+                          />
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                          <Setter Property="Foreground" Value="#CCCCCC" />
+                          <Setter TargetName="Path" Property="Fill" Value="#CCCCCC" />
+                        </Trigger>
+                      </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                  </Setter.Value>
+                </Setter>
+              </Style>
+            </Button.Resources>
+            <Button.Foreground>
+              <StaticResource ResourceKey="Button.Static.Default" />
+            </Button.Foreground>
+          </Button>
+          <Button
             x:Name="btn_QRCode"
             Margin="10"
             Width="22"

--- a/Beanfun/Pages/id-pass_form.xaml
+++ b/Beanfun/Pages/id-pass_form.xaml
@@ -650,7 +650,7 @@
             Height="22"
             HorizontalAlignment="Right"
             Visibility="Collapsed"
-            ToolTip="GamePass Login"
+            ToolTip="{DynamicResource GamePassLogin}"
             Click="btn_GamePass_Click"
           >
             <Button.Resources>

--- a/Beanfun/Pages/id-pass_form.xaml.cs
+++ b/Beanfun/Pages/id-pass_form.xaml.cs
@@ -268,5 +268,25 @@ namespace Beanfun
             App.LoginMethod = (int)LoginMethod.QRCode;
             App.MainWnd.loginMethodChanged();
         }
+
+        private void btn_GamePass_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                var client = new BeanfunClient();
+                string skey = client.GetSessionkey();
+                if (string.IsNullOrEmpty(skey))
+                {
+                    MessageBox.Show("無法取得 SessionKey，請稍後再試");
+                    return;
+                }
+                App.MainWnd.bfClient = client;
+                new GamePassBrowser(skey).Show();
+            }
+            catch
+            {
+                MessageBox.Show("連線失敗，請檢查網路連線");
+            }
+        }
     }
 }

--- a/Beanfun/Pages/id-pass_form.xaml.cs
+++ b/Beanfun/Pages/id-pass_form.xaml.cs
@@ -269,15 +269,16 @@ namespace Beanfun
             App.MainWnd.loginMethodChanged();
         }
 
-        private void btn_GamePass_Click(object sender, RoutedEventArgs e)
+        private async void btn_GamePass_Click(object sender, RoutedEventArgs e)
         {
+            btn_GamePass.IsEnabled = false;
             try
             {
                 var client = new BeanfunClient();
-                string skey = client.GetSessionkey();
+                string skey = await System.Threading.Tasks.Task.Run(() => client.GetSessionkey());
                 if (string.IsNullOrEmpty(skey))
                 {
-                    MessageBox.Show("無法取得 SessionKey，請稍後再試");
+                    MessageBox.Show(TryFindResource("SessionKeyFailed") as string);
                     return;
                 }
                 App.MainWnd.bfClient = client;
@@ -285,7 +286,11 @@ namespace Beanfun
             }
             catch
             {
-                MessageBox.Show("連線失敗，請檢查網路連線");
+                MessageBox.Show(TryFindResource("ConnectionFailed") as string);
+            }
+            finally
+            {
+                btn_GamePass.IsEnabled = true;
             }
         }
     }

--- a/Beanfun/Tools/BeanfunClient.Login.cs
+++ b/Beanfun/Tools/BeanfunClient.Login.cs
@@ -12,15 +12,27 @@ namespace Beanfun
 {
     public partial class BeanfunClient : WebClient
     {
-        private string RegularLogin(string id, string pass, string skey)
+        private string RegularLogin(
+            string id,
+            string pass,
+            string skey,
+            string service_code = "610074",
+            string service_region = "T9"
+        )
         {
             if (App.LoginRegion == "TW")
-                return TwRegularLogin(id, pass, skey);
+                return TwRegularLogin(id, pass, skey, service_code, service_region);
             else
                 return HkRegularLogin(id, pass, skey);
         }
 
-        private string TwRegularLogin(string id, string pass, string skey)
+        private string TwRegularLogin(
+            string id,
+            string pass,
+            string skey,
+            string service_code,
+            string service_region
+        )
         {
             try
             {
@@ -81,12 +93,77 @@ namespace Beanfun
                     if (result == "1")
                         return "REDIRECT_VERIFY";
 
-                    this.DownloadString($"{apiBase}/Login/Finalize?pSKey={skey}");
-                    string akey = Regex
-                        .Match(this.ResponseUri?.ToString() ?? "", @"akey=([^&]+)")
-                        .Groups[1]
-                        .Value;
-                    return string.IsNullOrEmpty(akey) ? "SUCCESS" : akey;
+                    // Use SendLogin flow (same as QRCode) to get bfWebToken
+                    SetBaseHeaders(
+                        true,
+                        "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+                        indexUrl
+                    );
+                    string sendLoginHtml = this.DownloadString($"{apiBase}/Login/SendLogin");
+
+                    NameValueCollection payload = new NameValueCollection();
+                    foreach (
+                        Match tag in Regex.Matches(
+                            sendLoginHtml,
+                            @"<input[^>]+>",
+                            RegexOptions.IgnoreCase | RegexOptions.Singleline
+                        )
+                    )
+                    {
+                        string tagStr = tag.Value;
+                        Match nameMatch = Regex.Match(
+                            tagStr,
+                            @"name\s*=\s*['""]([^'""]+)['""]",
+                            RegexOptions.IgnoreCase
+                        );
+                        Match valMatch = Regex.Match(
+                            tagStr,
+                            @"value\s*=\s*['""]([^'""]*)['""]",
+                            RegexOptions.IgnoreCase
+                        );
+                        if (
+                            nameMatch.Success
+                            && valMatch.Success
+                            && tagStr.IndexOf("type=\"submit\"", StringComparison.OrdinalIgnoreCase)
+                                == -1
+                        )
+                            payload.Add(nameMatch.Groups[1].Value, valMatch.Groups[1].Value);
+                    }
+
+                    if (payload.Count == 0)
+                    {
+                        this.errmsg = "SendLoginNoFormData";
+                        return null;
+                    }
+
+                    this.redirect = false;
+                    SetBaseHeaders(true, null, $"{apiBase}/");
+                    string returnResponse = this.UploadString(
+                        "https://tw.beanfun.com/beanfun_block/bflogin/return.aspx",
+                        payload
+                    );
+                    string setCookieHeader = this.ResponseHeaders?["Set-Cookie"];
+                    if (!string.IsNullOrEmpty(setCookieHeader))
+                    {
+                        Match tokenMatch = Regex.Match(setCookieHeader, @"bfWebToken=([^;]+)");
+                        if (tokenMatch.Success)
+                            this.webtoken = tokenMatch.Groups[1].Value;
+                    }
+                    this.redirect = true;
+
+                    if (string.IsNullOrEmpty(this.webtoken))
+                    {
+                        this.errmsg = "LoginNoWebtoken";
+                        return null;
+                    }
+
+                    GetAccounts(service_code, service_region, false);
+                    if (this.errmsg != null)
+                        return null;
+
+                    this.remainPoint = getRemainPoint();
+                    this.errmsg = null;
+                    return null; // return null with no errmsg = success, skip LoginCompleted
                 }
 
                 // ResultCode 2: AdvanceCheck required
@@ -782,7 +859,7 @@ namespace Beanfun
                 switch (loginMethod)
                 {
                     case (int)LoginMethod.Regular:
-                        akey = RegularLogin(id, pass, SessionKey);
+                        akey = RegularLogin(id, pass, SessionKey, service_code, service_region);
                         break;
                     case (int)LoginMethod.QRCode:
                         akey = QRCodeLogin(qrcodeClass);

--- a/Beanfun/Tools/BeanfunClient.Login.cs
+++ b/Beanfun/Tools/BeanfunClient.Login.cs
@@ -264,7 +264,10 @@ namespace Beanfun
             });
 
             if (dialogResult != true || string.IsNullOrEmpty(userEmail))
+            {
+                this.errmsg = "LoginAdvanceCheck";
                 return null;
+            }
 
             // Submit advance check form
             SetBaseHeaders(true, null, advanceUrl);

--- a/Beanfun/Tools/BeanfunClient.Login.cs
+++ b/Beanfun/Tools/BeanfunClient.Login.cs
@@ -91,7 +91,10 @@ namespace Beanfun
                 if (resultCode == "1")
                 {
                     if (result == "1")
-                        return "REDIRECT_VERIFY";
+                    {
+                        this.errmsg = "LoginAdvanceCheck";
+                        return null;
+                    }
 
                     // Use SendLogin flow (same as QRCode) to get bfWebToken
                     SetBaseHeaders(

--- a/Beanfun/Tools/BeanfunClient.Login.cs
+++ b/Beanfun/Tools/BeanfunClient.Login.cs
@@ -14,17 +14,217 @@ namespace Beanfun
     {
         private string RegularLogin(string id, string pass, string skey)
         {
-            string loginHost;
             if (App.LoginRegion == "TW")
-                loginHost = "tw.newlogin.beanfun.com";
+                return TwRegularLogin(id, pass, skey);
             else
-                loginHost = "login.hk.beanfun.com";
+                return HkRegularLogin(id, pass, skey);
+        }
 
+        private string TwRegularLogin(string id, string pass, string skey)
+        {
             try
             {
-                string response = this.DownloadString(
-                    $"https://{loginHost}/login/id-pass_form{(App.LoginRegion == "HK" ? "_newBF.aspx?otp1" : ".aspx?skey")}={skey}"
+                string apiBase = "https://login.beanfun.com";
+                string indexUrl = $"{apiBase}/Login/Index?pSKey={skey}";
+
+                // Step 1: Get index page and antiforgery token
+                SetBaseHeaders(false, "text/html");
+                string indexHtml = this.DownloadString(indexUrl);
+                string formToken = Regex
+                    .Match(indexHtml, "name=\"__RequestVerificationToken\"[^>]+value=\"([^\"]+)\"")
+                    .Groups[1]
+                    .Value;
+
+                if (string.IsNullOrEmpty(formToken))
+                {
+                    this.errmsg = "LoginNoToken";
+                    return null;
+                }
+
+                // Step 2: Check account type
+                SetJsonHeaders(formToken, indexUrl);
+                string checkTypeBody =
+                    $"{{\"Account\":\"{EscapeJson(id)}\",\"Captcha\":\"\",\"__RequestVerificationToken\":\"{formToken}\"}}";
+                string checkTypeRes = this.UploadString(
+                    $"{apiBase}/Login/CheckAccountType?pSKey={skey}",
+                    "POST",
+                    checkTypeBody
                 );
+
+                string captchaToken = "";
+                if (
+                    !string.IsNullOrWhiteSpace(checkTypeRes)
+                    && checkTypeRes.TrimStart().StartsWith("{")
+                )
+                {
+                    var checkJson = JObject.Parse(checkTypeRes);
+                    captchaToken = checkJson["ResultData"]?["Captcha"]?.ToString() ?? "";
+                }
+
+                // Step 3: Account login
+                SetJsonHeaders(formToken, indexUrl);
+                string loginBody =
+                    $"{{\"Account\":\"{EscapeJson(id)}\",\"Pasw\":\"{EscapeJson(pass)}\",\"IsMobile\":false,\"Captcha\":\"{captchaToken}\",\"__RequestVerificationToken\":\"{formToken}\"}}";
+                string loginRes = this.UploadString(
+                    $"{apiBase}/Login/AccountLogin?pSKey={skey}",
+                    "POST",
+                    loginBody
+                );
+
+                var loginJson = JObject.Parse(loginRes);
+                string resultCode = loginJson["ResultCode"]?.ToString();
+                string result = loginJson["Result"]?.ToString();
+                string resultMsg = loginJson["ResultMessage"]?.ToString() ?? "";
+
+                if (resultCode == "1")
+                {
+                    if (result == "1")
+                        return "REDIRECT_VERIFY";
+
+                    this.DownloadString($"{apiBase}/Login/Finalize?pSKey={skey}");
+                    string akey = Regex
+                        .Match(this.ResponseUri?.ToString() ?? "", @"akey=([^&]+)")
+                        .Groups[1]
+                        .Value;
+                    return string.IsNullOrEmpty(akey) ? "SUCCESS" : akey;
+                }
+
+                // ResultCode 2: AdvanceCheck required
+                if (resultCode == "2" && resultMsg.StartsWith("http"))
+                    return HandleAdvanceCheck(resultMsg);
+
+                this.errmsg = resultMsg;
+                return null;
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[TwRegularLogin] Exception: {ex.Message}");
+                this.errmsg = "LoginUnknown\n\n" + ex.Message + "\n" + ex.StackTrace;
+                return null;
+            }
+        }
+
+        private string HandleAdvanceCheck(string advanceUrl)
+        {
+            if (advanceUrl.Contains("gamaweb.beanfun.com"))
+            {
+                this.errmsg = "帳號狀態異常，請先使用瀏覽器登入官網確認（可能需聯絡客服）";
+                return null;
+            }
+
+            string advanceHtml = this.DownloadString(advanceUrl);
+
+            var captchaMatch = Regex.Match(
+                advanceHtml,
+                "id=\"LBD_VCID_[^\"]+\"[^>]+value=\"([^\"]+)\""
+            );
+            if (!captchaMatch.Success)
+            {
+                this.errmsg = "無法取得驗證碼編號，帳號可能處於異常狀態";
+                return null;
+            }
+            string captchaId = captchaMatch.Groups[1].Value;
+
+            string viewState = Regex
+                .Match(advanceHtml, "id=\"__VIEWSTATE\"[^>]+value=\"([^\"]+)\"")
+                .Groups[1]
+                .Value;
+            string viewStateGen = Regex
+                .Match(advanceHtml, "id=\"__VIEWSTATEGENERATOR\"[^>]+value=\"([^\"]+)\"")
+                .Groups[1]
+                .Value;
+            string eventValidation = Regex
+                .Match(advanceHtml, "id=\"__EVENTVALIDATION\"[^>]+value=\"([^\"]+)\"")
+                .Groups[1]
+                .Value;
+            string captchaImgSrc = Regex
+                .Match(advanceHtml, "class=\"LBD_CaptchaImage\"[^>]+src=\"([^\"]+)\"")
+                .Groups[1]
+                .Value;
+            string emailHint = Regex
+                .Match(advanceHtml, "id=\"lblAuthType\">([^<]+)<")
+                .Groups[1]
+                .Value;
+            string formAction = Regex
+                .Match(advanceHtml, "action=\"(AdvanceCheck\\.aspx[^\"]+)\"")
+                .Groups[1]
+                .Value;
+
+            string captchaImgUrl =
+                $"https://tw.newlogin.beanfun.com/LoginCheck/{captchaImgSrc.TrimStart('/')}".Replace(
+                    "&amp;",
+                    "&"
+                );
+            string submitUrl =
+                $"https://tw.newlogin.beanfun.com/LoginCheck/{formAction.Replace("&amp;", "&")}";
+
+            byte[] captchaImgBytes = null;
+            try
+            {
+                captchaImgBytes = this.DownloadData(captchaImgUrl);
+            }
+            catch { }
+
+            if (captchaImgBytes == null || captchaImgBytes.Length < 500)
+            {
+                this.errmsg = "無法載入驗證碼圖片（Session 可能已過期）";
+                return null;
+            }
+
+            string userEmail = "",
+                userCaptcha = "";
+            bool? dialogResult = false;
+
+            App.Current.Dispatcher.Invoke(() =>
+            {
+                var dlg = new AdvanceCheckDialog(emailHint, captchaImgBytes);
+                dialogResult = dlg.ShowDialog();
+                if (dialogResult == true)
+                {
+                    userEmail = dlg.Email;
+                    userCaptcha = dlg.CaptchaCode;
+                }
+            });
+
+            if (dialogResult != true || string.IsNullOrEmpty(userEmail))
+                return null;
+
+            // Submit advance check form
+            SetBaseHeaders(true, null, advanceUrl);
+            this.Headers[HttpRequestHeader.ContentType] = "application/x-www-form-urlencoded";
+
+            string submitBody =
+                $"__VIEWSTATE={Uri.EscapeDataString(viewState)}"
+                + $"&__VIEWSTATEGENERATOR={Uri.EscapeDataString(viewStateGen)}"
+                + $"&__EVENTVALIDATION={Uri.EscapeDataString(eventValidation)}"
+                + $"&txtVerify={Uri.EscapeDataString(userEmail)}"
+                + $"&CodeTextBox={Uri.EscapeDataString(userCaptcha)}"
+                + $"&LBD_VCID_c_logincheck_advancecheck_samplecaptcha={Uri.EscapeDataString(captchaId)}"
+                + "&imgbtnSubmit.x=30&imgbtnSubmit.y=10";
+
+            string submitRes = this.UploadString(submitUrl, "POST", submitBody);
+
+            if (submitRes.Contains("驗證成功") || submitRes.Contains("再次輸入您的帳號密碼"))
+            {
+                this.errmsg = "AdvanceCheckSuccessRetry";
+                return null;
+            }
+
+            string akeyFinal = Regex
+                .Match(this.ResponseUri?.ToString() ?? "", @"akey=([^&]+)")
+                .Groups[1]
+                .Value;
+            return string.IsNullOrEmpty(akeyFinal) ? null : akeyFinal;
+        }
+
+        private string HkRegularLogin(string id, string pass, string skey)
+        {
+            string loginHost = "login.hk.beanfun.com";
+            try
+            {
+                string url = $"https://{loginHost}/login/id-pass_form_newBF.aspx?otp1={skey}";
+                string response = this.DownloadString(url);
+
                 Regex regex = new Regex("id=\"__VIEWSTATE\" value=\"(.*)\" />");
                 if (!regex.IsMatch(response))
                 {
@@ -40,6 +240,7 @@ namespace Beanfun
                     return null;
                 }
                 string eventvalidation = regex.Match(response).Groups[1].Value;
+
                 regex = new Regex("id=\"__VIEWSTATEGENERATOR\" value=\"(.*)\" />");
                 if (!regex.IsMatch(response))
                 {
@@ -47,43 +248,20 @@ namespace Beanfun
                     return null;
                 }
                 string viewstateGenerator = regex.Match(response).Groups[1].Value;
-                /*
-                regex = new Regex("id=\"LBD_VCID_c_login_idpass_form_samplecaptcha\" value=\"(.*)\" />");
-                if (!regex.IsMatch(response))
-                { this.errmsg = "LoginNoSamplecaptcha"; return null; }
-                string samplecaptcha = regex.Match(response).Groups[1].Value;
-
-                string Captcha = "";
-                regex = new Regex("isHideCaptcha\\s?=\\s?false");
-                if (regex.IsMatch(response))
-                {
-                    CaptchaWnd wnd = null;
-                    (wnd = new CaptchaWnd(this, samplecaptcha)).ShowDialog();
-                    if (wnd == null) { this.errmsg = "LoginInitCaptcha"; return null; }
-                    else Captcha = wnd.Captcha;
-                }
-                */
 
                 NameValueCollection payload = new NameValueCollection();
                 payload.Add("__EVENTTARGET", "");
                 payload.Add("__EVENTARGUMENT", "");
                 payload.Add("__VIEWSTATE", viewstate);
                 payload.Add("__VIEWSTATEGENERATOR", viewstateGenerator);
-                if (App.LoginRegion == "HK")
-                    payload.Add("__VIEWSTATEENCRYPTED", "");
+                payload.Add("__VIEWSTATEENCRYPTED", "");
                 payload.Add("__EVENTVALIDATION", eventvalidation);
                 payload.Add("t_AccountID", id);
                 payload.Add("t_Password", pass);
-                //payload.Add("CodeTextBox", Captcha);
-                //payload.Add("LBD_VCID_c_login_idpass_form_samplecaptcha", samplecaptcha);
-                //payload.Add("g-recaptcha-response", samplecaptcha);
-                //payload.Add("token1", "");
                 payload.Add("btn_login", "登入");
 
-                response = this.UploadString(
-                    $"https://{loginHost}/login/id-pass_form{(App.LoginRegion == "HK" ? "_newBF.aspx?otp1" : ".aspx?skey")}={skey}",
-                    payload
-                );
+                response = this.UploadString(url, payload);
+
                 if (response.Contains("RELOAD_CAPTCHA_CODE") && response.Contains("alert"))
                 {
                     this.errmsg = "LoginAdvanceCheck";
@@ -93,8 +271,7 @@ namespace Beanfun
                 if (response.Contains("totpLoginBtn"))
                 {
                     this.totpResponse = response;
-                    this.totpUrl =
-                        $"https://{loginHost}/login/id-pass_form{(App.LoginRegion == "HK" ? "_newBF.aspx?otp1" : ".aspx?skey")}={skey}";
+                    this.totpUrl = url;
                     this.errmsg = "need_totp";
                     return null;
                 }
@@ -124,15 +301,32 @@ namespace Beanfun
                     }
                     return null;
                 }
-                string akey = regex.Match(this.ResponseUri.ToString()).Groups[1].Value;
-
-                return akey;
+                return regex.Match(this.ResponseUri.ToString()).Groups[1].Value;
             }
             catch (Exception e)
             {
                 this.errmsg = "LoginUnknown\n\n" + e.Message + "\n" + e.StackTrace;
                 return null;
             }
+        }
+
+        private static string EscapeJson(string s)
+        {
+            if (string.IsNullOrEmpty(s))
+                return "";
+            return s.Replace("\\", "\\\\")
+                .Replace("\"", "\\\"")
+                .Replace("\n", "\\n")
+                .Replace("\r", "\\r")
+                .Replace("\t", "\\t");
+        }
+
+        private void SetJsonHeaders(string verificationToken, string referer)
+        {
+            SetBaseHeaders(true, "application/json, text/plain, */*", referer);
+            this.Headers.Add("X-Requested-With", "XMLHttpRequest");
+            this.Headers.Add("RequestVerificationToken", verificationToken);
+            this.Headers[HttpRequestHeader.ContentType] = "application/json; charset=utf-8";
         }
 
         public void TotpLogin(
@@ -245,22 +439,6 @@ namespace Beanfun
             SetBaseHeaders(false, "text/html");
             string url = $"https://login.beanfun.com/Login/Index?pSKey={skey}";
             string response = this.DownloadString(url);
-            //Regex regex = new Regex("id=\"__VIEWSTATE\" value=\"(.*)\" />");
-            //if (!regex.IsMatch(response))
-            //{ this.errmsg = "LoginNoViewstate"; return null; }
-            //string viewstate = regex.Match(response).Groups[1].Value;
-
-            //regex = new Regex("id=\"__EVENTVALIDATION\" value=\"(.*)\" />");
-            //if (!regex.IsMatch(response))
-            //{ this.errmsg = "LoginNoEventvalidation"; return null; }
-            //string eventvalidation = regex.Match(response).Groups[1].Value;
-
-            //Thread.Sleep(3000);
-
-            //regex = new Regex("\\$\\(\"#theQrCodeImg\"\\)\\.attr\\(\"src\", \"\\.\\./(.*)\"");
-            //if (!regex.IsMatch(response))
-            //{ this.errmsg = "LoginNoHash"; return null; }
-            //string value = regex.Match(response).Groups[1].Value;
 
             JObject strEncryptData = this.getQRCodeStrEncryptData(skey);
             if (strEncryptData == null)
@@ -374,7 +552,6 @@ namespace Beanfun
             try
             {
                 string skey = qrcodeclass.skey;
-                // QRLogin
                 SetBaseHeaders(
                     true,
                     "application/json, text/plain, */*",
@@ -383,7 +560,6 @@ namespace Beanfun
                 string response = this.DownloadString("https://login.beanfun.com/QRLogin/QRLogin");
                 Debug.WriteLine("QRLogin response: " + response);
 
-                // SendLogin
                 SetBaseHeaders(
                     true,
                     "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
@@ -429,7 +605,6 @@ namespace Beanfun
                     return null;
                 }
 
-                // Get bfWebToken Data
                 this.redirect = false;
                 SetBaseHeaders(true, null, "https://login.beanfun.com/");
                 string returnUrl = "https://tw.beanfun.com/beanfun_block/bflogin/return.aspx";
@@ -456,13 +631,11 @@ namespace Beanfun
             try
             {
                 string skey = qrcodeclass.skey;
-                //int errorCount = 0;
                 string result;
                 this.Headers.Add("User-Agent", "Mozilla/5.0");
                 this.Headers.Add("Accept", "application/json, text/plain, */*");
                 this.Headers.Add("Referer", $"https://login.beanfun.com/Login/Index?pSKey={skey}");
                 this.Headers.Add("Origin", "https://login.beanfun.com");
-                //Debug.WriteLine(qrcodeclass.value);
 
                 string response = this.DownloadString(
                     $"https://login.beanfun.com/QRLogin/CheckLoginStatus?pSKey={skey}"
@@ -483,10 +656,7 @@ namespace Beanfun
                 if (result == "Failed" || result == "Wait Login")
                     return 0;
                 else if (result == "Token Expired")
-                {
-                    //this.errmsg = "登入逾時，請重新取得QRCode";
                     return -2;
-                }
                 else if (result == "Success")
                     return 1;
                 else
@@ -546,25 +716,23 @@ namespace Beanfun
         {
             if (App.LoginRegion == "TW")
             {
-                string response = this.DownloadString(
+                this.DownloadString(
                     "https://tw.beanfun.com/beanfun_block/bflogin/default.aspx?service=999999_T0"
                 );
-                //this.DownloadString(this.ResponseHeaders["Location"]);
-                //this.DownloadString(this.ResponseHeaders["Location"]);
-                //response = this.ResponseHeaders["Location"];
-                response = this.ResponseUri.ToString();
-                if (response == null)
+                string finalUrl = this.ResponseUri?.ToString();
+                if (string.IsNullOrEmpty(finalUrl))
                 {
                     this.errmsg = "LoginNoResponse";
                     return null;
                 }
-                Regex regex = new Regex("skey=(.*)&display");
-                if (!regex.IsMatch(response))
+
+                Regex regex = new Regex(@"[sp][Ss]?[Kk]ey=([^&]+)");
+                if (!regex.IsMatch(finalUrl))
                 {
                     this.errmsg = "LoginNoSkey";
                     return null;
                 }
-                return regex.Match(response).Groups[1].Value;
+                return regex.Match(finalUrl).Groups[1].Value;
             }
             else
             {
@@ -672,9 +840,7 @@ namespace Beanfun
                 $"https://{host}/beanfun_block/bflogin/return.aspx",
                 payload
             );
-            //Debug.WriteLine(response);
             response = this.DownloadString($"https://{host}/{this.ResponseHeaders["Location"]}");
-            //Debug.WriteLine(response);
             Debug.WriteLine(this.ResponseHeaders);
 
             this.webtoken = this.GetCookie("bfWebToken");

--- a/Beanfun/Tools/BeanfunClient.Login.cs
+++ b/Beanfun/Tools/BeanfunClient.Login.cs
@@ -890,6 +890,41 @@ namespace Beanfun
             }
         }
 
+        public void GamePassLogin(
+            string webToken,
+            System.Collections.Generic.IEnumerable<System.Net.Cookie> cookies,
+            string service_code = "610074",
+            string service_region = "T9"
+        )
+        {
+            try
+            {
+                // Sync all cookies from WebView2 to BeanfunClient
+                foreach (var cookie in cookies)
+                {
+                    SetCookie(
+                        cookie.Name,
+                        cookie.Value,
+                        cookie.Domain.TrimStart('.'),
+                        string.IsNullOrEmpty(cookie.Path) ? "/" : cookie.Path
+                    );
+                }
+
+                this.webtoken = webToken;
+
+                GetAccounts(service_code, service_region, false);
+                if (this.errmsg != null)
+                    return;
+
+                this.remainPoint = getRemainPoint();
+                this.errmsg = null;
+            }
+            catch (Exception e)
+            {
+                this.errmsg = "LoginUnknown\n\n" + e.Message + "\n" + e.StackTrace;
+            }
+        }
+
         private void LoginCompleted(
             string akey,
             string service_code = "610074",

--- a/Beanfun/Tools/BeanfunClient.Login.cs
+++ b/Beanfun/Tools/BeanfunClient.Login.cs
@@ -185,7 +185,7 @@ namespace Beanfun
         {
             if (advanceUrl.Contains("gamaweb.beanfun.com"))
             {
-                this.errmsg = "帳號狀態異常，請先使用瀏覽器登入官網確認（可能需聯絡客服）";
+                this.errmsg = "AdvanceCheckAccountAbnormal";
                 return null;
             }
 
@@ -197,7 +197,7 @@ namespace Beanfun
             );
             if (!captchaMatch.Success)
             {
-                this.errmsg = "無法取得驗證碼編號，帳號可能處於異常狀態";
+                this.errmsg = "AdvanceCheckNoCaptchaId";
                 return null;
             }
             string captchaId = captchaMatch.Groups[1].Value;
@@ -244,7 +244,7 @@ namespace Beanfun
 
             if (captchaImgBytes == null || captchaImgBytes.Length < 500)
             {
-                this.errmsg = "無法載入驗證碼圖片（Session 可能已過期）";
+                this.errmsg = "AdvanceCheckCaptchaLoadFailed";
                 return null;
             }
 

--- a/Beanfun/Tools/BeanfunClient.Verify.cs
+++ b/Beanfun/Tools/BeanfunClient.Verify.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Specialized;
+using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.Net;
@@ -28,20 +29,33 @@ namespace Beanfun
 
         public BitmapImage getVerifyCaptcha(string samplecaptcha)
         {
+            if (string.IsNullOrWhiteSpace(samplecaptcha))
+                return null;
+
             BitmapImage result;
             try
             {
-                byte[] buffer = this.DownloadData(
+                string url =
                     "https://tw.newlogin.beanfun.com/LoginCheck/BotDetectCaptcha.ashx?get=image&c=c_logincheck_advancecheck_samplecaptcha&t="
-                        + samplecaptcha
-                );
+                    + samplecaptcha;
+                byte[] buffer = this.DownloadData(url);
+
+                if (buffer == null || buffer.Length < 500)
+                {
+                    Debug.WriteLine("[Captcha] Downloaded data is too small to be an image.");
+                    return null;
+                }
+
                 result = new BitmapImage();
                 result.BeginInit();
+                result.CacheOption = BitmapCacheOption.OnLoad;
                 result.StreamSource = new MemoryStream(buffer);
                 result.EndInit();
+                result.Freeze();
             }
-            catch (Exception)
+            catch (Exception ex)
             {
+                Debug.WriteLine($"[Captcha] Error parsing image: {ex.Message}");
                 result = null;
             }
             return result;

--- a/Beanfun/Tools/BeanfunClient.cs
+++ b/Beanfun/Tools/BeanfunClient.cs
@@ -161,6 +161,16 @@ namespace Beanfun
             return null;
         }
 
+        public void SetCookie(string name, string value, string domain, string path = "/")
+        {
+            this.CookieContainer.Add(new Cookie(name, value, path, domain));
+        }
+
+        public void SetWebToken(string token)
+        {
+            this.webtoken = token;
+        }
+
         private string GetCurrentTime(int method = 0)
         {
             DateTime date = DateTime.Now;

--- a/Beanfun/Tools/BeanfunClient.cs
+++ b/Beanfun/Tools/BeanfunClient.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Diagnostics;
 using System.IO;
 using System.Net;
 using System.Text;
@@ -98,22 +99,45 @@ namespace Beanfun
 
         protected override WebRequest GetWebRequest(Uri address)
         {
+            ServicePointManager.SecurityProtocol =
+                SecurityProtocolType.Tls12 | SecurityProtocolType.Tls13;
             HttpWebRequest webRequest = base.GetWebRequest(address) as HttpWebRequest;
-            webRequest.Timeout = Timeout;
 
             if (webRequest != null)
             {
+                webRequest.Timeout = this.Timeout;
+                if (this.CookieContainer == null)
+                    this.CookieContainer = new CookieContainer();
+
                 webRequest.CookieContainer = this.CookieContainer;
                 webRequest.AllowAutoRedirect = this.redirect;
+                webRequest.AutomaticDecompression =
+                    DecompressionMethods.GZip | DecompressionMethods.Deflate;
             }
             return webRequest;
         }
 
         protected override WebResponse GetWebResponse(WebRequest request)
         {
-            WebResponse webResponse = base.GetWebResponse(request);
-            this.ResponseUri = webResponse.ResponseUri;
-            return webResponse;
+            try
+            {
+                WebResponse webResponse = base.GetWebResponse(request);
+                this.ResponseUri = webResponse.ResponseUri;
+                return webResponse;
+            }
+            catch (WebException wex)
+            {
+                if (wex.Response != null)
+                {
+                    var httpResponse = wex.Response as HttpWebResponse;
+                    Debug.WriteLine(
+                        $"[WebResponse] Status={httpResponse?.StatusCode} Uri={wex.Response.ResponseUri}"
+                    );
+                    this.ResponseUri = wex.Response.ResponseUri;
+                    return wex.Response;
+                }
+                throw;
+            }
         }
 
         public CookieCollection GetCookies()

--- a/Beanfun/Windows/GamePassBrowser.xaml
+++ b/Beanfun/Windows/GamePassBrowser.xaml
@@ -12,9 +12,6 @@
   WindowStartupLocation="CenterScreen"
 >
   <Grid>
-    <wv2:WebView2
-      x:Name="wb_Main"
-      NavigationStarting="wb_Main_NavigationStarting"
-    />
+    <wv2:WebView2 x:Name="wb_Main" NavigationStarting="wb_Main_NavigationStarting" />
   </Grid>
 </Window>

--- a/Beanfun/Windows/GamePassBrowser.xaml
+++ b/Beanfun/Windows/GamePassBrowser.xaml
@@ -1,0 +1,20 @@
+<Window
+  x:Class="Beanfun.GamePassBrowser"
+  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+  xmlns:wv2="clr-namespace:Microsoft.Web.WebView2.Wpf;assembly=Microsoft.Web.WebView2.Wpf"
+  mc:Ignorable="d"
+  Title="GamePass Login"
+  Height="550"
+  Width="850"
+  WindowStartupLocation="CenterScreen"
+>
+  <Grid>
+    <wv2:WebView2
+      x:Name="wb_Main"
+      NavigationStarting="wb_Main_NavigationStarting"
+    />
+  </Grid>
+</Window>

--- a/Beanfun/Windows/GamePassBrowser.xaml.cs
+++ b/Beanfun/Windows/GamePassBrowser.xaml.cs
@@ -25,8 +25,6 @@ namespace Beanfun
         private async void OnLoaded(object sender, RoutedEventArgs e)
         {
             Loaded -= OnLoaded;
-
-            // Hide window until GamePass page loads
             this.Opacity = 0;
 
             wb_Main.CoreWebView2InitializationCompleted += OnWebViewReady;
@@ -58,17 +56,23 @@ namespace Beanfun
                 foreach (Cookie cookie in App.MainWnd.bfClient.GetCookies())
                     wb_Main.CoreWebView2.CookieManager.AddOrUpdateCookie(
                         wb_Main.CoreWebView2.CookieManager.CreateCookie(
-                            cookie.Name, cookie.Value, cookie.Domain, cookie.Path
+                            cookie.Name,
+                            cookie.Value,
+                            cookie.Domain,
+                            cookie.Path
                         )
                     );
             }
         }
 
-        private async void OnNavigationCompleted(object sender, CoreWebView2NavigationCompletedEventArgs e)
+        private async void OnNavigationCompleted(
+            object sender,
+            CoreWebView2NavigationCompletedEventArgs e
+        )
         {
             string url = wb_Main.Source?.ToString() ?? "";
 
-            // On Login/Index page, auto-click the GamePass button
+            // Auto-click GamePass button on login page
             if (!_hasClickedGamePass && url.Contains("Login/Index"))
             {
                 _hasClickedGamePass = true;
@@ -81,18 +85,96 @@ namespace Beanfun
                 return;
             }
 
-            // Once we've left Login/Index, show the window
+            // Show window once past login page
             if (_hasClickedGamePass && !url.Contains("Login/Index"))
-            {
                 this.Opacity = 1;
-            }
 
-            // TODO: intercept callback URL with akey after GamePass login completes
+            // After callback completes, beanfun redirects to SendLogin then return.aspx
+            // Check if we've landed back on beanfun with bfWebToken cookie set
+            if (
+                url.Contains("beanfun.com")
+                && (
+                    url.Contains("return.aspx")
+                    || url.Contains("index.aspx")
+                    || url.Contains("SendLogin")
+                )
+            )
+            {
+                await TryCompleteLogin();
+            }
         }
 
-        private void wb_Main_NavigationStarting(object sender, CoreWebView2NavigationStartingEventArgs e)
+        private async System.Threading.Tasks.Task TryCompleteLogin()
         {
-            this.Title = "GamePass Login";
+            try
+            {
+                var twCookies = await wb_Main.CoreWebView2.CookieManager.GetCookiesAsync(
+                    "https://tw.beanfun.com"
+                );
+                var loginCookies = await wb_Main.CoreWebView2.CookieManager.GetCookiesAsync(
+                    "https://login.beanfun.com"
+                );
+                var newLoginCookies = await wb_Main.CoreWebView2.CookieManager.GetCookiesAsync(
+                    "https://tw.newlogin.beanfun.com"
+                );
+
+                string webToken = null;
+                foreach (var cookie in twCookies)
+                {
+                    if (cookie.Name == "bfWebToken")
+                    {
+                        webToken = cookie.Value;
+                        break;
+                    }
+                }
+
+                if (string.IsNullOrEmpty(webToken))
+                    return;
+
+                // Convert WebView2 cookies to System.Net.Cookie for BeanfunClient
+                var allCookies = new System.Collections.Generic.List<Cookie>();
+                ConvertCookies(twCookies, allCookies);
+                ConvertCookies(loginCookies, allCookies);
+                ConvertCookies(newLoginCookies, allCookies);
+
+                Dispatcher.Invoke(() =>
+                {
+                    this.Close();
+                    App.MainWnd.GamePassLoginCompleted(webToken, allCookies);
+                });
+            }
+            catch { }
+        }
+
+        private void ConvertCookies(
+            System.Collections.Generic.IReadOnlyList<CoreWebView2Cookie> source,
+            System.Collections.Generic.List<Cookie> target
+        )
+        {
+            foreach (var wv2Cookie in source)
+            {
+                try
+                {
+                    target.Add(
+                        new Cookie(
+                            wv2Cookie.Name,
+                            wv2Cookie.Value,
+                            string.IsNullOrEmpty(wv2Cookie.Path) ? "/" : wv2Cookie.Path,
+                            wv2Cookie.Domain.TrimStart('.')
+                        )
+                    );
+                }
+                catch { }
+            }
+        }
+
+        private void wb_Main_NavigationStarting(
+            object sender,
+            CoreWebView2NavigationStartingEventArgs e
+        )
+        {
+            this.Title =
+                Application.Current.TryFindResource("GamePassLogin") as string ?? "GamePass Login";
         }
     }
 }

--- a/Beanfun/Windows/GamePassBrowser.xaml.cs
+++ b/Beanfun/Windows/GamePassBrowser.xaml.cs
@@ -10,6 +10,7 @@ namespace Beanfun
     {
         private readonly string _skey;
         private bool _hasClickedGamePass = false;
+        private bool _loginCompleted = false;
 
         public GamePassBrowser(string skey)
         {
@@ -20,6 +21,16 @@ namespace Beanfun
                 Path.GetTempPath() + "\\Beanfun\\WebView2\\"
             );
             Loaded += OnLoaded;
+            Closed += OnClosed;
+        }
+
+        private void OnClosed(object sender, EventArgs e)
+        {
+            if (!_loginCompleted)
+            {
+                // User closed window without completing login, reset bfClient
+                App.MainWnd.bfClient = null;
+            }
         }
 
         private async void OnLoaded(object sender, RoutedEventArgs e)
@@ -139,6 +150,7 @@ namespace Beanfun
 
                 Dispatcher.Invoke(() =>
                 {
+                    _loginCompleted = true;
                     this.Close();
                     App.MainWnd.GamePassLoginCompleted(webToken, allCookies);
                 });

--- a/Beanfun/Windows/GamePassBrowser.xaml.cs
+++ b/Beanfun/Windows/GamePassBrowser.xaml.cs
@@ -1,0 +1,98 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Windows;
+using Microsoft.Web.WebView2.Core;
+
+namespace Beanfun
+{
+    public partial class GamePassBrowser : Window
+    {
+        private readonly string _skey;
+        private bool _hasClickedGamePass = false;
+
+        public GamePassBrowser(string skey)
+        {
+            InitializeComponent();
+            _skey = skey;
+            Environment.SetEnvironmentVariable(
+                "WEBVIEW2_USER_DATA_FOLDER",
+                Path.GetTempPath() + "\\Beanfun\\WebView2\\"
+            );
+            Loaded += OnLoaded;
+        }
+
+        private async void OnLoaded(object sender, RoutedEventArgs e)
+        {
+            Loaded -= OnLoaded;
+
+            // Hide window until GamePass page loads
+            this.Opacity = 0;
+
+            wb_Main.CoreWebView2InitializationCompleted += OnWebViewReady;
+
+            if (bool.Parse(ConfigAppSettings.GetValue("disableHardwareAcceleration", "false")))
+            {
+                string userDataFolder = Path.Combine(Path.GetTempPath(), "Beanfun", "WebView2");
+                var options = new CoreWebView2EnvironmentOptions();
+                options.AdditionalBrowserArguments = "--disable-gpu --disable-gpu-compositing";
+                var env = await CoreWebView2Environment.CreateAsync(null, userDataFolder, options);
+                await wb_Main.EnsureCoreWebView2Async(env);
+            }
+
+            wb_Main.Source = new Uri($"https://login.beanfun.com/Login/Index?pSKey={_skey}");
+        }
+
+        private void OnWebViewReady(object sender, CoreWebView2InitializationCompletedEventArgs e)
+        {
+            wb_Main.CoreWebView2.NewWindowRequested += (s, args) =>
+            {
+                wb_Main.CoreWebView2.Navigate(args.Uri);
+                args.Handled = true;
+            };
+
+            wb_Main.CoreWebView2.NavigationCompleted += OnNavigationCompleted;
+
+            if (App.MainWnd.bfClient != null)
+            {
+                foreach (Cookie cookie in App.MainWnd.bfClient.GetCookies())
+                    wb_Main.CoreWebView2.CookieManager.AddOrUpdateCookie(
+                        wb_Main.CoreWebView2.CookieManager.CreateCookie(
+                            cookie.Name, cookie.Value, cookie.Domain, cookie.Path
+                        )
+                    );
+            }
+        }
+
+        private async void OnNavigationCompleted(object sender, CoreWebView2NavigationCompletedEventArgs e)
+        {
+            string url = wb_Main.Source?.ToString() ?? "";
+
+            // On Login/Index page, auto-click the GamePass button
+            if (!_hasClickedGamePass && url.Contains("Login/Index"))
+            {
+                _hasClickedGamePass = true;
+                await wb_Main.CoreWebView2.ExecuteScriptAsync(
+                    @"(function() {
+                        var btn = document.querySelector('a.use-gama-pass');
+                        if (btn) btn.click();
+                    })()"
+                );
+                return;
+            }
+
+            // Once we've left Login/Index, show the window
+            if (_hasClickedGamePass && !url.Contains("Login/Index"))
+            {
+                this.Opacity = 1;
+            }
+
+            // TODO: intercept callback URL with akey after GamePass login completes
+        }
+
+        private void wb_Main_NavigationStarting(object sender, CoreWebView2NavigationStartingEventArgs e)
+        {
+            this.Title = "GamePass Login";
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Download available at <https://github.com/pungin/Beanfun/releases/latest>.
 ## Built With
 
 * [.NET 8](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) - 目標框架（Self-contained，使用者不需另外安裝）
-* [ini-parser](https://github.com/rickyah/ini-parser) - ini元件
+* [ini-parser-netstandard](https://github.com/lukazh/ini-parser-standard) - ini元件
 * [log4net](https://logging.apache.org/log4net/) - 日誌元件
 * [Newtonsoft.Json](https://www.newtonsoft.com/json) - JSON元件
 * [Microsoft.Web.WebView2](https://www.nuget.org/packages/Microsoft.Web.WebView2) - 內嵌瀏覽器元件
@@ -43,6 +43,16 @@ Download available at <https://github.com/pungin/Beanfun/releases/latest>.
 * [Locale_Remulator](https://github.com/InWILL/Locale_Remulator) - 區域模擬元件
 
 ## Development
+
+### 建置發行版本
+
+```bash
+# 清理並發行單一 exe（Self-contained，不需安裝 .NET Runtime）
+dotnet clean Beanfun/Beanfun.csproj -c Release
+dotnet publish Beanfun/Beanfun.csproj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -p:IncludeAllContentForSelfExtract=true -p:EnableCompressionInSingleFile=true -p:DebugType=none -o publish
+```
+
+產出的 `publish/Beanfun.exe` 即為可直接發行的單一執行檔。
 
 ### 程式碼格式化
 


### PR DESCRIPTION
Fixes #182 #185 #186

因為橘子更新了登入介面，舊版 `tw.newlogin.beanfun.com` 的 ASP.NET Form 登入方式已經失效。這個 PR 將台灣區登入改為使用新版 `login.beanfun.com` JSON API，並整合進階認證流程。另外也修復了舊版使用者啟動時會跳轉到不存在的 GitHub 工具頁面（404）的問題，將資料格式轉換直接內建到主程式中。

主要改動：

- 台灣區登入改用新版 JSON API（CheckAccountType → AccountLogin → Finalize）
- 新增 AdvanceCheck dialog，使用者可以直接在程式內完成進階認證（針對沒有整合到 GamaPlay 的用家）
<img width="384" height="271" alt="image" src="https://github.com/user-attachments/assets/9385f01c-48ba-41b7-a715-46eda04a28bf" />

- 新增 `TryAutoMigrateLegacyData`，舊版 `Users.dat`（BinaryFormatter 格式）會自動轉換為 JSON，並移除失效的外部工具連結與提示視窗
<img width="368" height="150" alt="image" src="https://github.com/user-attachments/assets/0ec4c3b4-bbd7-480f-af93-7fc3a5b1cd62" /> 

- 修復 `errexit` 遺漏的 error cases 以及 Unicode unescape 導致的 crash
- 將重複的登入成功邏輯抽取為獨立方法（方便日後維護）
- 修復 `GetSessionkey` 的 regex 以相容新版跳轉 URL 格式
- 清理多餘的 header 操作與冗長的註解


#### 已完成測試，代碼格式化通過：
- [x] dotnet tool restore
- [x] dotnet csharpier format .
- [x] dotnet csharpier check 