### PR TITLE
fix: OTP 提示改為 toast、遊戲資訊非同步載入、QR Code 複製/放大按鈕

### DIFF
--- a/Beanfun/API/WindowsAPI.cs
+++ b/Beanfun/API/WindowsAPI.cs
@@ -203,5 +203,53 @@ namespace Beanfun
             [MarshalAs(UnmanagedType.LPWStr)] string lpDestStr,
             int cchDest
         );
+
+        [DllImport("user32.dll")]
+        private static extern bool OpenClipboard(IntPtr hWndNewOwner);
+
+        [DllImport("user32.dll")]
+        private static extern bool CloseClipboard();
+
+        [DllImport("user32.dll")]
+        private static extern bool EmptyClipboard();
+
+        [DllImport("user32.dll")]
+        private static extern IntPtr SetClipboardData(uint uFormat, IntPtr hMem);
+
+        [DllImport("kernel32.dll")]
+        private static extern IntPtr GlobalAlloc(uint uFlags, UIntPtr dwBytes);
+
+        [DllImport("kernel32.dll")]
+        private static extern IntPtr GlobalLock(IntPtr hMem);
+
+        [DllImport("kernel32.dll")]
+        private static extern bool GlobalUnlock(IntPtr hMem);
+
+        private const uint CF_UNICODETEXT = 13;
+        private const uint GMEM_MOVEABLE = 0x0002;
+
+        public static bool CopyText(string text)
+        {
+            if (!OpenClipboard(IntPtr.Zero))
+                return false;
+            try
+            {
+                EmptyClipboard();
+                int bytes = (text.Length + 1) * 2;
+                IntPtr hGlobal = GlobalAlloc(GMEM_MOVEABLE, (UIntPtr)bytes);
+                if (hGlobal == IntPtr.Zero)
+                    return false;
+                IntPtr target = GlobalLock(hGlobal);
+                Marshal.Copy(text.ToCharArray(), 0, target, text.Length);
+                Marshal.WriteInt16(target, text.Length * 2, 0);
+                GlobalUnlock(hGlobal);
+                SetClipboardData(CF_UNICODETEXT, hGlobal);
+                return true;
+            }
+            finally
+            {
+                CloseClipboard();
+            }
+        }
     }
 }

--- a/Beanfun/Lang/en.xaml
+++ b/Beanfun/Lang/en.xaml
@@ -496,6 +496,8 @@
     >Enter the two-factor authentication code from your app</system:String
   >
   <system:String x:Key="CopyDeeplink">Copy Deeplink</system:String>
+  <system:String x:Key="CopyQRCode">Copy QR Code Image</system:String>
+  <system:String x:Key="EnlargeQRCode">Enlarge QR Code</system:String>
   <system:String x:Key="CopyDeeplinkSuccess">Deeplink copied to clipboard.</system:String>
   <system:String x:Key="CopyDeeplinkNotReady"
     >Deeplink is not ready yet. Please wait for the QR Code to load.</system:String

--- a/Beanfun/Lang/en.xaml
+++ b/Beanfun/Lang/en.xaml
@@ -496,6 +496,9 @@
     >Enter the two-factor authentication code from your app</system:String
   >
   <system:String x:Key="CopyDeeplink">Copy Deeplink</system:String>
+  <system:String x:Key="CopyQRCode">Copy QR Code Image</system:String>
+  <system:String x:Key="CopyQRCodeSuccess">QR Code copied</system:String>
+  <system:String x:Key="EnlargeQRCode">Enlarge QR Code</system:String>
   <system:String x:Key="CopyDeeplinkSuccess">Deeplink copied to clipboard.</system:String>
   <system:String x:Key="CopyDeeplinkNotReady"
     >Deeplink is not ready yet. Please wait for the QR Code to load.</system:String

--- a/Beanfun/Lang/en.xaml
+++ b/Beanfun/Lang/en.xaml
@@ -497,6 +497,7 @@
   >
   <system:String x:Key="CopyDeeplink">Copy Deeplink</system:String>
   <system:String x:Key="CopyQRCode">Copy QR Code Image</system:String>
+  <system:String x:Key="CopyQRCodeSuccess">QR Code copied</system:String>
   <system:String x:Key="EnlargeQRCode">Enlarge QR Code</system:String>
   <system:String x:Key="CopyDeeplinkSuccess">Deeplink copied to clipboard.</system:String>
   <system:String x:Key="CopyDeeplinkNotReady"

--- a/Beanfun/Lang/zh-Hans.xaml
+++ b/Beanfun/Lang/zh-Hans.xaml
@@ -407,6 +407,8 @@
   <system:String x:Key="LoginMode">登入方式</system:String>
   <system:String x:Key="InputTotp">请输入二次验证程序动态密码</system:String>
   <system:String x:Key="CopyDeeplink">复制 Deeplink</system:String>
+  <system:String x:Key="CopyQRCode">复制 QR Code 图片</system:String>
+  <system:String x:Key="EnlargeQRCode">放大 QR Code</system:String>
   <system:String x:Key="CopyDeeplinkSuccess">Deeplink 已复制到剪贴板。</system:String>
   <system:String x:Key="CopyDeeplinkNotReady"
     >Deeplink 尚未取得，请等待二维码加载完成。</system:String

--- a/Beanfun/Lang/zh-Hans.xaml
+++ b/Beanfun/Lang/zh-Hans.xaml
@@ -408,6 +408,7 @@
   <system:String x:Key="InputTotp">请输入二次验证程序动态密码</system:String>
   <system:String x:Key="CopyDeeplink">复制 Deeplink</system:String>
   <system:String x:Key="CopyQRCode">复制 QR Code 图片</system:String>
+  <system:String x:Key="CopyQRCodeSuccess">QR Code 已复制</system:String>
   <system:String x:Key="EnlargeQRCode">放大 QR Code</system:String>
   <system:String x:Key="CopyDeeplinkSuccess">Deeplink 已复制到剪贴板。</system:String>
   <system:String x:Key="CopyDeeplinkNotReady"

--- a/Beanfun/Lang/zh-Hans.xaml
+++ b/Beanfun/Lang/zh-Hans.xaml
@@ -407,6 +407,9 @@
   <system:String x:Key="LoginMode">登入方式</system:String>
   <system:String x:Key="InputTotp">请输入二次验证程序动态密码</system:String>
   <system:String x:Key="CopyDeeplink">复制 Deeplink</system:String>
+  <system:String x:Key="CopyQRCode">复制 QR Code 图片</system:String>
+  <system:String x:Key="CopyQRCodeSuccess">QR Code 已复制</system:String>
+  <system:String x:Key="EnlargeQRCode">放大 QR Code</system:String>
   <system:String x:Key="CopyDeeplinkSuccess">Deeplink 已复制到剪贴板。</system:String>
   <system:String x:Key="CopyDeeplinkNotReady"
     >Deeplink 尚未取得，请等待二维码加载完成。</system:String

