### PR TITLE
feat: 登入頁面新增啟動遊戲按鈕、修正登入模式預設值、大陸用戶更新加速

### DIFF
--- a/Beanfun/Pages/Settings.xaml.cs
+++ b/Beanfun/Pages/Settings.xaml.cs
@@ -79,9 +79,7 @@ namespace Beanfun
 
             cb_ThemeColor.Text = ConfigAppSettings.GetValue("ThemeColor", "#FF8201");
 
-            cb_LoginMode.SelectedIndex = ConfigAppSettings.GetValue("loginMethod", "0").Equals("0")
-                ? 0
-                : 1;
+            cb_LoginMode.SelectedIndex = App.LoginMethod == (int)LoginMethod.Regular ? 0 : 1;
         }
 
         private void Button_Click(object sender, RoutedEventArgs e)

--- a/Beanfun/Pages/id-pass_form.xaml
+++ b/Beanfun/Pages/id-pass_form.xaml
@@ -628,18 +628,35 @@
             Content="{DynamicResource ForgotPassword}"
           />
         </Grid>
-        <Button
-          x:Name="btn_login"
-          Content="{DynamicResource Login}"
-          Height="30"
-          MinWidth="{Binding MinWidth, ElementName=t_AccountID}"
-          FontWeight="Bold"
-          Margin="0 10 0 20"
-          Click="btn_login_Click"
-          IsDefault="True"
-          Background="#7FF5F5F5"
-          Foreground="Black"
-        />
+        <Grid Margin="0 10 0 20">
+          <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="Auto" />
+          </Grid.ColumnDefinitions>
+          <Button
+            Grid.Column="0"
+            x:Name="btn_login"
+            Content="{DynamicResource Login}"
+            Height="30"
+            FontWeight="Bold"
+            Margin="0 0 5 0"
+            Click="btn_login_Click"
+            IsDefault="True"
+            Background="#7FF5F5F5"
+            Foreground="Black"
+          />
+          <Button
+            Grid.Column="1"
+            x:Name="btn_StartGame"
+            Content="{DynamicResource GameStart}"
+            Height="30"
+            Padding="10 0"
+            FontWeight="Bold"
+            Click="btn_StartGame_Click"
+            Background="#7FF5F5F5"
+            Foreground="Black"
+          />
+        </Grid>
       </StackPanel>
       <Grid MinWidth="{Binding MinWidth, ElementName=SideBarLeft}">
         <StackPanel VerticalAlignment="Bottom">

--- a/Beanfun/Pages/id-pass_form.xaml.cs
+++ b/Beanfun/Pages/id-pass_form.xaml.cs
@@ -293,5 +293,10 @@ namespace Beanfun
                 btn_GamePass.IsEnabled = true;
             }
         }
+
+        private void btn_StartGame_Click(object sender, RoutedEventArgs e)
+        {
+            App.MainWnd.runGame();
+        }
     }
 }

--- a/Beanfun/Pages/qr_form.xaml
+++ b/Beanfun/Pages/qr_form.xaml
@@ -118,18 +118,35 @@
           Foreground="Black"
           Click="btn_CopyDeeplink_Click"
         />
-        <Button
-          x:Name="btn_back"
-          Content="{DynamicResource BackRegularLogin}"
-          Height="30"
-          Width="250"
-          FontWeight="Bold"
-          Margin="0 10 0 20"
-          IsDefault="True"
-          Background="#7FF5F5F5"
-          Foreground="Black"
-          Click="btn_back_Click"
-        />
+        <Grid Margin="0 10 0 20" Width="250">
+          <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="Auto" />
+          </Grid.ColumnDefinitions>
+          <Button
+            Grid.Column="0"
+            x:Name="btn_back"
+            Content="{DynamicResource BackRegularLogin}"
+            Height="30"
+            FontWeight="Bold"
+            Margin="0 0 5 0"
+            IsDefault="True"
+            Background="#7FF5F5F5"
+            Foreground="Black"
+            Click="btn_back_Click"
+          />
+          <Button
+            Grid.Column="1"
+            x:Name="btn_StartGame"
+            Content="{DynamicResource GameStart}"
+            Height="30"
+            Padding="10 0"
+            FontWeight="Bold"
+            Background="#7FF5F5F5"
+            Foreground="Black"
+            Click="btn_StartGame_Click"
+          />
+        </Grid>
       </StackPanel>
       <Grid MinWidth="{Binding MinWidth, ElementName=SideBarLeft}" />
     </DockPanel>

--- a/Beanfun/Pages/qr_form.xaml.cs
+++ b/Beanfun/Pages/qr_form.xaml.cs
@@ -80,5 +80,10 @@ namespace Beanfun
             App.LoginMethod = (int)LoginMethod.Regular;
             App.MainWnd.loginMethodChanged();
         }
+
+        private void btn_StartGame_Click(object sender, RoutedEventArgs e)
+        {
+            App.MainWnd.runGame();
+        }
     }
 }

