### PR TITLE
refactor: cache App.AppDir as static readonly field

### DIFF
--- a/Beanfun/App.xaml.cs
+++ b/Beanfun/App.xaml.cs
@@ -124,9 +124,9 @@ namespace Beanfun
             }
         }
 
-        public static string AppDir =>
+        public static readonly string AppDir =
             Path.GetDirectoryName(
-                System.Diagnostics.Process.GetCurrentProcess().MainModule.FileName
+                Process.GetCurrentProcess().MainModule.FileName
             );
 
         public static int ReleaseResource(string file)


### PR DESCRIPTION
## Summary

- Change App.AppDir from an expression-bodied property to a static readonly field
- The exe path never changes during the application lifetime, so caching avoids repeated Process.GetCurrentProcess() calls (called 5 times via ReleaseResource in startByLR)
- Also removes redundant System.Diagnostics namespace qualifier since using System.Diagnostics is already imported

Follow-up to #197

## Test plan

- [ ] Verify game launch works on non-Traditional-Chinese systems (e.g. zh-CN) with LocaleRemulator
- [ ] Verify App.AppDir resolves to the correct exe directory in both single-file publish and normal build modes