--- a/Beanfun/Lang/zh.xaml
+++ b/Beanfun/Lang/zh.xaml
@@ -430,6 +430,7 @@
   <system:String x:Key="InputTotp">輸入應用程式內顯示的雙重驗證碼</system:String>
   <system:String x:Key="CopyDeeplink">複製 Deeplink</system:String>
   <system:String x:Key="CopyQRCode">複製 QR Code 圖片</system:String>
+  <system:String x:Key="CopyQRCodeSuccess">QR Code 已複製</system:String>
   <system:String x:Key="EnlargeQRCode">放大 QR Code</system:String>
   <system:String x:Key="CopyDeeplinkSuccess">Deeplink 已複製到剪貼簿。</system:String>
   <system:String x:Key="CopyDeeplinkNotReady"

--- a/Beanfun/Lang/zh.xaml
+++ b/Beanfun/Lang/zh.xaml
@@ -429,6 +429,9 @@
   <system:String x:Key="LoginMode">登入方式</system:String>
   <system:String x:Key="InputTotp">輸入應用程式內顯示的雙重驗證碼</system:String>
   <system:String x:Key="CopyDeeplink">複製 Deeplink</system:String>
+  <system:String x:Key="CopyQRCode">複製 QR Code 圖片</system:String>
+  <system:String x:Key="CopyQRCodeSuccess">QR Code 已複製</system:String>
+  <system:String x:Key="EnlargeQRCode">放大 QR Code</system:String>
   <system:String x:Key="CopyDeeplinkSuccess">Deeplink 已複製到剪貼簿。</system:String>
   <system:String x:Key="CopyDeeplinkNotReady"
     >Deeplink 尚未取得，請等待 QR Code 載入完成。</system:String

--- a/Beanfun/Lang/zh.xaml
+++ b/Beanfun/Lang/zh.xaml
@@ -429,6 +429,8 @@
   <system:String x:Key="LoginMode">登入方式</system:String>
   <system:String x:Key="InputTotp">輸入應用程式內顯示的雙重驗證碼</system:String>
   <system:String x:Key="CopyDeeplink">複製 Deeplink</system:String>
+  <system:String x:Key="CopyQRCode">複製 QR Code 圖片</system:String>
+  <system:String x:Key="EnlargeQRCode">放大 QR Code</system:String>
   <system:String x:Key="CopyDeeplinkSuccess">Deeplink 已複製到剪貼簿。</system:String>
   <system:String x:Key="CopyDeeplinkNotReady"
     >Deeplink 尚未取得，請等待 QR Code 載入完成。</system:String

--- a/Beanfun/MainWindow.xaml.cs
+++ b/Beanfun/MainWindow.xaml.cs
@@ -683,46 +683,67 @@ namespace Beanfun
         {
             if (!GameList.ContainsKey(App.LoginRegion.ToLower()))
             {
-                List<GameService> gameList = new List<GameService>();
-                WebClient wc = new WebClient();
-
-                string res = Encoding.UTF8.GetString(
-                    wc.DownloadData(
-                        "https://"
-                            + (App.LoginRegion == "HK" ? "bfweb.hk" : "tw")
-                            + ".beanfun.com/beanfun_block/generic_handlers/get_service_ini.ashx"
-                    )
-                );
-
-                IniDataParser parser = new IniDataParser();
-                INIData = parser.Parse(res);
-
-                res = Encoding.UTF8.GetString(
-                    wc.DownloadData(
-                        "https://"
-                            + (App.LoginRegion == "HK" ? "bfweb.hk" : "tw")
-                            + ".beanfun.com/game_zone/"
-                    )
-                );
-                Regex reg = new Regex("Services\\.ServiceList = (.*);");
-                if (reg.IsMatch(res))
+                new Thread(() =>
                 {
-                    string json = reg.Match(res).Groups[1].Value;
-                    bool newJson = new Regex("^\\[(.*)\\]$").IsMatch(json);
-                    if (newJson)
+                    try
                     {
-                        JArray jsons = JArray.Parse(json);
-                        foreach (JObject game in jsons)
-                            AddGameServiceFromJson(gameList, game);
+                        List<GameService> gameList = new List<GameService>();
+                        WebClient wc = new WebClient();
+
+                        string res = Encoding.UTF8.GetString(
+                            wc.DownloadData(
+                                "https://"
+                                    + (App.LoginRegion == "HK" ? "bfweb.hk" : "tw")
+                                    + ".beanfun.com/beanfun_block/generic_handlers/get_service_ini.ashx"
+                            )
+                        );
+
+                        IniDataParser parser = new IniDataParser();
+                        var iniData = parser.Parse(res);
+
+                        res = Encoding.UTF8.GetString(
+                            wc.DownloadData(
+                                "https://"
+                                    + (App.LoginRegion == "HK" ? "bfweb.hk" : "tw")
+                                    + ".beanfun.com/game_zone/"
+                            )
+                        );
+                        Regex reg = new Regex("Services\\.ServiceList = (.*);");
+                        if (reg.IsMatch(res))
+                        {
+                            string json = reg.Match(res).Groups[1].Value;
+                            bool newJson = new Regex("^\\[(.*)\\]$").IsMatch(json);
+                            if (newJson)
+                            {
+                                JArray jsons = JArray.Parse(json);
+                                foreach (JObject game in jsons)
+                                    AddGameServiceFromJson(gameList, game);
+                            }
+                            else
+                            {
+                                JObject o = JObject.Parse(json);
+                                foreach (JObject game in o["Rows"])
+                                    AddGameServiceFromJson(gameList, game);
+                            }
+                        }
+
+                        Dispatcher.Invoke(() =>
+                        {
+                            INIData = iniData;
+                            if (!GameList.ContainsKey(App.LoginRegion.ToLower()))
+                                GameList.Add(App.LoginRegion.ToLower(), gameList);
+                            selectedGameChanged();
+                        });
                     }
-                    else
+                    catch (Exception ex)
                     {
-                        JObject o = JObject.Parse(json);
-                        foreach (JObject game in o["Rows"])
-                            AddGameServiceFromJson(gameList, game);
+                        Console.WriteLine("reLoadGameInfo failed: " + ex.Message);
                     }
-                }
-                GameList.Add(App.LoginRegion.ToLower(), gameList);
+                })
+                {
+                    IsBackground = true,
+                }.Start();
+                return;
             }
 
             selectedGameChanged();
@@ -1366,6 +1387,7 @@ namespace Beanfun
         {
             try
             {
+                loginPage.qr.CloseEnlargeWindow();
                 frame.Content = accountList;
                 btn_Region.Visibility = Visibility.Collapsed;
 
@@ -2169,7 +2191,7 @@ namespace Beanfun
                             try
                             {
                                 Clipboard.SetText(accountList.t_Password.Text);
-                                MessageBox.Show(TryFindResource("GetOtpSuccessAndCopy") as string);
+                                ShowOtpCopiedHint();
                             }
                             catch { }
                         }
@@ -2259,9 +2281,23 @@ namespace Beanfun
                             1
                         )
                     );
+        }
 
