### PR TITLE
fix(updater): thread-safe probe, background-thread check, DRY cleanup + btn_login MinWidth

### DIFF
--- a/Beanfun/Pages/id-pass_form.xaml
+++ b/Beanfun/Pages/id-pass_form.xaml
@@ -628,7 +628,7 @@
             Content="{DynamicResource ForgotPassword}"
           />
         </Grid>
-        <Grid Margin="0 10 0 20">
+        <Grid Margin="0 10 0 20" MinWidth="{Binding MinWidth, ElementName=t_AccountID}">
           <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*" />
             <ColumnDefinition Width="Auto" />

--- a/Beanfun/Update/ApplicationUpdater.cs
+++ b/Beanfun/Update/ApplicationUpdater.cs
@@ -18,7 +18,26 @@ namespace Beanfun.Update
             "https://ghfast.top/",
         };
 
+        private const int ProbeTimeoutMs = 5000;
+
         private static string _cachedProxy;
+
+        private static bool TryProbe(string url)
+        {
+            try
+            {
+                var req = WebRequest.CreateHttp(url);
+                req.Method = "HEAD";
+                req.Timeout = ProbeTimeoutMs;
+                req.UserAgent = $"Beanfun(V{App.AssemblyVersion})";
+                using (req.GetResponse()) { }
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
 
         private static string GetProxy()
         {
@@ -26,31 +45,16 @@ namespace Beanfun.Update
                 return _cachedProxy;
 
             // Test direct GitHub access first
-            try
-            {
-                var req = WebRequest.CreateHttp("https://api.github.com");
-                req.Method = "HEAD";
-                req.Timeout = 5000;
-                req.UserAgent = "Beanfun";
-                using (req.GetResponse()) { }
+            if (TryProbe("https://api.github.com"))
                 return _cachedProxy = "";
-            }
-            catch { }
 
             // Direct access failed, try proxies
             foreach (var proxy in GH_PROXIES)
             {
-                try
-                {
-                    var req = WebRequest.CreateHttp(proxy + "https://api.github.com");
-                    req.Method = "HEAD";
-                    req.Timeout = 5000;
-                    req.UserAgent = "Beanfun";
-                    using (req.GetResponse()) { }
+                if (TryProbe(proxy + "https://api.github.com"))
                     return _cachedProxy = proxy;
-                }
-                catch { }
             }
+
             return _cachedProxy = "";
         }
 

--- a/Beanfun/Update/ApplicationUpdater.cs
+++ b/Beanfun/Update/ApplicationUpdater.cs
@@ -85,7 +85,33 @@ namespace Beanfun.Update
             public string BrowserDownloadUrl { get; set; }
         }
 
+        private static int _checkRunning;
+
         internal static void CheckApplicationUpdate(bool show)
+        {
+            // Prevent concurrent checks (e.g. startup probe + About-page click collision).
+            if (Interlocked.CompareExchange(ref _checkRunning, 1, 0) != 0)
+                return;
+
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    RunCheck(show);
+                }
+                finally
+                {
+                    Interlocked.Exchange(ref _checkRunning, 0);
+                }
+            })
+            {
+                IsBackground = true,
+                Name = "UpdateCheck",
+            };
+            thread.Start();
+        }
+
+        private static void RunCheck(bool show)
         {
             string proxy = GetProxy();
             var url = proxy + "https://api.github.com/repos/pungin/beanfun/releases";

--- a/Beanfun/Update/ApplicationUpdater.cs
+++ b/Beanfun/Update/ApplicationUpdater.cs
@@ -101,7 +101,8 @@ namespace Beanfun.Update
                     if (release == null)
                         return;
 
-                    // 解析遠端 Tag (格式: vMajor.Minor.Patch.Timestamp)
+                    // 1. 解析遠端 Tag (格式: vMajor.Minor.Patch.Timestamp)
+                    // Groups: [1]=Major, [2]=Minor, [3]=Patch, [4]=Timestamp
                     var match = Regex.Match(release.TagName, @"^v(\d+)\.(\d+)\.(\d+)\.(\d+)$");
                     if (!match.Success)
                         return;
@@ -110,8 +111,11 @@ namespace Beanfun.Update
                     string minor = match.Groups[2].Value;
                     string patch = match.Groups[3].Value;
                     string timestamp = match.Groups[4].Value;
+
+                    // 2. 準備顯示文字: 5.8.3(2604011114)
                     string newVerDisplay = $"{major}.{minor}.{patch}({timestamp})";
 
+                    // 3. 數值比較邏輯 (傳入 patch 以支援 5.8.9 < 5.8.10)
                     if (IsNewerVersion(App.AssemblyVersion, major, minor, patch, timestamp))
                     {
                         string msg = string.Format(
@@ -182,6 +186,7 @@ namespace Beanfun.Update
 
         /// <summary>
         /// 比較版本號。將 Major, Minor, Patch 全部補齊 3 位後與 Timestamp 拼接進行 Long 比較。
+        /// 確保 5.8.9 < 5.8.10 且 Timestamp 格式永遠大於舊版。
         /// </summary>
         private static bool IsNewerVersion(
             string localVer,
@@ -193,13 +198,16 @@ namespace Beanfun.Update
         {
             try
             {
+                // 提取本地 Timestamp
                 var match = Regex.Match(localVer, @"(\d+)\.(\d+)\.?(\d+)?\.?\((\d+)\)");
 
                 if (match.Success)
                 {
                     string localTimestamp = match.Groups[4].Value;
                     if (timestamp == localTimestamp)
+                    {
                         return false;
+                    }
 
                     long remoteNum = long.Parse(
                         string.Format(

--- a/Beanfun/Update/ApplicationUpdater.cs
+++ b/Beanfun/Update/ApplicationUpdater.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Net;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Windows;
 using Newtonsoft.Json;
 
@@ -20,7 +21,10 @@ namespace Beanfun.Update
 
         private const int ProbeTimeoutMs = 5000;
 
-        private static string _cachedProxy;
+        private static readonly Lazy<string> _cachedProxy = new Lazy<string>(
+            DiscoverProxy,
+            LazyThreadSafetyMode.ExecutionAndPublication
+        );
 
         private static bool TryProbe(string url)
         {
@@ -39,24 +43,23 @@ namespace Beanfun.Update
             }
         }
 
-        private static string GetProxy()
+        private static string DiscoverProxy()
         {
-            if (_cachedProxy != null)
-                return _cachedProxy;
-
             // Test direct GitHub access first
             if (TryProbe("https://api.github.com"))
-                return _cachedProxy = "";
+                return "";
 
             // Direct access failed, try proxies
             foreach (var proxy in GH_PROXIES)
             {
                 if (TryProbe(proxy + "https://api.github.com"))
-                    return _cachedProxy = proxy;
+                    return proxy;
             }
 
-            return _cachedProxy = "";
+            return "";
         }
+
+        private static string GetProxy() => _cachedProxy.Value;
 
         public class GitHubRelease
         {


### PR DESCRIPTION
## Summary
Follow-up cleanup for the review findings raised on #210 after merge.

- `refactor(updater)`: extract `TryProbe` helper, unify UserAgent, replace the hand-rolled `_cachedProxy` double-check with `Lazy<string>` so the probe is thread-safe under concurrent calls.
- `perf(updater)`: run `CheckApplicationUpdate` on a background `Thread` with an `Interlocked`-guarded flag, so manual "Check for Update" from the About page no longer freezes the UI for up to 20s on restricted networks.
- `style(updater)`: restore the step-numbered comments and the XML-doc line that #210 removed incidentally.
- `fix(ui)`: restore `btn_login`'s `MinWidth` binding (moved to the wrapping Grid so both the login button and the new Start Game button share the minimum-width constraint).

No behavior change for the happy path; no config/schema change.

Fixes #212