### PR TITLE
fix: prevent concurrent WebClient I/O on shared bfClient instance

### DIFF
--- a/Beanfun/MainWindow.xaml.cs
+++ b/Beanfun/MainWindow.xaml.cs
@@ -64,6 +64,7 @@ namespace Beanfun
         public AccountManager accountManager = null;
 
         public BeanfunClient bfClient;
+        private readonly object _bfClientLock = new object();
 
         public BeanfunClient.QRCodeClass qrcodeClass;
 
@@ -2267,16 +2268,24 @@ namespace Beanfun
                     break;
                 }
 
-                if (this.getOtpWorker.IsBusy || this.loginWorker.IsBusy || this.totpWorker.IsBusy)
+                if (this.getOtpWorker.IsBusy || this.loginWorker.IsBusy || this.totpWorker.IsBusy
+                    || this.qrWorker.IsBusy || this.verifyWorker.IsBusy)
                 {
                     Console.WriteLine("ping.busy sleep 1s");
                     System.Threading.Thread.Sleep(1000 * 1);
                     continue;
                 }
 
-                if (this.bfClient != null)
+                if (this.bfClient != null && Monitor.TryEnter(_bfClientLock))
                 {
-                    this.bfClient.Ping();
+                    try
+                    {
+                        this.bfClient.Ping();
+                    }
+                    finally
+                    {
+                        Monitor.Exit(_bfClientLock);
+                    }
                 }
 
                 for (int i = 0; i < WaitSecs; ++i)
@@ -2314,7 +2323,17 @@ namespace Beanfun
                 MessageBox.Show("QRCode not get yet");
                 return;
             }
-            int res = this.bfClient.QRCodeCheckLoginStatus(this.qrcodeClass);
+            if (!Monitor.TryEnter(_bfClientLock))
+                return;
+            int res;
+            try
+            {
+                res = this.bfClient.QRCodeCheckLoginStatus(this.qrcodeClass);
+            }
+            finally
+            {
+                Monitor.Exit(_bfClientLock);
+            }
             if (res != 0)
                 this.qrCheckLogin.IsEnabled = false;
             if (res == 1)
@@ -2358,7 +2377,17 @@ namespace Beanfun
 
         private void bfAPPAutoLogin_Tick(object sender, EventArgs e)
         {
-            JObject resultJson = this.bfClient.CheckIsRegisteDevice(service_code, service_region);
+            if (!Monitor.TryEnter(_bfClientLock))
+                return;
+            JObject resultJson;
+            try
+            {
+                resultJson = this.bfClient.CheckIsRegisteDevice(service_code, service_region);
+            }
+            finally
+            {
+                Monitor.Exit(_bfClientLock);
+            }
             if (resultJson == null || resultJson["IntResult"] == null)
                 return;
             if ((string)resultJson["IntResult"] != "1" && (string)resultJson["IntResult"] != "0")

--- a/Beanfun/MainWindow.xaml.cs
+++ b/Beanfun/MainWindow.xaml.cs
@@ -2268,8 +2268,13 @@ namespace Beanfun
                     break;
                 }
 
-                if (this.getOtpWorker.IsBusy || this.loginWorker.IsBusy || this.totpWorker.IsBusy
-                    || this.qrWorker.IsBusy || this.verifyWorker.IsBusy)
+                if (
+                    this.getOtpWorker.IsBusy
+                    || this.loginWorker.IsBusy
+                    || this.totpWorker.IsBusy
+                    || this.qrWorker.IsBusy
+                    || this.verifyWorker.IsBusy
+                )
                 {
                     Console.WriteLine("ping.busy sleep 1s");
                     System.Threading.Thread.Sleep(1000 * 1);


### PR DESCRIPTION
## Summary

- **Fix #199**: WebClient does not support concurrent I/O operations error when scanning QR Code
- Add Monitor.TryEnter synchronization on pingWorker_DoWork, qrCheckLogin_Tick, and fAPPAutoLogin_Tick to prevent concurrent access to the shared fClient (WebClient) instance
- Add missing qrWorker.IsBusy and erifyWorker.IsBusy checks in pingWorker_DoWork`n
## Root Cause

pingWorker (background thread, every 60s) calls fClient.Ping() without checking whether qrWorker or erifyWorker is busy. Meanwhile, qrCheckLogin_Tick (UI timer, every 2s) calls fClient.QRCodeCheckLoginStatus() on the same instance. When both fire simultaneously, WebClient throws the concurrent I/O error.

## Approach

Use Monitor.TryEnter (non-blocking) so that:
- If pingWorker can't acquire the lock, it skips this ping cycle (retries in 60s)
- If qrCheckLogin_Tick / fAPPAutoLogin_Tick can't acquire the lock, they skip this tick (retry in 2s)
- No UI thread blocking

Closes #199