-            //if (!this.pingWorker.IsBusy)  this.pingWorker.RunWorkerAsync();
-            //this.pingWorker.RunWorkerAsync();
+        private void ShowOtpCopiedHint()
+        {
+            accountList.toastText.Text =
+                TryFindResource("GetOtpSuccessAndCopy") as string ?? "Copied!";
+            accountList.toastBorder.Visibility = Visibility.Visible;
+            var timer = new System.Windows.Threading.DispatcherTimer
+            {
+                Interval = TimeSpan.FromSeconds(2),
+            };
+            timer.Tick += (s, _) =>
+            {
+                timer.Stop();
+                accountList.toastBorder.Visibility = Visibility.Collapsed;
+            };
+            timer.Start();
         }
 
         // Ping to Beanfun website.

--- a/Beanfun/MainWindow.xaml.cs
+++ b/Beanfun/MainWindow.xaml.cs
@@ -683,46 +683,67 @@ namespace Beanfun
         {
             if (!GameList.ContainsKey(App.LoginRegion.ToLower()))
             {
-                List<GameService> gameList = new List<GameService>();
-                WebClient wc = new WebClient();
-
-                string res = Encoding.UTF8.GetString(
-                    wc.DownloadData(
-                        "https://"
-                            + (App.LoginRegion == "HK" ? "bfweb.hk" : "tw")
-                            + ".beanfun.com/beanfun_block/generic_handlers/get_service_ini.ashx"
-                    )
-                );
-
-                IniDataParser parser = new IniDataParser();
-                INIData = parser.Parse(res);
-
-                res = Encoding.UTF8.GetString(
-                    wc.DownloadData(
-                        "https://"
-                            + (App.LoginRegion == "HK" ? "bfweb.hk" : "tw")
-                            + ".beanfun.com/game_zone/"
-                    )
-                );
-                Regex reg = new Regex("Services\\.ServiceList = (.*);");
-                if (reg.IsMatch(res))
+                new Thread(() =>
                 {
-                    string json = reg.Match(res).Groups[1].Value;
-                    bool newJson = new Regex("^\\[(.*)\\]$").IsMatch(json);
-                    if (newJson)
+                    try
                     {
-                        JArray jsons = JArray.Parse(json);
-                        foreach (JObject game in jsons)
-                            AddGameServiceFromJson(gameList, game);
+                        List<GameService> gameList = new List<GameService>();
+                        WebClient wc = new WebClient();
+
+                        string res = Encoding.UTF8.GetString(
+                            wc.DownloadData(
+                                "https://"
+                                    + (App.LoginRegion == "HK" ? "bfweb.hk" : "tw")
+                                    + ".beanfun.com/beanfun_block/generic_handlers/get_service_ini.ashx"
+                            )
+                        );
+
+                        IniDataParser parser = new IniDataParser();
+                        var iniData = parser.Parse(res);
+
+                        res = Encoding.UTF8.GetString(
+                            wc.DownloadData(
+                                "https://"
+                                    + (App.LoginRegion == "HK" ? "bfweb.hk" : "tw")
+                                    + ".beanfun.com/game_zone/"
+                            )
+                        );
+                        Regex reg = new Regex("Services\\.ServiceList = (.*);");
+                        if (reg.IsMatch(res))
+                        {
+                            string json = reg.Match(res).Groups[1].Value;
+                            bool newJson = new Regex("^\\[(.*)\\]$").IsMatch(json);
+                            if (newJson)
+                            {
+                                JArray jsons = JArray.Parse(json);
+                                foreach (JObject game in jsons)
+                                    AddGameServiceFromJson(gameList, game);
+                            }
+                            else
+                            {
+                                JObject o = JObject.Parse(json);
+                                foreach (JObject game in o["Rows"])
+                                    AddGameServiceFromJson(gameList, game);
+                            }
+                        }
+
+                        Dispatcher.Invoke(() =>
+                        {
+                            INIData = iniData;
+                            if (!GameList.ContainsKey(App.LoginRegion.ToLower()))
+                                GameList.Add(App.LoginRegion.ToLower(), gameList);
+                            selectedGameChanged();
+                        });
                     }
-                    else
+                    catch (Exception ex)
                     {
-                        JObject o = JObject.Parse(json);
-                        foreach (JObject game in o["Rows"])
-                            AddGameServiceFromJson(gameList, game);
+                        Console.WriteLine("reLoadGameInfo failed: " + ex.Message);
                     }
-                }
-                GameList.Add(App.LoginRegion.ToLower(), gameList);
+                })
+                {
+                    IsBackground = true,
+                }.Start();
+                return;
             }
 
             selectedGameChanged();
@@ -2169,7 +2190,7 @@ namespace Beanfun
                             try
                             {
                                 Clipboard.SetText(accountList.t_Password.Text);
-                                MessageBox.Show(TryFindResource("GetOtpSuccessAndCopy") as string);
+                                ShowOtpCopiedHint();
                             }
                             catch { }
                         }
@@ -2259,9 +2280,23 @@ namespace Beanfun
                             1
                         )
                     );
+        }
 
-            //if (!this.pingWorker.IsBusy)  this.pingWorker.RunWorkerAsync();
-            //this.pingWorker.RunWorkerAsync();
+        private void ShowOtpCopiedHint()
+        {
+            accountList.toastText.Text =
+                TryFindResource("GetOtpSuccessAndCopy") as string ?? "Copied!";
+            accountList.toastBorder.Visibility = Visibility.Visible;
+            var timer = new System.Windows.Threading.DispatcherTimer
+            {
+                Interval = TimeSpan.FromSeconds(2),
+            };
+            timer.Tick += (s, _) =>
+            {
+                timer.Stop();
+                accountList.toastBorder.Visibility = Visibility.Collapsed;
+            };
+            timer.Start();
         }
 
         // Ping to Beanfun website.