--- a/Beanfun/Update/ApplicationUpdater.cs
+++ b/Beanfun/Update/ApplicationUpdater.cs
@@ -11,6 +11,49 @@ namespace Beanfun.Update
 {
     class ApplicationUpdater
     {
+        private static readonly string[] GH_PROXIES = new[]
+        {
+            "https://ghproxy.vip/",
+            "https://ghproxy.net/",
+            "https://ghfast.top/",
+        };
+
+        private static string _cachedProxy;
+
+        private static string GetProxy()
+        {
+            if (_cachedProxy != null)
+                return _cachedProxy;
+
+            // Test direct GitHub access first
+            try
+            {
+                var req = WebRequest.CreateHttp("https://api.github.com");
+                req.Method = "HEAD";
+                req.Timeout = 5000;
+                req.UserAgent = "Beanfun";
+                using (req.GetResponse()) { }
+                return _cachedProxy = "";
+            }
+            catch { }
+
+            // Direct access failed, try proxies
+            foreach (var proxy in GH_PROXIES)
+            {
+                try
+                {
+                    var req = WebRequest.CreateHttp(proxy + "https://api.github.com");
+                    req.Method = "HEAD";
+                    req.Timeout = 5000;
+                    req.UserAgent = "Beanfun";
+                    using (req.GetResponse()) { }
+                    return _cachedProxy = proxy;
+                }
+                catch { }
+            }
+            return _cachedProxy = "";
+        }
+
         public class GitHubRelease
         {
             [JsonProperty("name")]
@@ -37,7 +80,8 @@ namespace Beanfun.Update
 
         internal static void CheckApplicationUpdate(bool show)
         {
-            var url = "https://api.github.com/repos/pungin/beanfun/releases";
+            string proxy = GetProxy();
+            var url = proxy + "https://api.github.com/repos/pungin/beanfun/releases";
 
             try
             {
@@ -53,8 +97,7 @@ namespace Beanfun.Update
                     if (release == null)
                         return;
 
-                    // 1. 解析遠端 Tag (格式: vMajor.Minor.Patch.Timestamp)
-                    // Groups: [1]=Major, [2]=Minor, [3]=Patch, [4]=Timestamp
+                    // 解析遠端 Tag (格式: vMajor.Minor.Patch.Timestamp)
                     var match = Regex.Match(release.TagName, @"^v(\d+)\.(\d+)\.(\d+)\.(\d+)$");
                     if (!match.Success)
                         return;
@@ -63,11 +106,8 @@ namespace Beanfun.Update
                     string minor = match.Groups[2].Value;
                     string patch = match.Groups[3].Value;
                     string timestamp = match.Groups[4].Value;
-
-                    // 2. 準備顯示文字: 5.8.3(2604011114)
                     string newVerDisplay = $"{major}.{minor}.{patch}({timestamp})";
 
-                    // 3. 數值比較邏輯 (傳入 patch 以支援 5.8.9 < 5.8.10)
                     if (IsNewerVersion(App.AssemblyVersion, major, minor, patch, timestamp))
                     {
                         string msg = string.Format(
@@ -91,7 +131,7 @@ namespace Beanfun.Update
                         {
                             string downloadUrl =
                                 (release.Assets != null && release.Assets.Count > 0)
-                                    ? release.Assets[0].BrowserDownloadUrl
+                                    ? proxy + release.Assets[0].BrowserDownloadUrl
                                     : $"https://github.com/pungin/Beanfun/releases/tag/{release.TagName}";
 
                             Process.Start(
@@ -138,7 +178,6 @@ namespace Beanfun.Update
 
         /// <summary>
         /// 比較版本號。將 Major, Minor, Patch 全部補齊 3 位後與 Timestamp 拼接進行 Long 比較。
-        /// 確保 5.8.9 < 5.8.10 且 Timestamp 格式永遠大於舊版。
         /// </summary>
         private static bool IsNewerVersion(
             string localVer,
@@ -150,16 +189,13 @@ namespace Beanfun.Update
         {
             try
             {
-                // 提取本地 Timestamp
                 var match = Regex.Match(localVer, @"(\d+)\.(\d+)\.?(\d+)?\.?\((\d+)\)");
 
                 if (match.Success)
                 {
                     string localTimestamp = match.Groups[4].Value;
                     if (timestamp == localTimestamp)
-                    {
                         return false;
-                    }
 
                     long remoteNum = long.Parse(
                         string.Format(


### PR DESCRIPTION
## 改動內容

### 1. 登入頁面新增「啟動遊戲」按鈕
- 在帳號密碼登入頁面的登入按鈕旁邊新增「啟動遊戲」按鈕
- 用戶不需要登入即可直接啟動遊戲（不帶帳號密碼，純啟動 exe）
- 解決登入失敗時無法啟動遊戲的問題
<img width="430" height="327" alt="image" src="https://github.com/user-attachments/assets/f7ebd2da-3520-48c3-b21a-287c1d247f25" />

### 2. 修正設定頁面登入模式預設值
- Settings 頁面的 cb_LoginMode 改為讀取 App.LoginMethod 而非直接讀 config
- 確保與啟動時的 loginMethod clamp 邏輯一致（#208），避免顯示已失效的 QRCode/GamePass 選項

### 3. GitHub 更新自動加速
- 更新檢查時先測試直連 GitHub API（5 秒 timeout）
- 如果直連失敗，自動 fallback 到 ghproxy.vip / ghproxy.net / ghfast.top代理
- 首次探測結果 cache，整個 session 不重複測試
- 能正常連 GitHub 的用戶完全不受影響