### PR TITLE
fix: 修復登入方式還原/區域切換卡住 及 QR 登入後 WebClient 並發錯誤

### DIFF
--- a/Beanfun/MainWindow.xaml.cs
+++ b/Beanfun/MainWindow.xaml.cs
@@ -378,8 +378,9 @@ namespace Beanfun
                 );
                 if (loginMethod < (int)LoginMethod.Regular)
                     loginMethod = int.Parse(ConfigAppSettings.GetValue("loginMethod", "0"));
-                if (loginMethod > (int)LoginMethod.GamePass)
-                    loginMethod = (int)LoginMethod.GamePass;
+                // Don't restore QRCode/GamePass on startup — they require active auth sessions
+                if (loginMethod > (int)LoginMethod.Regular)
+                    loginMethod = (int)LoginMethod.Regular;
 
                 loginMethodInit();
 
@@ -1013,6 +1014,7 @@ namespace Beanfun
         public void loginMethodChanged()
         {
             qrCheckLogin.IsEnabled = false;
+            btn_Region.IsEnabled = true;
 
             if (App.LoginRegion == "TW")
             {

--- a/Beanfun/MainWindow.xaml.cs
+++ b/Beanfun/MainWindow.xaml.cs
@@ -2084,11 +2084,6 @@ namespace Beanfun
         private void getOtpWorker_DoWork(object sender, DoWorkEventArgs e)
         {
             CancelWork();
-            //if (this.pingWorker.IsBusy) this.pingWorker.CancelAsync();
-            /*while (this.pingWorker.IsBusy) {
-                Thread.Sleep(133);
-            }
-            */
 
             Console.WriteLine("getOtpWorker start");
             Thread.CurrentThread.Name = "GetOTP Worker";
@@ -2099,11 +2094,19 @@ namespace Beanfun
                 return;
             }
             Console.WriteLine("call GetOTP");
-            this.otp = this.bfClient.GetOTP(
-                this.bfClient.accountList[index],
-                this.service_code,
-                this.service_region
-            );
+            Monitor.Enter(_bfClientLock);
+            try
+            {
+                this.otp = this.bfClient.GetOTP(
+                    this.bfClient.accountList[index],
+                    this.service_code,
+                    this.service_region
+                );
+            }
+            finally
+            {
+                Monitor.Exit(_bfClientLock);
+            }
             Console.WriteLine("call GetOTP done");
             if (this.otp == null)
                 e.Result = -1;
@@ -2112,8 +2115,6 @@ namespace Beanfun
                 e.Result = index;
             }
 
-            //if (!this.pingWorker.IsBusy) this.pingWorker.RunWorkerAsync();
-            //this.pingWorker.RunWorkerAsync();
             ResumeWork();
             return;
         }


### PR DESCRIPTION
## 修復內容

### 1. 啟動時還原 QRCode/GamePass 登入方式導致區域切換卡住
- 程式啟動時若上次使用 QRCode 或 GamePass 登入，會還原該登入方式，導致區域切換按鈕被鎖定無法操作
<img width="294" height="492" alt="image" src="https://github.com/user-attachments/assets/2605dcfd-bb29-4f57-9c6d-b36b2af1832a" />


### 2. Fixs #203 QR 掃碼登入後彈出 WebClient concurrent I/O 錯誤 
- #199 的修復 (aa4adf8) 為 pingWorker、qrCheckLogin_Tick、bfAPPAutoLogin_Tick 加上了 _bfClientLock，但遺漏了 getOtpWorker_DoWork
- 當「登入後自動啟動遊戲」開啟時，ShowAccountListPage 幾乎同時啟動 pingWorker 和 getOtpWorker，pingWorker 持有 lock 呼叫 bfClient.Ping() 的同時 getOtpWorker 無 lock 呼叫 bfClient.GetOTP()，觸發「WebClient does not support concurrent I/O operations」