--- a/Beanfun/MainWindow.xaml.cs
+++ b/Beanfun/MainWindow.xaml.cs
@@ -1387,6 +1387,7 @@ namespace Beanfun
         {
             try
             {
+                loginPage.qr.CloseEnlargeWindow();
                 frame.Content = accountList;
                 btn_Region.Visibility = Visibility.Collapsed;
 

--- a/Beanfun/MainWindow.xaml.cs
+++ b/Beanfun/MainWindow.xaml.cs
@@ -917,8 +917,22 @@ namespace Beanfun
                 frame.Focus();
         }
 
+        private void CloseGamePassBrowser()
+        {
+            foreach (Window wnd in Application.Current.Windows)
+            {
+                if (wnd is GamePassBrowser)
+                {
+                    wnd.Close();
+                    break;
+                }
+            }
+        }
+
         private void btn_Region_Click(object sender, RoutedEventArgs e)
         {
+            loginPage.qr.CloseEnlargeWindow();
+            CloseGamePassBrowser();
             App.LoginRegion = App.LoginRegion == "TW" ? "HK" : "TW";
             ConfigAppSettings.SetValue("loginRegion", App.LoginRegion);
             loginMethodInit();
@@ -1039,6 +1053,8 @@ namespace Beanfun
         {
             if (qrWorker.IsBusy)
                 qrWorker.CancelAsync();
+            loginPage.qr.CloseEnlargeWindow();
+            CloseGamePassBrowser();
             qrCheckLogin.IsEnabled = false;
             btn_Region.IsEnabled = true;
             settingPage.LoginModePanel.Visibility =
@@ -1244,7 +1260,7 @@ namespace Beanfun
                 case "authkeyParseFailed":
                 case "LoginUnknown":
                     msg = TryFindResource(msg) as string;
-                    method = 0;
+                    method = 1;
                     break;
                 case "LoginNoAkey":
                     msg = $"{TryFindResource("LoginNoAkey") as string}({msg})";
@@ -2370,8 +2386,17 @@ namespace Beanfun
         private void qrWorker_RunWorkerCompleted(object sender, RunWorkerCompletedEventArgs e)
         {
             btn_Region.IsEnabled = true;
+            if (e.Cancelled)
+                return;
             if (updateQRCodeImage())
+            {
                 qrCheckLogin.IsEnabled = true;
+            }
+            else
+            {
+                App.LoginMethod = (int)LoginMethod.Regular;
+                loginMethodChanged();
+            }
         }
 
         private void qrCheckLogin_Tick(object sender, EventArgs e)

--- a/Beanfun/MainWindow.xaml.cs
+++ b/Beanfun/MainWindow.xaml.cs
@@ -2207,10 +2207,10 @@ namespace Beanfun
                         {
                             try
                             {
-                                Clipboard.SetText(accountList.t_Password.Text);
-                                ShowOtpCopiedHint();
+                                WindowsAPI.CopyText(accountList.t_Password.Text);
                             }
                             catch { }
+                            ShowOtpCopiedHint();
                         }
                         else
                         {
@@ -2300,10 +2300,13 @@ namespace Beanfun
                     );
         }
 
-        private void ShowOtpCopiedHint()
+        public void ShowOtpCopiedHint(string message = null)
         {
             accountList.toastText.Text =
-                TryFindResource("GetOtpSuccessAndCopy") as string ?? "Copied!";
+                "✓ " + (message ?? TryFindResource("GetOtpSuccessAndCopy") as string ?? "Copied!");
+            accountList.toastBorder.Background = new SolidColorBrush(
+                (Color)ColorConverter.ConvertFromString("#CC2E7D32")
+            );
             accountList.toastBorder.Visibility = Visibility.Visible;
             var timer = new System.Windows.Threading.DispatcherTimer
             {
@@ -2313,6 +2316,9 @@ namespace Beanfun
             {
                 timer.Stop();
                 accountList.toastBorder.Visibility = Visibility.Collapsed;
+                accountList.toastBorder.Background = new SolidColorBrush(
+                    (Color)ColorConverter.ConvertFromString("#CC333333")
+                );
             };
             timer.Start();
         }
@@ -2395,7 +2401,7 @@ namespace Beanfun
             else
             {
                 App.LoginMethod = (int)LoginMethod.Regular;
-                loginMethodChanged();
+                Dispatcher.BeginInvoke(new System.Action(() => loginMethodChanged()));
             }
         }
 

--- a/Beanfun/Pages/AccountList.xaml
+++ b/Beanfun/Pages/AccountList.xaml
@@ -305,5 +305,17 @@
         </StackPanel>
       </StackPanel>
     </Grid>
+    <Border
+      x:Name="toastBorder"
+      Background="#CC333333"
+      CornerRadius="6"
+      Padding="14 8"
+      HorizontalAlignment="Center"
+      VerticalAlignment="Bottom"
+      Margin="0 0 0 50"
+      Visibility="Collapsed"
+    >
+      <TextBlock x:Name="toastText" Foreground="White" FontSize="13" />
+    </Border>
   </Grid>
 </Page>

--- a/Beanfun/Pages/AccountList.xaml
+++ b/Beanfun/Pages/AccountList.xaml
@@ -309,14 +309,12 @@
       x:Name="toastBorder"
       Background="#CC333333"
       CornerRadius="6"
-      Padding="14 8"
       HorizontalAlignment="Center"
       VerticalAlignment="Bottom"
       Margin="0 0 0 50"
       Visibility="Collapsed"
-      Panel.ZIndex="999"
     >
-      <TextBlock x:Name="toastText" Foreground="White" FontSize="13" />
+      <TextBlock x:Name="toastText" Foreground="White" FontSize="13" Margin="14 8" />
     </Border>
   </Grid>
 </Page>

--- a/Beanfun/Pages/AccountList.xaml
+++ b/Beanfun/Pages/AccountList.xaml
@@ -305,5 +305,18 @@
         </StackPanel>
       </StackPanel>
     </Grid>
+    <Border
+      x:Name="toastBorder"
+      Background="#CC333333"
+      CornerRadius="6"
+      Padding="14 8"
+      HorizontalAlignment="Center"
+      VerticalAlignment="Bottom"
+      Margin="0 0 0 50"
+      Visibility="Collapsed"
+      Panel.ZIndex="999"
+    >
+      <TextBlock x:Name="toastText" Foreground="White" FontSize="13" />
+    </Border>
   </Grid>
 </Page>

--- a/Beanfun/Pages/AccountList.xaml.cs
+++ b/Beanfun/Pages/AccountList.xaml.cs
@@ -47,7 +47,7 @@ namespace Beanfun
                 return;
             try
             {
-                Clipboard.SetText(account.sid);
+                WindowsAPI.CopyText(account.sid);
             }
             catch { }
         }
@@ -109,9 +109,10 @@ namespace Beanfun
                 return;
             try
             {
-                Clipboard.SetText(t_Password.Text);
+                WindowsAPI.CopyText(t_Password.Text);
             }
             catch { }
+            App.MainWnd.ShowOtpCopiedHint(TryFindResource("CopyFinished") as string ?? "Copied");
         }
 
         private void btnAddServiceAccount_Click(object sender, RoutedEventArgs e)

--- a/Beanfun/Pages/LoginTotp.xaml
+++ b/Beanfun/Pages/LoginTotp.xaml
@@ -94,7 +94,8 @@
           <TextBox
             x:Name="otp1"
             GotFocus="otp_GotFocus"
-            PreviewKeyUp="otp1_PreviewKeyUp"
+            PreviewKeyDown="otp_PreviewKeyDown"
+            TextChanged="otp_TextChanged"
             Grid.Column="0"
             TextAlignment="Center"
             VerticalContentAlignment="Center"
@@ -104,7 +105,8 @@
           <TextBox
             x:Name="otp2"
             GotFocus="otp_GotFocus"
-            PreviewKeyUp="otp2_PreviewKeyUp"
+            PreviewKeyDown="otp_PreviewKeyDown"
+            TextChanged="otp_TextChanged"
             Grid.Column="2"
             TextAlignment="Center"
             VerticalContentAlignment="Center"
@@ -114,7 +116,8 @@
           <TextBox
             x:Name="otp3"
             GotFocus="otp_GotFocus"
-            PreviewKeyUp="otp3_PreviewKeyUp"
+            PreviewKeyDown="otp_PreviewKeyDown"
+            TextChanged="otp_TextChanged"
             Grid.Column="4"
             TextAlignment="Center"
             VerticalContentAlignment="Center"
