### PR TITLE
fix: 修復非繁體中文系統（如簡體中文）無法透過 LocaleRemulator 啟動遊戲的問題

### DIFF
--- a/Beanfun/App.xaml.cs
+++ b/Beanfun/App.xaml.cs
@@ -124,9 +124,14 @@ namespace Beanfun
             }
         }
 
+        public static string AppDir =>
+            Path.GetDirectoryName(
+                System.Diagnostics.Process.GetCurrentProcess().MainModule.FileName
+            );
+
         public static int ReleaseResource(string file)
         {
-            string path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, file);
+            string path = Path.Combine(AppDir, file);
             using (Stream stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(file))
             {
                 if (stream != null)

--- a/Beanfun/MainWindow.xaml.cs
+++ b/Beanfun/MainWindow.xaml.cs
@@ -1897,7 +1897,10 @@ namespace Beanfun
                 || App.ReleaseResource("LRProc.exe") == -1
                 || App.ReleaseResource("LRSubMenus.dll") == -1
             )
+            {
                 MessageBox.Show(TryFindResource("MsgLocalePluginReleaseError") as string);
+                return;
+            }
 
             var commandLine = string.Empty;
             commandLine = path.StartsWith("\"") ? $"{path} " : $"\"{path}\" ";
@@ -1912,12 +1915,7 @@ namespace Beanfun
                     try
                     {
                         var proc = new Process();
-                        proc.StartInfo.FileName = Path.Combine(
-                            Path.GetDirectoryName(
-                                System.Diagnostics.Process.GetCurrentProcess().MainModule.FileName
-                            ),
-                            "LRProc.exe"
-                        );
+                        proc.StartInfo.FileName = Path.Combine(App.AppDir, "LRProc.exe");
                         proc.StartInfo.Arguments =
                             "ef3e7b42-a87c-4c07-ae3e-eeebeef12762 " + commandLine;
                         proc.StartInfo.WorkingDirectory = Path.GetDirectoryName(path);


### PR DESCRIPTION
## Issue

在簡體中文 Windows 10 系統上，點擊啟動遊戲時出現「啟動失敗，請嘗試從桌面捷徑直接啟動遊戲」的錯誤。 #196 

## Finding

應用程式使用 `dotnet publish -p:PublishSingleFile=true` 發佈。在 single-file 模式下：

- `AppDomain.CurrentDomain.BaseDirectory` → 指向 exe 解壓後的臨時目錄（如 `%TEMP%\.net\Beanfun\...`）
- `Process.GetCurrentProcess().MainModule.FileName` → 指向實際 exe 所在目錄

`ReleaseResource()` 使用 `BaseDirectory` 將 LR 檔案（LRProc.exe、LRHookx32.dll 等）釋放到臨時目錄，但 `startByLR()` 卻用 `MainModule.FileName` 的目錄去找 LRProc.exe，路徑不一致導致找不到檔案而啟動失敗。

此問題影響所有需要 LocaleRemulator 的非繁體中文系統（簡體中文、英文、日文等）。

## Fixs

- 新增 `App.AppDir` 屬性，統一使用 exe 實際所在目錄
- `ReleaseResource()` 和 `startByLR()` 均改用 `App.AppDir`
- `startByLR()` 在資源釋放失敗時提前 return，避免嘗試啟動不存在的 LRProc.exe