@@ -124,7 +127,8 @@
           <TextBox
             x:Name="otp4"
             GotFocus="otp_GotFocus"
-            PreviewKeyUp="otp4_PreviewKeyUp"
+            PreviewKeyDown="otp_PreviewKeyDown"
+            TextChanged="otp_TextChanged"
             Grid.Column="6"
             TextAlignment="Center"
             VerticalContentAlignment="Center"
@@ -134,7 +138,8 @@
           <TextBox
             x:Name="otp5"
             GotFocus="otp_GotFocus"
-            PreviewKeyUp="otp5_PreviewKeyUp"
+            PreviewKeyDown="otp_PreviewKeyDown"
+            TextChanged="otp_TextChanged"
             Grid.Column="8"
             TextAlignment="Center"
             VerticalContentAlignment="Center"
@@ -144,7 +149,8 @@
           <TextBox
             x:Name="otp6"
             GotFocus="otp_GotFocus"
-            PreviewKeyUp="otp6_PreviewKeyUp"
+            PreviewKeyDown="otp_PreviewKeyDown"
+            TextChanged="otp_TextChanged"
             Grid.Column="10"
             TextAlignment="Center"
             VerticalContentAlignment="Center"

--- a/Beanfun/Pages/LoginTotp.xaml.cs
+++ b/Beanfun/Pages/LoginTotp.xaml.cs
@@ -1,28 +1,19 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
 using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 
 namespace Beanfun
 {
-    /// <summary>
-    /// LoginTotp.xaml 的交互逻辑
-    /// </summary>
     public partial class LoginTotp : Page
     {
+        private TextBox[] _otpBoxes;
+        private bool _isPasting;
+
         public LoginTotp()
         {
             InitializeComponent();
+            _otpBoxes = new[] { otp1, otp2, otp3, otp4, otp5, otp6 };
         }
 
         private void btn_login_Click(object sender, RoutedEventArgs e)
@@ -37,65 +28,94 @@ namespace Beanfun
             App.MainWnd.frame.Content = App.MainWnd.loginPage;
         }
 
-        private void otp1_PreviewKeyUp(object sender, KeyEventArgs e)
+        private void otp_PreviewKeyDown(object sender, KeyEventArgs e)
         {
-            if (otp1.Text.Length > 0)
-            {
-                otp2.Focus();
-            }
-        }
+            var box = sender as TextBox;
+            int index = System.Array.IndexOf(_otpBoxes, box);
 
-        private void otp2_PreviewKeyUp(object sender, KeyEventArgs e)
-        {
-            if (otp2.Text.Length > 0)
+            if (e.Key == Key.Back && box.Text.Length == 0 && index > 0)
             {
-                otp3.Focus();
+                _otpBoxes[index - 1].Text = "";
+                _otpBoxes[index - 1].Focus();
+                e.Handled = true;
+                return;
             }
-        }
 
-        private void otp3_PreviewKeyUp(object sender, KeyEventArgs e)
-        {
-            if (otp3.Text.Length > 0)
-            {
-                otp4.Focus();
-            }
-        }
-
-        private void otp4_PreviewKeyUp(object sender, KeyEventArgs e)
-        {
-            if (otp4.Text.Length > 0)
-            {
-                otp5.Focus();
-            }
-        }
-
-        private void otp5_PreviewKeyUp(object sender, KeyEventArgs e)
-        {
-            if (otp5.Text.Length > 0)
-            {
-                otp6.Focus();
-            }
-        }
-
-        private void otp6_PreviewKeyUp(object sender, KeyEventArgs e)
-        {
             if (
-                otp1.Text.Length > 0
-                && otp2.Text.Length > 0
-                && otp3.Text.Length > 0
-                && otp4.Text.Length > 0
-                && otp5.Text.Length > 0
-                && otp6.Text.Length > 0
+                e.Key == Key.V
+                && (Keyboard.Modifiers & ModifierKeys.Control) == ModifierKeys.Control
             )
             {
-                btn_login.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+                e.Handled = true;
+                HandlePaste();
             }
+        }
+
+        private void HandlePaste()
+        {
+            string text = "";
+            try
+            {
+                text = Clipboard.GetText();
+            }
+            catch
+            {
+                return;
+            }
+            string digits = new string(text.Where(char.IsDigit).ToArray());
+            if (digits.Length == 0)
+                return;
+
+            _isPasting = true;
+            for (int i = 0; i < _otpBoxes.Length && i < digits.Length; i++)
+            {
+                _otpBoxes[i].Text = digits[i].ToString();
+            }
+            _isPasting = false;
+
+            int focusIndex = System.Math.Min(digits.Length, _otpBoxes.Length - 1);
+            _otpBoxes[focusIndex].Focus();
+
+            TryAutoSubmit();
+        }
+
+        private void otp_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            if (_isPasting)
+                return;
+
+            var box = sender as TextBox;
+            int index = System.Array.IndexOf(_otpBoxes, box);
+
+            // Filter non-digit
+            string digits = new string(box.Text.Where(char.IsDigit).ToArray());
+            if (digits != box.Text)
+            {
+                box.Text = digits;
+                box.CaretIndex = digits.Length;
+                return;
+            }
+
+            if (box.Text.Length == 1 && index < _otpBoxes.Length - 1)
+            {
+                _otpBoxes[index + 1].Focus();
+            }
+
+            TryAutoSubmit();
         }
 
         private void otp_GotFocus(object sender, RoutedEventArgs e)
         {
             TextBox box = sender as TextBox;
             box.SelectAll();
+        }
+
+        private void TryAutoSubmit()
+        {
+            if (btn_login.IsEnabled && _otpBoxes.All(b => b.Text.Length == 1))
+            {
+                btn_login.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+            }
         }
     }
 }

--- a/Beanfun/Pages/LoginTotp.xaml.cs
+++ b/Beanfun/Pages/LoginTotp.xaml.cs
@@ -5,6 +5,9 @@ using System.Windows.Input;
 
 namespace Beanfun
 {
+    /// <summary>
+    /// LoginTotp.xaml 的交互逻辑
+    /// </summary>
     public partial class LoginTotp : Page
     {
         private TextBox[] _otpBoxes;

--- a/Beanfun/Pages/qr_form.xaml
+++ b/Beanfun/Pages/qr_form.xaml
@@ -232,5 +232,21 @@
       </StackPanel>
       <Grid MinWidth="{Binding MinWidth, ElementName=SideBarLeft}" />
     </DockPanel>
+    <Border
+      x:Name="toastBorder"
+      Background="#CC333333"
+      CornerRadius="6"
+      Padding="14 8"
+      HorizontalAlignment="Center"
+      VerticalAlignment="Bottom"
+      Margin="0 0 0 30"
+      Visibility="Collapsed"
+    >
+      <TextBlock
+        x:Name="toastText"
+        Foreground="White"
+        FontSize="13"
+      />
+    </Border>
   </Grid>
 </Page>

--- a/Beanfun/Pages/qr_form.xaml
+++ b/Beanfun/Pages/qr_form.xaml
@@ -107,6 +107,88 @@
             </Button>
           </DockPanel>
         </TextBlock>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0 5 0 0">
+          <Button
+            x:Name="btn_CopyQR"
+            Width="20"
+            Height="20"
+            Margin="5 0"
+            Cursor="Hand"
+            ToolTip="{DynamicResource CopyQRCode}"
+            Click="CopyQRCode_Click"
+          >
+            <Button.Resources>
+              <Style TargetType="{x:Type Button}">
+                <Setter Property="Padding" Value="0" />
+                <Setter Property="BorderThickness" Value="0" />
+                <Setter Property="Background" Value="Transparent" />
+                <Setter Property="BorderBrush" Value="{x:Null}" />
+                <Setter Property="Template">
+                  <Setter.Value>
+                    <ControlTemplate TargetType="{x:Type Button}">
+                      <TextBlock>
+                        <Path
+                          x:Name="Path"
+                          Fill="#848484"
+                          Stretch="Uniform"
+                          Data="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                        />
+                      </TextBlock>
+                      <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                          <Setter TargetName="Path" Property="Fill" Value="#484848" />
+                        </Trigger>
+                        <Trigger Property="IsPressed" Value="True">
+                          <Setter TargetName="Path" Property="Fill" Value="#3AC3F7" />
+                        </Trigger>
+                      </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                  </Setter.Value>
+                </Setter>
+              </Style>
+            </Button.Resources>
+          </Button>
+          <Button
+            x:Name="btn_EnlargeQR"
+            Width="20"
+            Height="20"
+            Margin="5 0"
+            Cursor="Hand"
+            ToolTip="{DynamicResource EnlargeQRCode}"
+            Click="EnlargeQRCode_Click"
+          >
+            <Button.Resources>
+              <Style TargetType="{x:Type Button}">
+                <Setter Property="Padding" Value="0" />
+                <Setter Property="BorderThickness" Value="0" />
+                <Setter Property="Background" Value="Transparent" />
+                <Setter Property="BorderBrush" Value="{x:Null}" />
+                <Setter Property="Template">
+                  <Setter.Value>
+                    <ControlTemplate TargetType="{x:Type Button}">
+                      <TextBlock>
+                        <Path
+                          x:Name="Path"
+                          Fill="#848484"
+                          Stretch="Uniform"
+                          Data="M15 3l2.3 2.3-2.89 2.87 1.42 1.42L18.7 6.7 21 9V3h-6zM3 9l2.3-2.3 2.87 2.89 1.42-1.42L6.7 5.3 9 3H3v6zm6 12l-2.3-2.3 2.89-2.87-1.42-1.42L5.3 17.3 3 15v6h6zm12-6l-2.3 2.3-2.87-2.89-1.42 1.42 2.89 2.87L15 21h6v-6z"
+                        />
+                      </TextBlock>
+                      <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                          <Setter TargetName="Path" Property="Fill" Value="#484848" />
+                        </Trigger>
+                        <Trigger Property="IsPressed" Value="True">
+                          <Setter TargetName="Path" Property="Fill" Value="#3AC3F7" />
+                        </Trigger>
+                      </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                  </Setter.Value>
+                </Setter>
+              </Style>
+            </Button.Resources>
+          </Button>
+        </StackPanel>
         <Button
           x:Name="btn_CopyDeeplink"
           Content="{DynamicResource CopyDeeplink}"

--- a/Beanfun/Pages/qr_form.xaml
+++ b/Beanfun/Pages/qr_form.xaml
@@ -107,6 +107,88 @@
             </Button>
           </DockPanel>
         </TextBlock>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0 5 0 0">
+          <Button
+            x:Name="btn_CopyQR"
+            Width="20"
+            Height="20"
+            Margin="5 0"
+            Cursor="Hand"
+            ToolTip="{DynamicResource CopyQRCode}"
+            Click="CopyQRCode_Click"
+          >
+            <Button.Resources>
+              <Style TargetType="{x:Type Button}">
+                <Setter Property="Padding" Value="0" />
+                <Setter Property="BorderThickness" Value="0" />
+                <Setter Property="Background" Value="Transparent" />
+                <Setter Property="BorderBrush" Value="{x:Null}" />
+                <Setter Property="Template">
+                  <Setter.Value>
+                    <ControlTemplate TargetType="{x:Type Button}">
+                      <TextBlock>
+                        <Path
+                          x:Name="Path"
+                          Fill="#848484"
+                          Stretch="Uniform"
+                          Data="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                        />
+                      </TextBlock>
+                      <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                          <Setter TargetName="Path" Property="Fill" Value="#484848" />
+                        </Trigger>
+                        <Trigger Property="IsPressed" Value="True">
+                          <Setter TargetName="Path" Property="Fill" Value="#3AC3F7" />
+                        </Trigger>
+                      </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                  </Setter.Value>
+                </Setter>
+              </Style>
+            </Button.Resources>
+          </Button>
+          <Button
+            x:Name="btn_EnlargeQR"
+            Width="20"
+            Height="20"
+            Margin="5 0"
+            Cursor="Hand"
+            ToolTip="{DynamicResource EnlargeQRCode}"
+            Click="EnlargeQRCode_Click"
+          >
+            <Button.Resources>
+              <Style TargetType="{x:Type Button}">
+                <Setter Property="Padding" Value="0" />
+                <Setter Property="BorderThickness" Value="0" />
+                <Setter Property="Background" Value="Transparent" />
+                <Setter Property="BorderBrush" Value="{x:Null}" />
+                <Setter Property="Template">
+                  <Setter.Value>
+                    <ControlTemplate TargetType="{x:Type Button}">
+                      <TextBlock>
+                        <Path
+                          x:Name="Path"
+                          Fill="#848484"
+                          Stretch="Uniform"
+                          Data="M15 3l2.3 2.3-2.89 2.87 1.42 1.42L18.7 6.7 21 9V3h-6zM3 9l2.3-2.3 2.87 2.89 1.42-1.42L6.7 5.3 9 3H3v6zm6 12l-2.3-2.3 2.89-2.87-1.42-1.42L5.3 17.3 3 15v6h6zm12-6l-2.3 2.3-2.87-2.89-1.42 1.42 2.89 2.87L15 21h6v-6z"
+                        />
+                      </TextBlock>
+                      <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                          <Setter TargetName="Path" Property="Fill" Value="#484848" />
+                        </Trigger>
+                        <Trigger Property="IsPressed" Value="True">
+                          <Setter TargetName="Path" Property="Fill" Value="#3AC3F7" />
+                        </Trigger>
+                      </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                  </Setter.Value>
+                </Setter>
+              </Style>
+            </Button.Resources>
+          </Button>
+        </StackPanel>
         <Button
           x:Name="btn_CopyDeeplink"
           Content="{DynamicResource CopyDeeplink}"
@@ -150,5 +232,18 @@
       </StackPanel>
       <Grid MinWidth="{Binding MinWidth, ElementName=SideBarLeft}" />
     </DockPanel>
+    <Border
+      x:Name="toastBorder"
+      Background="#CC333333"
+      CornerRadius="6"
+      Padding="14 8"
+      HorizontalAlignment="Center"
+      VerticalAlignment="Bottom"
+      Margin="0 0 0 30"
+      Visibility="Collapsed"
+      Panel.ZIndex="999"
+    >
+      <TextBlock x:Name="toastText" Foreground="White" FontSize="13" />
+    </Border>
   </Grid>
 </Page>

--- a/Beanfun/Pages/qr_form.xaml
+++ b/Beanfun/Pages/qr_form.xaml
@@ -242,11 +242,7 @@
       Margin="0 0 0 30"
       Visibility="Collapsed"
     >
-      <TextBlock
-        x:Name="toastText"
-        Foreground="White"
-        FontSize="13"
-      />
+      <TextBlock x:Name="toastText" Foreground="White" FontSize="13" />
     </Border>
   </Grid>
 </Page>

--- a/Beanfun/Pages/qr_form.xaml
+++ b/Beanfun/Pages/qr_form.xaml
@@ -238,14 +238,12 @@
       x:Name="toastBorder"
       Background="#CC333333"
       CornerRadius="6"
-      Padding="14 8"
       HorizontalAlignment="Center"
       VerticalAlignment="Bottom"
       Margin="0 0 0 30"
       Visibility="Collapsed"
-      Panel.ZIndex="999"
     >
-      <TextBlock x:Name="toastText" Foreground="White" FontSize="13" />
+      <TextBlock x:Name="toastText" Foreground="White" FontSize="13" Margin="14 8" />
     </Border>
   </Grid>
 </Page>

--- a/Beanfun/Pages/qr_form.xaml.cs
+++ b/Beanfun/Pages/qr_form.xaml.cs
@@ -92,32 +92,26 @@ namespace Beanfun
         {
             if (qr_image.Source is BitmapSource bmp)
             {
+                bool ok = false;
                 try
                 {
                     var encoder = new PngBitmapEncoder();
                     encoder.Frames.Add(BitmapFrame.Create(bmp));
-                    var stream = new System.IO.MemoryStream();
-                    encoder.Save(stream);
-
-                    var data = new DataObject();
-                    data.SetData("PNG", stream);
-                    stream.Position = 0;
-                    data.SetData(DataFormats.Bitmap, bmp);
-                    Clipboard.SetDataObject(data, true);
-
-                    ShowToast(
-                        Application.Current.TryFindResource("CopyQRCodeSuccess") as string
-                            ?? "QR Code copied!"
-                    );
+                    using (var stream = new System.IO.MemoryStream())
+                    {
+                        encoder.Save(stream);
+                        stream.Position = 0;
+                        var bitmap = new System.Drawing.Bitmap(stream);
+                        System.Windows.Forms.Clipboard.SetImage(bitmap);
+                        ok = true;
+                    }
                 }
-                catch
-                {
-                    ShowToast(
-                        Application.Current.TryFindResource("CopyFailed") as string
-                            ?? "Copy failed",
-                        false
-                    );
-                }
+                catch { }
+                ShowToast(
+                    Application.Current.TryFindResource(ok ? "CopyQRCodeSuccess" : "CopyFailed")
+                        as string ?? (ok ? "QR Code copied!" : "Copy failed"),
+                    ok
+                );
             }
         }
 

--- a/Beanfun/Pages/qr_form.xaml.cs
+++ b/Beanfun/Pages/qr_form.xaml.cs
@@ -109,7 +109,8 @@ namespace Beanfun
                 catch { }
                 ShowToast(
                     Application.Current.TryFindResource(ok ? "CopyQRCodeSuccess" : "CopyFailed")
-                        as string ?? (ok ? "QR Code copied!" : "Copy failed"),
+                        as string
+                        ?? (ok ? "QR Code copied!" : "Copy failed"),
                     ok
                 );
             }

--- a/Beanfun/Pages/qr_form.xaml.cs
+++ b/Beanfun/Pages/qr_form.xaml.cs
@@ -1,7 +1,9 @@
+using System;
 using System.Diagnostics;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using System.Windows.Media.Imaging;
 
 namespace Beanfun
 {
@@ -84,6 +86,87 @@ namespace Beanfun
         private void btn_StartGame_Click(object sender, RoutedEventArgs e)
         {
             App.MainWnd.runGame();
+        }
+
+        private void CopyQRCode_Click(object sender, RoutedEventArgs e)
+        {
+            if (qr_image.Source is BitmapSource bmp)
+            {
+                try
+                {
+                    var encoder = new PngBitmapEncoder();
+                    encoder.Frames.Add(BitmapFrame.Create(bmp));
+                    using (var stream = new System.IO.MemoryStream())
+                    {
+                        encoder.Save(stream);
+                        stream.Position = 0;
+                        var bitmap = new System.Drawing.Bitmap(stream);
+                        System.Windows.Forms.Clipboard.SetImage(bitmap);
+                    }
+                    ShowToast(
+                        Application.Current.TryFindResource("CopyQRCodeSuccess") as string
+                            ?? "QR Code copied!"
+                    );
+                }
+                catch
+                {
+                    ShowToast(
+                        Application.Current.TryFindResource("CopyFailed") as string ?? "Copy failed"
+                    );
+                }
+            }
+        }
+
+        private Window _enlargeWnd;
+
+        public void CloseEnlargeWindow()
+        {
+            if (_enlargeWnd != null)
+            {
+                _enlargeWnd.Close();
+                _enlargeWnd = null;
+            }
+        }
+
+        private void EnlargeQRCode_Click(object sender, RoutedEventArgs e)
+        {
+            if (qr_image.Source == null)
+                return;
+
+            CloseEnlargeWindow();
+
+            _enlargeWnd = new Window
+            {
+                Title = "QR Code",
+                Width = 350,
+                Height = 350,
+                WindowStartupLocation = WindowStartupLocation.CenterOwner,
+                Owner = Window.GetWindow(this),
+                ResizeMode = ResizeMode.CanResize,
+                Content = new Image
+                {
+                    Source = qr_image.Source,
+                    Stretch = System.Windows.Media.Stretch.Uniform,
+                },
+            };
+            _enlargeWnd.Closed += (s, _) => _enlargeWnd = null;
+            _enlargeWnd.Show();
+        }
+
+        private void ShowToast(string message)
+        {
+            toastText.Text = message;
+            toastBorder.Visibility = Visibility.Visible;
+            var timer = new System.Windows.Threading.DispatcherTimer
+            {
+                Interval = TimeSpan.FromSeconds(2),
+            };
+            timer.Tick += (s, _) =>
+            {
+                timer.Stop();
+                toastBorder.Visibility = Visibility.Collapsed;
+            };
+            timer.Start();
         }
     }
 }

--- a/Beanfun/Pages/qr_form.xaml.cs
+++ b/Beanfun/Pages/qr_form.xaml.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using System.Windows.Media.Imaging;
 
 namespace Beanfun
 {
@@ -84,6 +85,40 @@ namespace Beanfun
         private void btn_StartGame_Click(object sender, RoutedEventArgs e)
         {
             App.MainWnd.runGame();
+        }
+
+        private void CopyQRCode_Click(object sender, RoutedEventArgs e)
+        {
+            if (qr_image.Source is BitmapSource bmp)
+            {
+                try
+                {
+                    Clipboard.SetImage(bmp);
+                }
+                catch { }
+            }
+        }
+
+        private void EnlargeQRCode_Click(object sender, RoutedEventArgs e)
+        {
+            if (qr_image.Source == null)
+                return;
+
+            var wnd = new Window
+            {
+                Title = "QR Code",
+                SizeToContent = SizeToContent.WidthAndHeight,
+                WindowStartupLocation = WindowStartupLocation.CenterOwner,
+                Owner = Window.GetWindow(this),
+                ResizeMode = ResizeMode.NoResize,
+                Content = new Image
+                {
+                    Source = qr_image.Source,
+                    Width = 300,
+                    Height = 300,
+                },
+            };
+            wnd.ShowDialog();
         }
     }
 }

--- a/Beanfun/Pages/qr_form.xaml.cs
+++ b/Beanfun/Pages/qr_form.xaml.cs
@@ -59,7 +59,7 @@ namespace Beanfun
             {
                 try
                 {
-                    Clipboard.SetText(qrcodeClass.deeplink);
+                    WindowsAPI.CopyText(qrcodeClass.deeplink);
                     MessageBox.Show(
                         Application.Current.TryFindResource("CopyDeeplinkSuccess") as string
                     );
@@ -96,13 +96,15 @@ namespace Beanfun
                 {
                     var encoder = new PngBitmapEncoder();
                     encoder.Frames.Add(BitmapFrame.Create(bmp));
-                    using (var stream = new System.IO.MemoryStream())
-                    {
-                        encoder.Save(stream);
-                        stream.Position = 0;
-                        var bitmap = new System.Drawing.Bitmap(stream);
-                        System.Windows.Forms.Clipboard.SetImage(bitmap);
-                    }
+                    var stream = new System.IO.MemoryStream();
+                    encoder.Save(stream);
+
+                    var data = new DataObject();
+                    data.SetData("PNG", stream);
+                    stream.Position = 0;
+                    data.SetData(DataFormats.Bitmap, bmp);
+                    Clipboard.SetDataObject(data, true);
+
                     ShowToast(
                         Application.Current.TryFindResource("CopyQRCodeSuccess") as string
                             ?? "QR Code copied!"
@@ -111,7 +113,9 @@ namespace Beanfun
                 catch
                 {
                     ShowToast(
-                        Application.Current.TryFindResource("CopyFailed") as string ?? "Copy failed"
+                        Application.Current.TryFindResource("CopyFailed") as string
+                            ?? "Copy failed",
+                        false
                     );
                 }
             }
@@ -153,9 +157,15 @@ namespace Beanfun
             _enlargeWnd.Show();
         }
 
-        private void ShowToast(string message)
+        private void ShowToast(string message, bool success = true)
         {
-            toastText.Text = message;
+            toastText.Text = (success ? "✓ " : "") + message;
+            toastBorder.Background = new System.Windows.Media.SolidColorBrush(
+                (System.Windows.Media.Color)
+                    System.Windows.Media.ColorConverter.ConvertFromString(
+                        success ? "#CC2E7D32" : "#CC333333"
+                    )
+            );
             toastBorder.Visibility = Visibility.Visible;
             var timer = new System.Windows.Threading.DispatcherTimer
             {

--- a/Beanfun/Pages/qr_form.xaml.cs
+++ b/Beanfun/Pages/qr_form.xaml.cs
@@ -94,8 +94,23 @@ namespace Beanfun
                 try
                 {
                     Clipboard.SetImage(bmp);
+                    ShowToast(
+                        Application.Current.TryFindResource("CopyQRCodeSuccess") as string
+                            ?? "QR Code copied!"
+                    );
                 }
                 catch { }
+            }
+        }
+
+        private Window _enlargeWnd;
+
+        public void CloseEnlargeWindow()
+        {
+            if (_enlargeWnd != null)
+            {
+                _enlargeWnd.Close();
+                _enlargeWnd = null;
             }
         }
 
@@ -104,21 +119,40 @@ namespace Beanfun
             if (qr_image.Source == null)
                 return;
 
-            var wnd = new Window
+            CloseEnlargeWindow();
+
+            _enlargeWnd = new Window
             {
                 Title = "QR Code",
-                SizeToContent = SizeToContent.WidthAndHeight,
+                Width = 350,
+                Height = 350,
                 WindowStartupLocation = WindowStartupLocation.CenterOwner,
                 Owner = Window.GetWindow(this),
-                ResizeMode = ResizeMode.NoResize,
+                ResizeMode = ResizeMode.CanResize,
                 Content = new Image
                 {
                     Source = qr_image.Source,
-                    Width = 300,
-                    Height = 300,
+                    Stretch = System.Windows.Media.Stretch.Uniform,
                 },
             };
-            wnd.ShowDialog();
+            _enlargeWnd.Closed += (s, _) => _enlargeWnd = null;
+            _enlargeWnd.Show();
+        }
+
+        private void ShowToast(string message)
+        {
+            toastText.Text = message;
+            toastBorder.Visibility = Visibility.Visible;
+            var timer = new System.Windows.Threading.DispatcherTimer
+            {
+                Interval = TimeSpan.FromSeconds(2),
+            };
+            timer.Tick += (s, _) =>
+            {
+                timer.Stop();
+                toastBorder.Visibility = Visibility.Collapsed;
+            };
+            timer.Start();
         }
     }
 }

--- a/Beanfun/Windows/CopyBox.xaml.cs
+++ b/Beanfun/Windows/CopyBox.xaml.cs
@@ -24,7 +24,7 @@ namespace Beanfun
         {
             try
             {
-                Clipboard.SetText(t_Value.Text);
+                WindowsAPI.CopyText(t_Value.Text);
                 MessageBox.Show(TryFindResource("CopyFinished") as string);
             }
             catch


### PR DESCRIPTION
## 修復內容

### 1. OTP 密碼複製提示改為 toast（不再彈窗）#214
- 原本每次獲取密碼成功都會彈出 MessageBox 阻塞操作
- 改為頁面底部的深色半透明 toast 提示，2 秒後自動消失
- 不影響任何佈局，不需要手動關閉

### 2. 遊戲資訊載入改為非同步（修復啟動卡死）
- `reLoadGameInfo` 原本在 UI 線程上同步呼叫 `WebClient.DownloadData` 連接 beanfun.com
- 網路慢或被牆時會導致整個 app 卡死無法操作
- 改為背景線程執行網路請求，完成後透過 `Dispatcher.Invoke` 更新 UI

### 3. QR Code 頁面新增複製/放大 icon 按鈕 #215 
- 複製按鈕：將 QR Code 圖片複製到剪貼簿
- 放大按鈕：在 300×300 彈窗中顯示 QR Code
- 使用 SVG Path icon，hover/press 顏色效果與 codebase 一致
- 新增 i18n key：CopyQRCode、EnlargeQRCode（繁中/簡中/英文）
