### PR TITLE
feat: custom titlebar + glass-panel-as-window shell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ sync-upstream.ps1
 
 # Project-local task list (Cursor AI)
 Todo.md
+
+#project template
+mockups/

--- a/index.html
+++ b/index.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200"
+      rel="stylesheet"
+    />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Tauri + Vue + Typescript App</title>
   </head>

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -330,7 +330,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "beanfun"
-version = "6.0.0"
+version = "5.9.1"
 dependencies = [
  "aes",
  "anyhow",

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -3,5 +3,13 @@
   "identifier": "default",
   "description": "Capability for the main window",
   "windows": ["main"],
-  "permissions": ["core:default", "opener:default", "dialog:default"]
+  "permissions": [
+    "core:default",
+    "core:window:allow-minimize",
+    "core:window:allow-close",
+    "core:window:allow-start-dragging",
+    "core:window:allow-set-size",
+    "opener:default",
+    "dialog:default"
+  ]
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -13,8 +13,11 @@
     "windows": [
       {
         "title": "Beanfun",
-        "width": 720,
-        "height": 720
+        "width": 560,
+        "height": 480,
+        "decorations": false,
+        "transparent": true,
+        "resizable": false
       }
     ],
     "security": {

--- a/src/App.vue
+++ b/src/App.vue
@@ -116,7 +116,7 @@ onMounted(async () => {
   font-size: 14px;
   line-height: 1.5;
   color: #1f2329;
-  background-color: #f5f6f8;
+  background-color: transparent;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -132,5 +132,82 @@ body,
   padding: 0;
   height: 100%;
   width: 100%;
+  overflow: hidden;
+  background: transparent;
+}
+
+/* ---- Native app feel: no text selection, no right-click menu ---- */
+body {
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+/* Allow selection inside actual input / textarea elements */
+input,
+textarea,
+[contenteditable='true'] {
+  -webkit-user-select: text;
+  user-select: text;
+}
+
+/* ---- Scrollbar — thin, rounded, matches mockup design system ---- */
+::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+::-webkit-scrollbar-thumb {
+  background-color: rgba(0, 0, 0, 0.15);
+  border-radius: 3px;
+}
+::-webkit-scrollbar-thumb:hover {
+  background-color: rgba(0, 0, 0, 0.3);
+}
+
+/* ---- Element Plus MessageBox — glass-style override ---- */
+.el-overlay {
+  background: rgba(0, 0, 0, 0.35) !important;
+  backdrop-filter: blur(4px);
+}
+
+.el-message-box {
+  border-radius: var(--bf-radius-panel, 12px) !important;
+  border: 1px solid rgba(255, 255, 255, 0.6) !important;
+  box-shadow:
+    0 20px 48px rgba(0, 0, 0, 0.18),
+    0 4px 12px rgba(0, 0, 0, 0.1) !important;
+  padding: 1.25rem !important;
+}
+
+.el-message-box__header {
+  padding: 0 0 0.75rem !important;
+}
+
+.el-message-box__title {
+  font-size: 1rem !important;
+  font-weight: 700 !important;
+}
+
+.el-message-box__content {
+  padding: 0 !important;
+  font-size: 0.875rem !important;
+}
+
+.el-message-box__btns {
+  padding: 1rem 0 0 !important;
+}
+
+.el-message-box__btns .el-button--primary {
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--bf-primary-container, #ff8201) 85%, white 15%),
+    color-mix(in srgb, var(--bf-primary, #954a00) 92%, black 8%)
+  ) !important;
+  border-color: color-mix(in srgb, var(--bf-primary, #954a00) 50%, transparent) !important;
+  color: var(--bf-on-primary, #fff) !important;
+  border-radius: var(--bf-radius-button, 8px) !important;
+  font-weight: 600 !important;
 }
 </style>

--- a/src/components/TitleBar.vue
+++ b/src/components/TitleBar.vue
@@ -1,0 +1,131 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useRoute } from 'vue-router'
+import { useI18n } from 'vue-i18n'
+import { getCurrentWindow } from '@tauri-apps/api/window'
+
+const route = useRoute()
+const { t } = useI18n()
+const appWindow = getCurrentWindow()
+
+const titleText = computed(() => {
+  const key = route.meta.titleKey as string | undefined
+  return key ? t(key) : t('AppName')
+})
+
+const titleIcon = computed(() => {
+  return (route.meta.titleIcon as string | undefined) ?? 'coffee'
+})
+
+function handleDrag(e: MouseEvent): void {
+  if (e.buttons === 1) {
+    e.preventDefault()
+    appWindow.startDragging()
+  }
+}
+
+function handleMinimize(): void {
+  appWindow.minimize()
+}
+
+function handleClose(): void {
+  appWindow.close()
+}
+</script>
+
+<template>
+  <div class="bf-titlebar" @mousedown="handleDrag">
+    <div class="bf-titlebar__left">
+      <span class="material-symbols-outlined bf-titlebar__icon">{{ titleIcon }}</span>
+      <span class="bf-titlebar__title">{{ titleText }}</span>
+    </div>
+    <div class="bf-titlebar__right">
+      <div v-if="$slots.default" class="bf-titlebar__actions" @mousedown.stop>
+        <slot />
+      </div>
+      <button
+        type="button"
+        class="bf-titlebar__btn"
+        :title="t('titleBar.minimize')"
+        @mousedown.stop
+        @click="handleMinimize"
+      >
+        <span class="material-symbols-outlined">minimize</span>
+      </button>
+      <button
+        type="button"
+        class="bf-titlebar__btn bf-titlebar__btn--close"
+        :title="t('titleBar.close')"
+        @mousedown.stop
+        @click="handleClose"
+      >
+        <span class="material-symbols-outlined">close</span>
+      </button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.bf-titlebar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 40px;
+  padding: 0 0.375rem 0 1rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.4);
+  user-select: none;
+  cursor: default;
+  flex-shrink: 0;
+}
+.bf-titlebar__left {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  pointer-events: none;
+}
+.bf-titlebar__icon {
+  font-size: 20px;
+  color: var(--bf-primary-container, #ff8201);
+}
+.bf-titlebar__title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--bf-on-surface, #221a11);
+}
+.bf-titlebar__right {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+.bf-titlebar__actions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  margin-right: 4px;
+}
+.bf-titlebar__btn {
+  appearance: none;
+  background: transparent;
+  border: none;
+  width: 32px;
+  height: 32px;
+  display: grid;
+  place-items: center;
+  border-radius: 6px;
+  cursor: pointer;
+  color: var(--bf-on-surface, #221a11);
+  transition: background 150ms ease;
+  font: inherit;
+  padding: 0;
+}
+.bf-titlebar__btn .material-symbols-outlined {
+  font-size: 18px;
+}
+.bf-titlebar__btn:hover {
+  background: rgba(0, 0, 0, 0.06);
+}
+.bf-titlebar__btn--close:hover {
+  background: rgba(220, 38, 38, 0.8);
+  color: #fff;
+}
+</style>

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -105,6 +105,7 @@ export function createAppI18n() {
     messages: i18nMessages,
     missingWarn: isDev,
     fallbackWarn: isDev,
+    warnHtmlMessage: false,
   })
 }
 

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -259,9 +259,18 @@ type KeysMatch<T, U> = keyof T extends keyof U ? (keyof U extends keyof T ? unkn
 /* -------- zh-TW (canonical / authoritative source) -------- */
 
 const zhTW = {
-  loginShell: {
-    heading: '繽放',
-    subline: '歡迎登入',
+  titleBar: {
+    minimize: '最小化',
+    close: '關閉',
+    regionSelection: '選擇登入地區',
+    login: '登入',
+    totp: '雙重驗證',
+    loginWait: '登入中',
+    verify: '進階驗證',
+    accounts: '遊戲帳號',
+    settings: '設定',
+    about: '關於 beanfun! Next',
+    manageAccount: '管理帳號',
   },
   loginRegion: {
     subline: '請選擇您要登入的 Beanfun 服務地區。',
@@ -274,6 +283,9 @@ const zhTW = {
     subtitle: '開啟 Beanfun 行動版 App 掃描下方 QR Code 即可登入。',
     unsupportedHK: 'QR 登入僅支援台灣區，已返回登入入口。',
     connectionLost: '無法取得登入狀態，請點選重新整理重試。',
+    enlarge: '放大',
+    copyQr: '複製 QR',
+    copyQrSuccess: 'QR Code 已複製到剪貼簿。',
   },
   loginTotp: {
     title: '雙重驗證',
@@ -300,8 +312,6 @@ const zhTW = {
     refresh: '重新整理',
   },
   accountList: {
-    title: '帳號清單',
-    subtitle: '選擇遊戲帳號以開始遊戲，或新增、管理帳號。',
     serviceAccountsHeading: '遊戲帳號',
     accountCount: '{count} 個帳號',
     loading: '載入中…',
@@ -459,9 +469,18 @@ const zhTW = {
 /* -------- zh-CN (Simplified) -------- */
 
 const zhCN = {
-  loginShell: {
-    heading: '缤放',
-    subline: '欢迎登录',
+  titleBar: {
+    minimize: '最小化',
+    close: '关闭',
+    regionSelection: '选择登录地区',
+    login: '登录',
+    totp: '双重验证',
+    loginWait: '登录中',
+    verify: '进阶验证',
+    accounts: '游戏帐号',
+    settings: '设置',
+    about: '关于 beanfun! Next',
+    manageAccount: '管理帐号',
   },
   loginRegion: {
     subline: '请选择您要登录的 Beanfun 服务地区。',
@@ -474,6 +493,9 @@ const zhCN = {
     subtitle: '打开 Beanfun 移动版 App 扫描下方 QR Code 即可登录。',
     unsupportedHK: 'QR 登录仅支持台湾区，已返回登录入口。',
     connectionLost: '无法获取登录状态，请点选重新加载重试。',
+    enlarge: '放大',
+    copyQr: '复制 QR',
+    copyQrSuccess: 'QR Code 已复制到剪贴板。',
   },
   loginTotp: {
     title: '双重验证',
@@ -500,8 +522,6 @@ const zhCN = {
     refresh: '重新加载',
   },
   accountList: {
-    title: '账号列表',
-    subtitle: '选择游戏账号以开始游戏，或新增、管理账号。',
     serviceAccountsHeading: '游戏账号',
     accountCount: '{count} 个账号',
     loading: '加载中…',
@@ -659,9 +679,18 @@ const zhCN = {
 /* -------- en-US -------- */
 
 const enUS = {
-  loginShell: {
-    heading: 'Beanfun',
-    subline: 'Welcome — please sign in',
+  titleBar: {
+    minimize: 'Minimize',
+    close: 'Close',
+    regionSelection: 'Select Region',
+    login: 'Sign In',
+    totp: 'Two-Factor Auth',
+    loginWait: 'Signing In',
+    verify: 'Verification',
+    accounts: 'Game Accounts',
+    settings: 'Settings',
+    about: 'About beanfun! Next',
+    manageAccount: 'Manage Accounts',
   },
   loginRegion: {
     subline: 'Pick the beanfun! region you want to sign in to.',
@@ -674,6 +703,9 @@ const enUS = {
     subtitle: 'Open the beanfun! mobile app and scan the QR code below to sign in.',
     unsupportedHK: 'QR login is only available in Taiwan; redirected back to the login entry.',
     connectionLost: 'Unable to reach the login service. Please tap Reload and try again.',
+    enlarge: 'Enlarge',
+    copyQr: 'Copy QR',
+    copyQrSuccess: 'QR code copied to clipboard.',
   },
   loginTotp: {
     title: 'Two-factor authentication',
@@ -702,8 +734,6 @@ const enUS = {
     refresh: 'Reload',
   },
   accountList: {
-    title: 'Accounts',
-    subtitle: 'Pick a game account to start playing, or add and manage accounts.',
     serviceAccountsHeading: 'Game Accounts',
     accountCount: '{count} accounts',
     loading: 'Loading…',

--- a/src/main.ts
+++ b/src/main.ts
@@ -109,3 +109,10 @@ installRouterGuards(router, {
 })
 
 app.mount('#app')
+
+/*
+ * Disable the browser right-click context menu so the app feels
+ * native. Input elements are excluded via CSS `user-select: text`
+ * so copy/paste still works in form fields.
+ */
+document.addEventListener('contextmenu', (e) => e.preventDefault())

--- a/src/pages/About.vue
+++ b/src/pages/About.vue
@@ -65,6 +65,7 @@ import { useUiStore } from '../stores/ui'
 import { commands } from '../types/bindings'
 import { safeInvoke } from '../services/invoke'
 import iconUrl from '../assets/icon.png'
+import TitleBar from '../components/TitleBar.vue'
 
 defineOptions({ name: 'AboutPage' })
 
@@ -254,102 +255,122 @@ onMounted(() => {
 </script>
 
 <template>
-  <main class="about bf-mica-bg">
-    <div class="about__container">
-      <!-- Header: app icon + name + author -->
-      <header class="about__header bf-glass-panel">
-        <img
-          :src="iconUrl"
-          alt="Beanfun"
-          class="about__icon"
-          width="56"
-          height="56"
-          data-test="about-icon"
-        />
-        <div class="about__header-text">
-          <div class="about__title-row">
-            <h1 class="about__title bf-text-gradient">{{ t('AppName') }}</h1>
-            <span class="about__author">By Pungin and YCC3741</span>
+  <main class="about bf-glass-panel" data-window-root>
+    <TitleBar />
+    <div class="about__scroll">
+      <div class="about__container">
+        <!-- Header: app icon + name + author -->
+        <header class="about__header bf-glass-panel">
+          <img
+            :src="iconUrl"
+            alt="Beanfun"
+            class="about__icon"
+            width="56"
+            height="56"
+            data-test="about-icon"
+          />
+          <div class="about__header-text">
+            <div class="about__title-row">
+              <h1 class="about__title bf-text-gradient">{{ t('AppName') }}</h1>
+              <span class="about__author">By Pungin and YCC3741</span>
+            </div>
+            <p class="about__version-row" data-test="about-version-row">
+              <span>{{ t('Version') }}</span>
+              <span class="about__version-value" data-test="about-version-value">
+                {{ versionString }}
+              </span>
+              <a
+                href="#"
+                class="about__check-update"
+                :class="{ 'about__check-update--disabled': checkingUpdate }"
+                data-test="about-check-update"
+                @click.prevent="handleCheckUpdate"
+              >
+                {{ t('CheckUpdate') }}
+              </a>
+            </p>
           </div>
-          <p class="about__version-row" data-test="about-version-row">
-            <span>{{ t('Version') }}</span>
-            <span class="about__version-value" data-test="about-version-value">
-              {{ versionString }}
-            </span>
-            <a
-              href="#"
-              class="about__check-update"
-              :class="{ 'about__check-update--disabled': checkingUpdate }"
-              data-test="about-check-update"
-              @click.prevent="handleCheckUpdate"
-            >
-              {{ t('CheckUpdate') }}
-            </a>
-          </p>
-        </div>
-      </header>
+        </header>
 
-      <!-- Body: about text + contact + footer -->
-      <section class="about__body bf-glass-panel">
-        <p class="about__text" data-test="about-text">{{ aboutTextPlain }}</p>
+        <!-- Body: about text + contact + footer -->
+        <section class="about__body bf-glass-panel">
+          <p class="about__text" data-test="about-text">{{ aboutTextPlain }}</p>
 
-        <div class="about__separator" />
+          <div class="about__separator" />
 
-        <div class="about__contact" data-test="about-contact">
-          <span class="about__contact-label">{{ t('Contact') }}</span>
-          <div class="about__contact-col">
-            <a
-              href="#"
-              class="about__contact-link"
-              data-test="about-email-pungin"
-              @click.prevent="handleEmail('pungin@msn.com')"
-            >
-              <el-icon><Message /></el-icon>
-              <span>Pungin</span>
-            </a>
-            <a
-              href="#"
-              class="about__contact-link"
-              data-test="about-email-ycc3741"
-              @click.prevent="handleEmail('mo0307b1006@gmail.com')"
-            >
-              <el-icon><Message /></el-icon>
-              <span>YCC3741</span>
-            </a>
-            <a
-              href="#"
-              class="about__contact-link"
-              data-test="about-github"
-              @click.prevent="handleGithub"
-            >
-              <el-icon><InfoFilled /></el-icon>
-              <span>Github</span>
-            </a>
+          <div class="about__contact" data-test="about-contact">
+            <span class="about__contact-label">{{ t('Contact') }}</span>
+            <div class="about__contact-col">
+              <a
+                href="#"
+                class="about__contact-link"
+                data-test="about-email-pungin"
+                @click.prevent="handleEmail('pungin@msn.com')"
+              >
+                <el-icon><Message /></el-icon>
+                <span>Pungin</span>
+              </a>
+              <a
+                href="#"
+                class="about__contact-link"
+                data-test="about-email-ycc3741"
+                @click.prevent="handleEmail('mo0307b1006@gmail.com')"
+              >
+                <el-icon><Message /></el-icon>
+                <span>YCC3741</span>
+              </a>
+              <a
+                href="#"
+                class="about__contact-link"
+                data-test="about-github"
+                @click.prevent="handleGithub"
+              >
+                <el-icon><InfoFilled /></el-icon>
+                <span>Github</span>
+              </a>
+            </div>
           </div>
-        </div>
 
-        <footer class="about__footer">
-          <el-button
-            class="bf-btn-secondary about__back-btn"
-            data-test="about-back"
-            @click="handleBack"
-          >
-            <el-icon><ArrowLeft /></el-icon>
-            <span>{{ t('Back') }}</span>
-          </el-button>
-        </footer>
-      </section>
+          <footer class="about__footer">
+            <el-button
+              class="bf-btn-secondary about__back-btn"
+              data-test="about-back"
+              @click="handleBack"
+            >
+              <el-icon><ArrowLeft /></el-icon>
+              <span>{{ t('Back') }}</span>
+            </el-button>
+          </footer>
+        </section>
+      </div>
     </div>
   </main>
 </template>
 
 <style scoped>
 .about {
-  box-sizing: border-box;
-  min-height: 100vh;
-  padding: 2.5rem 1.5rem;
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  overflow: hidden;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.55) 0%, rgba(255, 255, 255, 0.45) 100%),
+    radial-gradient(
+      1200px 800px at 10% -10%,
+      color-mix(in srgb, var(--bf-primary-container) 30%, transparent) 0%,
+      transparent 60%
+    ),
+    radial-gradient(
+      900px 700px at 110% 110%,
+      color-mix(in srgb, var(--bf-primary) 22%, transparent) 0%,
+      transparent 55%
+    ),
+    linear-gradient(180deg, #f7f1ec 0%, #ece1d6 100%);
+}
+
+.about__scroll {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1.5rem;
 }
 
 .about__container {

--- a/src/pages/AccountList.vue
+++ b/src/pages/AccountList.vue
@@ -110,7 +110,6 @@ import {
   Plus,
   Refresh,
   Service,
-  Setting as SettingIcon,
   SwitchButton,
   User,
   VideoPlay,
@@ -139,6 +138,7 @@ import UnconnectedGameAddAccount from '../windows/UnconnectedGame_AddAccount.vue
 import UnconnectedGameChangePassword from '../windows/UnconnectedGame_ChangePassword.vue'
 import { TOOLS_GAME_CODES } from '../constants/tools'
 import { useGameLauncher } from '../composables/useGameLauncher'
+import TitleBar from '../components/TitleBar.vue'
 
 defineOptions({ name: 'AccountList' })
 
@@ -1753,49 +1753,35 @@ function handleDragEnd(): void {
 </script>
 
 <template>
-  <main class="account-list bf-mica-bg">
-    <div class="account-list__container">
-      <header class="account-list__header">
-        <div class="account-list__header-text">
-          <h1 class="account-list__title bf-text-gradient">{{ t('accountList.title') }}</h1>
-          <p class="account-list__subline">{{ t('accountList.subtitle') }}</p>
-        </div>
-        <!--
-          P12.4 D6: Settings + About entry buttons. Mirrors WPF
-          `MainWindow.xaml` titlebar L112-139 — both icons sit in the
-          window chrome alongside Logout / Min / Close. We reuse the
-          existing `bf-btn-ghost-icon` styling that the in-row Tools
-          + Logout buttons already use so the chrome stays visually
-          consistent across the page.
-        -->
-        <div class="account-list__header-actions">
-          <button
-            type="button"
-            class="bf-btn-ghost-icon account-list__icon-btn"
-            :title="t('Settings')"
-            data-test="account-list-settings"
-            @click="handleOpenSettings"
-          >
-            <el-icon><SettingIcon /></el-icon>
-          </button>
-          <button
-            type="button"
-            class="bf-btn-ghost-icon account-list__icon-btn"
-            :title="t('settings.aboutLink')"
-            data-test="account-list-about"
-            @click="handleOpenAbout"
-          >
-            <el-icon><InfoFilled /></el-icon>
-          </button>
-        </div>
-      </header>
-
-      <!-- Game info bar (D8d) — real game name + image + change-game button. -->
-      <section class="account-list__game bf-glass-panel">
-        <div class="account-list__game-row">
-          <div class="account-list__game-meta">
-            <div class="account-list__game-icon" aria-hidden="true">
-              <!--
+  <main class="account-list bf-glass-panel" data-window-root>
+    <TitleBar>
+      <button
+        type="button"
+        class="account-list__titlebar-btn"
+        :title="t('Settings')"
+        data-test="account-list-settings"
+        @click="handleOpenSettings"
+      >
+        <span class="material-symbols-outlined">settings</span>
+      </button>
+      <button
+        type="button"
+        class="account-list__titlebar-btn"
+        :title="t('settings.aboutLink')"
+        data-test="account-list-about"
+        @click="handleOpenAbout"
+      >
+        <span class="material-symbols-outlined">info</span>
+      </button>
+    </TitleBar>
+    <div class="account-list__scroll">
+      <div class="account-list__container">
+        <!-- Game info bar (D8d) — real game name + image + change-game button. -->
+        <section class="account-list__game bf-glass-panel">
+          <div class="account-list__game-row">
+            <div class="account-list__game-meta">
+              <div class="account-list__game-icon" aria-hidden="true">
+                <!--
                 D8d: prefer the per-game banner image when the catalogue
                 has hydrated; fall back to the generic VideoPlay glyph
                 so the layout doesn't collapse during the brief setup
@@ -1803,33 +1789,33 @@ function handleDragEnd(): void {
                 container size is fixed regardless so the row height
                 stays stable across the swap.
               -->
-              <img
-                v-if="gameImageUrl"
-                :src="gameImageUrl"
-                :alt="gameNameDisplay"
-                class="account-list__game-icon-img"
-                data-test="account-list-game-image"
-              />
-              <el-icon v-else :size="24"><VideoPlay /></el-icon>
+                <img
+                  v-if="gameImageUrl"
+                  :src="gameImageUrl"
+                  :alt="gameNameDisplay"
+                  class="account-list__game-icon-img"
+                  data-test="account-list-game-image"
+                />
+                <el-icon v-else :size="24"><VideoPlay /></el-icon>
+              </div>
+              <button
+                type="button"
+                class="account-list__game-info"
+                :title="t('accountList.changeGame')"
+                data-test="account-list-change-game"
+                @click="handleChangeGame"
+              >
+                <span class="account-list__game-name" data-test="account-list-game-name">
+                  {{ gameNameDisplay }}
+                </span>
+                <span class="account-list__game-status">
+                  <span class="account-list__game-status-dot" />
+                  {{ t('accountList.statusOnline') }}
+                </span>
+              </button>
             </div>
-            <button
-              type="button"
-              class="account-list__game-info"
-              :title="t('accountList.changeGame')"
-              data-test="account-list-change-game"
-              @click="handleChangeGame"
-            >
-              <span class="account-list__game-name" data-test="account-list-game-name">
-                {{ gameNameDisplay }}
-              </span>
-              <span class="account-list__game-status">
-                <span class="account-list__game-status-dot" />
-                {{ t('accountList.statusOnline') }}
-              </span>
-            </button>
-          </div>
-          <div class="account-list__game-actions">
-            <!--
+            <div class="account-list__game-actions">
+              <!--
               D8e: Tools button is only rendered for the three game
               codes WPF whitelisted (`610074_T9` / `610075_T9` /
               `610096_TE`). Hidden via `v-if` rather than `display:
@@ -1837,128 +1823,128 @@ function handleDragEnd(): void {
               that isn't reachable, and so the surrounding flex row
               tightens up cleanly when the button is absent.
             -->
-            <button
-              v-if="showToolsButton"
-              type="button"
-              class="bf-btn-ghost-icon account-list__icon-btn"
-              :title="t('accountList.toolsButton')"
-              data-test="account-list-tools"
-              @click="handleTools"
-            >
-              <el-icon><Operation /></el-icon>
-            </button>
-            <button
-              type="button"
-              class="bf-btn-ghost-icon account-list__icon-btn account-list__icon-btn--danger"
-              :title="t('Logout')"
-              data-test="account-list-logout"
-              @click="handleLogout"
-            >
-              <el-icon><SwitchButton /></el-icon>
-            </button>
-          </div>
-        </div>
-        <button
-          type="button"
-          class="bf-btn-gradient account-list__start-btn"
-          :disabled="startGameDisabled"
-          data-test="account-list-start"
-          @click="handleStartGame"
-        >
-          <el-icon><VideoPlay /></el-icon>
-          <span>{{ t('GameStart') }}</span>
-        </button>
-      </section>
-
-      <!-- Quick actions row: balance + member center + support (all stubs) -->
-      <section class="account-list__quick">
-        <div class="account-list__balance bf-glass-card bf-ghost-border">
-          <div class="account-list__balance-text">
-            <span class="account-list__balance-label">
-              {{ t('accountList.gashBalance') }}
-            </span>
-            <span class="account-list__balance-value" data-test="account-list-balance-value">
-              {{ formattedRemainPoint }}
-            </span>
+              <button
+                v-if="showToolsButton"
+                type="button"
+                class="bf-btn-ghost-icon account-list__icon-btn"
+                :title="t('accountList.toolsButton')"
+                data-test="account-list-tools"
+                @click="handleTools"
+              >
+                <el-icon><Operation /></el-icon>
+              </button>
+              <button
+                type="button"
+                class="bf-btn-ghost-icon account-list__icon-btn account-list__icon-btn--danger"
+                :title="t('Logout')"
+                data-test="account-list-logout"
+                @click="handleLogout"
+              >
+                <el-icon><SwitchButton /></el-icon>
+              </button>
+            </div>
           </div>
           <button
             type="button"
-            class="account-list__balance-refresh"
-            :class="{ 'account-list__balance-refresh--spinning': refreshing }"
-            :title="t('accountList.refreshBalance')"
-            :disabled="refreshing"
-            data-test="account-list-refresh-balance"
-            @click="handleRefreshBalance"
+            class="bf-btn-gradient account-list__start-btn"
+            :disabled="startGameDisabled"
+            data-test="account-list-start"
+            @click="handleStartGame"
           >
-            <el-icon><Refresh /></el-icon>
+            <el-icon><VideoPlay /></el-icon>
+            <span>{{ t('GameStart') }}</span>
           </button>
-        </div>
-        <button
-          type="button"
-          class="account-list__quick-link bf-glass-card bf-ghost-border"
-          data-test="account-list-member-center"
-          @click="handleMemberCenter"
-        >
-          <el-icon><User /></el-icon>
-          <span>{{ t('accountList.memberCenter') }}</span>
-        </button>
-        <button
-          type="button"
-          class="account-list__quick-link bf-glass-card bf-ghost-border"
-          data-test="account-list-customer-service"
-          @click="handleCustomerService"
-        >
-          <el-icon><Service /></el-icon>
-          <span>{{ t('accountList.customerService') }}</span>
-        </button>
-      </section>
+        </section>
 
-      <!-- Service accounts list — 4 rendered states (REAL) -->
-      <section class="account-list__list bf-glass-panel">
-        <header class="account-list__list-header">
-          <h2 class="account-list__list-title">
-            {{ t('accountList.serviceAccountsHeading') }}
-          </h2>
-          <span class="account-list__list-count" data-test="account-list-count">
-            {{ t('accountList.accountCount', { count: accountCount }) }}
-          </span>
-        </header>
-
-        <div class="account-list__list-body bf-custom-scrollbar">
-          <p
-            v-if="loadState === 'loading'"
-            class="account-list__list-state"
-            data-test="account-list-loading"
-          >
-            {{ t('accountList.loading') }}
-          </p>
-
-          <div
-            v-else-if="loadState === 'error'"
-            class="account-list__list-state account-list__list-state--error"
-            data-test="account-list-error"
-          >
-            <p>{{ loadError ?? t('accountList.loadFailed') }}</p>
-            <el-button
-              type="primary"
-              plain
-              size="small"
-              data-test="account-list-retry"
-              @click="loadList"
+        <!-- Quick actions row: balance + member center + support (all stubs) -->
+        <section class="account-list__quick">
+          <div class="account-list__balance bf-glass-card bf-ghost-border">
+            <div class="account-list__balance-text">
+              <span class="account-list__balance-label">
+                {{ t('accountList.gashBalance') }}
+              </span>
+              <span class="account-list__balance-value" data-test="account-list-balance-value">
+                {{ formattedRemainPoint }}
+              </span>
+            </div>
+            <button
+              type="button"
+              class="account-list__balance-refresh"
+              :class="{ 'account-list__balance-refresh--spinning': refreshing }"
+              :title="t('accountList.refreshBalance')"
+              :disabled="refreshing"
+              data-test="account-list-refresh-balance"
+              @click="handleRefreshBalance"
             >
-              {{ t('accountList.retry') }}
-            </el-button>
+              <el-icon><Refresh /></el-icon>
+            </button>
           </div>
-
-          <p
-            v-else-if="serviceAccounts.length === 0"
-            class="account-list__list-state"
-            data-test="account-list-empty"
+          <button
+            type="button"
+            class="account-list__quick-link bf-glass-card bf-ghost-border"
+            data-test="account-list-member-center"
+            @click="handleMemberCenter"
           >
-            {{ t('accountList.empty') }}
-          </p>
+            <el-icon><User /></el-icon>
+            <span>{{ t('accountList.memberCenter') }}</span>
+          </button>
+          <button
+            type="button"
+            class="account-list__quick-link bf-glass-card bf-ghost-border"
+            data-test="account-list-customer-service"
+            @click="handleCustomerService"
+          >
+            <el-icon><Service /></el-icon>
+            <span>{{ t('accountList.customerService') }}</span>
+          </button>
+        </section>
 
-          <!--
+        <!-- Service accounts list — 4 rendered states (REAL) -->
+        <section class="account-list__list bf-glass-panel">
+          <header class="account-list__list-header">
+            <h2 class="account-list__list-title">
+              {{ t('accountList.serviceAccountsHeading') }}
+            </h2>
+            <span class="account-list__list-count" data-test="account-list-count">
+              {{ t('accountList.accountCount', { count: accountCount }) }}
+            </span>
+          </header>
+
+          <div class="account-list__list-body bf-custom-scrollbar">
+            <p
+              v-if="loadState === 'loading'"
+              class="account-list__list-state"
+              data-test="account-list-loading"
+            >
+              {{ t('accountList.loading') }}
+            </p>
+
+            <div
+              v-else-if="loadState === 'error'"
+              class="account-list__list-state account-list__list-state--error"
+              data-test="account-list-error"
+            >
+              <p>{{ loadError ?? t('accountList.loadFailed') }}</p>
+              <el-button
+                type="primary"
+                plain
+                size="small"
+                data-test="account-list-retry"
+                @click="loadList"
+              >
+                {{ t('accountList.retry') }}
+              </el-button>
+            </div>
+
+            <p
+              v-else-if="serviceAccounts.length === 0"
+              class="account-list__list-state"
+              data-test="account-list-empty"
+            >
+              {{ t('accountList.empty') }}
+            </p>
+
+            <!--
             D7: vuedraggable wraps the row list. `:list` binds the
             actual mutable Pinia state array (not the read-only
             `serviceAccounts` computed) so Sortable.js' in-place
@@ -1969,82 +1955,82 @@ function handleDragEnd(): void {
             styles the placeholder slot during drag (defined at the
             bottom of <style scoped>).
           -->
-          <draggable
-            v-else
-            :list="account.serviceAccounts"
-            tag="ul"
-            item-key="sid"
-            handle=".account-list__row-grip"
-            :animation="150"
-            ghost-class="account-list__row--ghost"
-            class="account-list__rows"
-            data-test="account-list-rows"
-            @end="handleDragEnd"
-          >
-            <template #item="{ element: a, index: idx }">
-              <li
-                class="account-list__row"
-                :class="{
-                  'account-list__row--selected': isSelected(a),
-                  'account-list__row--banned': !a.is_enable,
-                }"
-                :data-test="`account-row-${a.sid}`"
-                @click="selectRow(a)"
-              >
-                <span
-                  class="account-list__row-grip"
-                  :title="t('accountList.dragHandle')"
-                  aria-hidden="true"
-                  >⋮⋮</span
+            <draggable
+              v-else
+              :list="account.serviceAccounts"
+              tag="ul"
+              item-key="sid"
+              handle=".account-list__row-grip"
+              :animation="150"
+              ghost-class="account-list__row--ghost"
+              class="account-list__rows"
+              data-test="account-list-rows"
+              @end="handleDragEnd"
+            >
+              <template #item="{ element: a, index: idx }">
+                <li
+                  class="account-list__row"
+                  :class="{
+                    'account-list__row--selected': isSelected(a),
+                    'account-list__row--banned': !a.is_enable,
+                  }"
+                  :data-test="`account-row-${a.sid}`"
+                  @click="selectRow(a)"
                 >
-                <span class="account-list__row-num">{{ idx + 1 }}</span>
-                <div class="account-list__row-info">
-                  <p class="account-list__row-name">{{ a.sname }}</p>
-                  <p class="account-list__row-sub">
-                    <template v-if="a.is_enable">ID: {{ a.sid }}</template>
-                    <template v-else>{{ t('accountList.statusBanned') }}</template>
-                  </p>
-                </div>
-                <el-dropdown
-                  trigger="click"
-                  placement="bottom-end"
-                  :hide-on-click="true"
-                  popper-class="account-list__row-menu-popper"
-                  @click.stop
-                >
-                  <button
-                    type="button"
-                    class="account-list__row-more"
-                    :title="t('accountList.moreActions')"
-                    :data-test="`account-row-more-${a.sid}`"
+                  <span
+                    class="account-list__row-grip"
+                    :title="t('accountList.dragHandle')"
+                    aria-hidden="true"
+                    >⋮⋮</span
+                  >
+                  <span class="account-list__row-num">{{ idx + 1 }}</span>
+                  <div class="account-list__row-info">
+                    <p class="account-list__row-name">{{ a.sname }}</p>
+                    <p class="account-list__row-sub">
+                      <template v-if="a.is_enable">ID: {{ a.sid }}</template>
+                      <template v-else>{{ t('accountList.statusBanned') }}</template>
+                    </p>
+                  </div>
+                  <el-dropdown
+                    trigger="click"
+                    placement="bottom-end"
+                    :hide-on-click="true"
+                    popper-class="account-list__row-menu-popper"
                     @click.stop
                   >
-                    <el-icon><MoreFilled /></el-icon>
-                  </button>
-                  <template #dropdown>
-                    <el-dropdown-menu>
-                      <el-dropdown-item
-                        :data-test="`account-row-change-alias-${a.sid}`"
-                        @click="handleChangeAlias(a)"
-                      >
-                        <el-icon><EditPen /></el-icon>
-                        <span>{{ t('ChangeAccountName') }}</span>
-                      </el-dropdown-item>
-                      <el-dropdown-item
-                        :data-test="`account-row-info-${a.sid}`"
-                        @click="handleAccountInfo(a)"
-                      >
-                        <el-icon><InfoFilled /></el-icon>
-                        <span>{{ t('GameAccountInfo') }}</span>
-                      </el-dropdown-item>
-                      <el-dropdown-item
-                        :data-test="`account-row-get-email-${a.sid}`"
-                        @click="handleGetEmail"
-                      >
-                        <el-icon><Message /></el-icon>
-                        <span>{{ t('CheckEmail') }}</span>
-                      </el-dropdown-item>
-                      <!--
+                    <button
+                      type="button"
+                      class="account-list__row-more"
+                      :title="t('accountList.moreActions')"
+                      :data-test="`account-row-more-${a.sid}`"
+                      @click.stop
+                    >
+                      <el-icon><MoreFilled /></el-icon>
+                    </button>
+                    <template #dropdown>
+                      <el-dropdown-menu>
+                        <el-dropdown-item
+                          :data-test="`account-row-change-alias-${a.sid}`"
+                          @click="handleChangeAlias(a)"
+                        >
+                          <el-icon><EditPen /></el-icon>
+                          <span>{{ t('ChangeAccountName') }}</span>
+                        </el-dropdown-item>
+                        <el-dropdown-item
+                          :data-test="`account-row-info-${a.sid}`"
+                          @click="handleAccountInfo(a)"
+                        >
+                          <el-icon><InfoFilled /></el-icon>
+                          <span>{{ t('GameAccountInfo') }}</span>
+                        </el-dropdown-item>
+                        <el-dropdown-item
+                          :data-test="`account-row-get-email-${a.sid}`"
+                          @click="handleGetEmail"
+                        >
+                          <el-icon><Message /></el-icon>
+                          <span>{{ t('CheckEmail') }}</span>
+                        </el-dropdown-item>
+                        <!--
                         D8h: Change Password menu item only appears for
                         unconnected games (mirrors WPF
                         `m_ChangePassword.Visibility` toggled by
@@ -2054,60 +2040,60 @@ function handleDragEnd(): void {
                         opened from the page-level chrome — no
                         per-row affordance is needed there.
                       -->
-                      <el-dropdown-item
-                        v-if="game.isUnconnectedGame"
-                        :data-test="`account-row-change-password-${a.sid}`"
-                        @click="handleChangePassword(a)"
-                      >
-                        <el-icon><Key /></el-icon>
-                        <span>{{ t('ChangePassword') }}</span>
-                      </el-dropdown-item>
-                    </el-dropdown-menu>
-                  </template>
-                </el-dropdown>
-              </li>
-            </template>
-          </draggable>
-        </div>
+                        <el-dropdown-item
+                          v-if="game.isUnconnectedGame"
+                          :data-test="`account-row-change-password-${a.sid}`"
+                          @click="handleChangePassword(a)"
+                        >
+                          <el-icon><Key /></el-icon>
+                          <span>{{ t('ChangePassword') }}</span>
+                        </el-dropdown-item>
+                      </el-dropdown-menu>
+                    </template>
+                  </el-dropdown>
+                </li>
+              </template>
+            </draggable>
+          </div>
 
-        <footer class="account-list__list-footer">
-          <button
-            type="button"
-            class="account-list__add-btn"
-            data-test="account-list-add"
-            @click="handleAddAccount"
-          >
-            <el-icon><Plus /></el-icon>
-            <span>{{ t('AddServiceAccount') }}</span>
-          </button>
-        </footer>
-      </section>
+          <footer class="account-list__list-footer">
+            <button
+              type="button"
+              class="account-list__add-btn"
+              data-test="account-list-add"
+              @click="handleAddAccount"
+            >
+              <el-icon><Plus /></el-icon>
+              <span>{{ t('AddServiceAccount') }}</span>
+            </button>
+          </footer>
+        </section>
 
-      <!-- Add Service Account modal (D3) — mounted unconditionally so its
+        <!-- Add Service Account modal (D3) — mounted unconditionally so its
            transitions can play; visibility is driven by `addAccountVisible`. -->
-      <AddServiceAccount v-model:visible="addAccountVisible" />
+        <AddServiceAccount v-model:visible="addAccountVisible" />
 
-      <!-- Change Service Account display-name modal (D4) — same mount-always
+        <!-- Change Service Account display-name modal (D4) — same mount-always
            pattern as D3. `changeAliasTarget` is cleared by the watcher above
            so stale account refs don't leak between sessions. -->
-      <ChangeServiceAccountDisplayName
-        v-model:visible="changeAliasVisible"
-        :account="changeAliasTarget"
-      />
+        <ChangeServiceAccountDisplayName
+          v-model:visible="changeAliasVisible"
+          :account="changeAliasTarget"
+        />
 
-      <!-- Service Account read-only info modal (D6) — same mount-always
+        <!-- Service Account read-only info modal (D6) — same mount-always
            pattern as D3 / D4. `accountInfoTarget` is cleared by the
            watcher above so stale account refs don't leak between sessions. -->
-      <ServiceAccountInfo v-model:visible="accountInfoVisible" :account="accountInfoTarget" />
+        <ServiceAccountInfo v-model:visible="accountInfoVisible" :account="accountInfoTarget" />
 
-      <!-- Generic copy-box dialog (D10.1) — currently driven by Get Email
+        <!-- Generic copy-box dialog (D10.1) — currently driven by Get Email
            (D10.5); future per-row context-menu items that need a similar
            "show + copy" affordance can reuse the same single mount by
            writing into `copyBoxTitle` / `copyBoxValue` before flipping
            `copyBoxVisible`. -->
-      <CopyBox v-model:visible="copyBoxVisible" :title="copyBoxTitle" :value="copyBoxValue" />
+        <CopyBox v-model:visible="copyBoxVisible" :title="copyBoxTitle" :value="copyBoxValue" />
 
-      <!-- D8c: Game picker dialog. Driven by either the Change Game
+        <!-- D8c: Game picker dialog. Driven by either the Change Game
            button on the game info bar or the mount-time auto-open
            inside `setupGameOnMount` (when no valid `loginGame`
            resolves against the loaded catalogue). The dialog
@@ -2123,36 +2109,36 @@ function handleDragEnd(): void {
            fallback (see `gameImageUrl` for the same defensive
            pattern); the gate is the cleaner option here because
            the dialog can't usefully open without a region anyway. -->
-      <GameList
-        v-if="auth.session"
-        v-model:visible="gameListVisible"
-        :region="auth.session.region"
-        @select="handleGameSelected"
-      />
+        <GameList
+          v-if="auth.session"
+          v-model:visible="gameListVisible"
+          :region="auth.session.region"
+          @select="handleGameSelected"
+        />
 
-      <!-- D8g: Unconnected-game Add Account dialog. Mounted alongside
+        <!-- D8g: Unconnected-game Add Account dialog. Mounted alongside
            the regular `<AddServiceAccount />` above; `handleAddAccount`
            dispatches between the two on `game.isUnconnectedGame`.
            The `created` event refreshes the row list so the new
            account appears immediately. -->
-      <UnconnectedGameAddAccount
-        v-model:visible="unconnectedAddVisible"
-        @created="handleUnconnectedAccountCreated"
-      />
+        <UnconnectedGameAddAccount
+          v-model:visible="unconnectedAddVisible"
+          @created="handleUnconnectedAccountCreated"
+        />
 
-      <!-- D8h: Unconnected-game Change Password dialog. Driven by the
+        <!-- D8h: Unconnected-game Change Password dialog. Driven by the
            per-row Change Password menu item (which is itself
            `v-if`-gated on `game.isUnconnectedGame`). The `accountIndex`
            prop is the row's 0-based index in `account.serviceAccounts`,
            captured at menu-trigger time so a downstream selection /
            reorder can't misroute the change-password POST. -->
-      <UnconnectedGameChangePassword
-        v-model:visible="changePasswordVisible"
-        :account-index="changePasswordAccountIndex"
-        @verify-code-sent="handleChangePasswordSent"
-      />
+        <UnconnectedGameChangePassword
+          v-model:visible="changePasswordVisible"
+          :account-index="changePasswordAccountIndex"
+          @verify-code-sent="handleChangePasswordSent"
+        />
 
-      <!-- P12.5 D7: Tools dialog stack — single mount that hosts
+        <!-- P12.5 D7: Tools dialog stack — single mount that hosts
            MapleTools / KartTools / EquipCalculator /
            CoreCalculator (in-app browser routed via composable;
            see followup-B B7). Opened imperatively by `handleTools` via
@@ -2162,75 +2148,113 @@ function handleDragEnd(): void {
            internal dialog mounts can play their open transitions
            on first open; per-dialog visibility is owned inside
            the wrapper. -->
-      <ToolsDialogStack ref="toolsDialogRef" />
+        <ToolsDialogStack ref="toolsDialogRef" />
 
-      <!-- OTP section (D5: REAL Get OTP / clipboard / auto-paste flow) -->
-      <section class="account-list__otp bf-glass-panel">
-        <header class="account-list__otp-header">
-          <h2 class="account-list__otp-title">{{ t('accountList.otpHeading') }}</h2>
-          <!--
+        <!-- OTP section (D5: REAL Get OTP / clipboard / auto-paste flow) -->
+        <section class="account-list__otp bf-glass-panel">
+          <header class="account-list__otp-header">
+            <h2 class="account-list__otp-title">{{ t('accountList.otpHeading') }}</h2>
+            <!--
             D5: bind via :model-value + @change (not v-model) so the
             persistence + first-time-AutoPasteTip side effects only run
             on the user's gesture, not on the setup-time hydration of
             the local ref from configStore.
           -->
-          <el-checkbox
-            :model-value="autoPaste"
-            size="small"
-            data-test="account-list-auto-paste"
-            @change="handleAutoPasteToggle"
-          >
-            {{ t('accountList.autoPaste') }}
-          </el-checkbox>
-        </header>
-        <div class="account-list__otp-row">
-          <div class="account-list__otp-input">
-            <input
-              type="text"
-              readonly
-              :value="otpValue"
-              :placeholder="t('accountList.otpPlaceholder')"
-              class="account-list__otp-field"
-              data-test="account-list-otp-field"
-            />
+            <el-checkbox
+              :model-value="autoPaste"
+              size="small"
+              data-test="account-list-auto-paste"
+              @change="handleAutoPasteToggle"
+            >
+              {{ t('accountList.autoPaste') }}
+            </el-checkbox>
+          </header>
+          <div class="account-list__otp-row">
+            <div class="account-list__otp-input">
+              <input
+                type="text"
+                readonly
+                :value="otpValue"
+                :placeholder="t('accountList.otpPlaceholder')"
+                class="account-list__otp-field"
+                data-test="account-list-otp-field"
+              />
+              <button
+                type="button"
+                class="account-list__otp-copy"
+                :title="t('accountList.copyOtp')"
+                :disabled="!otpValue"
+                data-test="account-list-otp-copy"
+                @click="handleCopyOtp"
+              >
+                <el-icon><DocumentCopy /></el-icon>
+              </button>
+            </div>
             <button
               type="button"
-              class="account-list__otp-copy"
-              :title="t('accountList.copyOtp')"
-              :disabled="!otpValue"
-              data-test="account-list-otp-copy"
-              @click="handleCopyOtp"
+              class="bf-btn-gradient account-list__otp-get"
+              :disabled="gettingOtp"
+              data-test="account-list-otp-get"
+              @click="handleGetOtp"
             >
-              <el-icon><DocumentCopy /></el-icon>
+              {{ gettingOtp ? t('GettingOtp') : t('GetOtp') }}
             </button>
           </div>
-          <button
-            type="button"
-            class="bf-btn-gradient account-list__otp-get"
-            :disabled="gettingOtp"
-            data-test="account-list-otp-get"
-            @click="handleGetOtp"
-          >
-            {{ gettingOtp ? t('GettingOtp') : t('GetOtp') }}
-          </button>
-        </div>
-      </section>
+        </section>
+      </div>
     </div>
   </main>
 </template>
 
 <style scoped>
 .account-list {
-  box-sizing: border-box;
-  min-height: 100vh;
-  padding: 2.5rem 1.5rem;
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  overflow: hidden;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.55) 0%, rgba(255, 255, 255, 0.45) 100%),
+    radial-gradient(
+      1200px 800px at 10% -10%,
+      color-mix(in srgb, var(--bf-primary-container) 30%, transparent) 0%,
+      transparent 60%
+    ),
+    radial-gradient(
+      900px 700px at 110% 110%,
+      color-mix(in srgb, var(--bf-primary) 22%, transparent) 0%,
+      transparent 55%
+    ),
+    linear-gradient(180deg, #f7f1ec 0%, #ece1d6 100%);
+}
+
+.account-list__titlebar-btn {
+  appearance: none;
+  background: transparent;
+  border: none;
+  width: 28px;
+  height: 28px;
+  display: grid;
+  place-items: center;
+  border-radius: 6px;
+  cursor: pointer;
+  color: var(--bf-on-surface-variant, #54443a);
+  transition: background 150ms ease;
+  padding: 0;
+}
+.account-list__titlebar-btn .material-symbols-outlined {
+  font-size: 18px;
+}
+.account-list__titlebar-btn:hover {
+  background: rgba(0, 0, 0, 0.06);
+}
+
+.account-list__scroll {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1.5rem;
 }
 
 .account-list__container {
   width: 100%;
-  max-width: 560px;
   display: flex;
   flex-direction: column;
   gap: 1rem;

--- a/src/pages/LoginPage.vue
+++ b/src/pages/LoginPage.vue
@@ -2,122 +2,142 @@
 /**
  * Login shell — the WPF `LoginPage.xaml` equivalent.
  *
- * # Why a shell instead of one big page?
- *
- * The WPF original is a near-empty `<Frame>` that hosts one of three
- * forms (`id_pass_form`, `qr_form`, `gamepass_form`) plus the modal
- * sub-flows (TOTP, captcha, wait spinner). Mirroring that structure
- * with `<RouterView />` keeps each form a self-contained route:
- *
- * - `/login/region`    — region picker (TW / HK), entry point
- * - `/login/id-pass`   — account+password form
- * - `/login/qr`        — QR-code login
- * - `/login/gamepass`  — GamePass login (opens Tauri WebviewWindow)
- * - `/login/totp`      — TOTP challenge
- * - `/login/wait`      — pending callback / handshake spinner
- * - `/login/verify`    — captcha + verify code
- *
- * Children are added route-by-route in P12.1 D2-D8; this D1 commit
- * only ships the shell + the empty `<RouterView />` slot so each
- * subsequent D-step has a stable mount point.
- *
- * # Title bar
- *
- * Currently relies on the OS-provided window decoration (Tauri
- * default). Migrating to a custom drag-region title bar (matching the
- * mockup's `title-bar` div) is a P12.4 concern — it touches every
- * page, not just login, so it lives in the Settings / shell-overhaul
- * D-step rather than here.
+ * The glass-panel IS the window body. Tauri runs with
+ * `decorations: false` + `transparent: true` so only the rounded
+ * card is visible. TitleBar provides drag + minimize / close.
  */
 
 import { computed } from 'vue'
-import { useI18n } from 'vue-i18n'
-
-import iconUrl from '../assets/icon-outline.png'
+import { useRoute, useRouter } from 'vue-router'
+import TitleBar from '../components/TitleBar.vue'
+import { useConfigStore } from '../stores/config'
+import type { LoginRegion } from '../types/bindings'
 
 defineOptions({ name: 'LoginPage' })
 
-const { t } = useI18n()
+const route = useRoute()
+const router = useRouter()
+const config = useConfigStore()
 
-const heading = computed(() => t('loginShell.heading'))
-const subline = computed(() => t('loginShell.subline'))
+const currentRegion = computed(() => (config.get('loginRegion') as LoginRegion | undefined) ?? 'TW')
+
+/** True when we're on the region picker itself — hide the switcher there. */
+const isRegionPage = computed(() => route.name === 'login-region')
+
+async function toggleRegion(): Promise<void> {
+  const next: LoginRegion = currentRegion.value === 'TW' ? 'HK' : 'TW'
+  await config.set('loginRegion', next)
+  // Navigate back to id-pass so any active QR/GamePass session is abandoned
+  if (route.path !== '/login/id-pass') {
+    await router.replace('/login/id-pass')
+  }
+}
+
+function handleOpenSettings(): void {
+  void router.push('/settings')
+}
+
+function handleOpenAbout(): void {
+  void router.push('/about')
+}
 </script>
 
 <template>
-  <main class="login-shell bf-mica-bg">
-    <section class="login-shell__panel bf-glass-panel">
-      <header class="login-shell__header">
-        <div class="login-shell__brand">
-          <img :src="iconUrl" alt="Beanfun" class="login-shell__icon" />
-          <h1 class="login-shell__title">{{ heading }}</h1>
-        </div>
-        <p class="login-shell__subline">{{ subline }}</p>
-      </header>
-      <div class="login-shell__body">
-        <RouterView />
-      </div>
-    </section>
-  </main>
+  <section class="login-shell bf-glass-panel" data-window-root>
+    <TitleBar>
+      <button
+        v-if="!isRegionPage"
+        type="button"
+        class="login-shell__region-btn"
+        :title="`Region: ${currentRegion}`"
+        @click="toggleRegion"
+      >
+        <span class="material-symbols-outlined login-shell__region-icon">public</span>
+        <span class="login-shell__region-label">{{ currentRegion }}</span>
+      </button>
+      <button type="button" class="login-shell__action-btn" @click="handleOpenSettings">
+        <span class="material-symbols-outlined">settings</span>
+      </button>
+      <button type="button" class="login-shell__action-btn" @click="handleOpenAbout">
+        <span class="material-symbols-outlined">info</span>
+      </button>
+    </TitleBar>
+    <div class="login-shell__body">
+      <RouterView />
+    </div>
+  </section>
 </template>
 
 <style scoped>
-/*
- * P12.2 D1 refactor: page-level chrome (background gradient + glass
- * surface) moved to project-wide utility classes
- * (`bf-mica-bg`, `bf-glass-panel`) declared in `src/styles/utilities.css`.
- * Only LoginPage-specific layout (size/spacing) stays here so adding
- * a second top-level page (P12.2 AccountList) reuses the same
- * primitives instead of copy-pasting the rgba/blur soup.
- */
 .login-shell {
-  box-sizing: border-box;
-  min-height: 100vh;
-  display: grid;
-  place-items: center;
-  padding: 2rem;
-}
-
-.login-shell__panel {
-  width: 100%;
-  max-width: 560px;
-  overflow: hidden;
-}
-
-.login-shell__header {
-  padding: 2rem 2rem 1rem;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.4);
-  text-align: center;
-}
-
-.login-shell__brand {
   display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.5rem;
-}
-
-.login-shell__icon {
-  height: 36px;
-  width: auto;
-  flex-shrink: 0;
-}
-
-.login-shell__title {
-  margin: 0;
-  font-size: 1.5rem;
-  font-weight: 800;
-  letter-spacing: -0.01em;
-  color: var(--bf-on-surface);
-}
-
-.login-shell__subline {
-  margin: 0.5rem 0 0;
-  font-size: 0.875rem;
-  color: var(--bf-on-surface-variant);
+  flex-direction: column;
+  overflow: hidden;
+  /* Mica gradient base (opaque) + glass white overlay */
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.55) 0%, rgba(255, 255, 255, 0.45) 100%),
+    radial-gradient(
+      1200px 800px at 10% -10%,
+      color-mix(in srgb, var(--bf-primary-container) 30%, transparent) 0%,
+      transparent 60%
+    ),
+    radial-gradient(
+      900px 700px at 110% 110%,
+      color-mix(in srgb, var(--bf-primary) 22%, transparent) 0%,
+      transparent 55%
+    ),
+    linear-gradient(180deg, #f7f1ec 0%, #ece1d6 100%);
 }
 
 .login-shell__body {
-  padding: 2rem;
-  min-height: 240px;
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 1.5rem;
+}
+
+.login-shell__action-btn {
+  appearance: none;
+  background: transparent;
+  border: none;
+  width: 28px;
+  height: 28px;
+  display: grid;
+  place-items: center;
+  border-radius: 6px;
+  cursor: pointer;
+  color: var(--bf-on-surface-variant, #54443a);
+  transition: background 150ms ease;
+  padding: 0;
+}
+.login-shell__action-btn .material-symbols-outlined {
+  font-size: 18px;
+}
+.login-shell__action-btn:hover {
+  background: rgba(0, 0, 0, 0.06);
+}
+
+.login-shell__region-btn {
+  appearance: none;
+  background: color-mix(in srgb, var(--bf-primary-container, #ff8201) 15%, transparent);
+  border: 1px solid color-mix(in srgb, var(--bf-primary-container, #ff8201) 30%, transparent);
+  height: 26px;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0 0.5rem 0 0.25rem;
+  border-radius: 6px;
+  cursor: pointer;
+  color: var(--bf-primary, #954a00);
+  font: inherit;
+  font-size: 11px;
+  font-weight: 700;
+  transition: background 150ms ease;
+}
+.login-shell__region-icon {
+  font-size: 14px;
+}
+.login-shell__region-btn:hover {
+  background: color-mix(in srgb, var(--bf-primary-container, #ff8201) 25%, transparent);
 }
 </style>

--- a/src/pages/LoginRegionSelection.vue
+++ b/src/pages/LoginRegionSelection.vue
@@ -32,7 +32,7 @@
  * first-launch + manual region-switch flows both work.
  */
 
-import { computed } from 'vue'
+import { computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 import { useConfigStore } from '../stores/config'
@@ -45,6 +45,16 @@ const router = useRouter()
 const config = useConfigStore()
 
 /**
+ * Skip the region picker if a region is already saved — go
+ * straight to the login form. First-launch users see the picker.
+ */
+onMounted(() => {
+  if (config.get('loginRegion')) {
+    void router.replace('/login/id-pass')
+  }
+})
+
+/**
  * Tile descriptors. Kept declarative so the template stays a flat
  * `v-for` rather than two near-duplicate `<button>` blocks (DRY).
  * Per-region runtime hints (e.g. "TOTP supported on HK") live in
@@ -55,6 +65,7 @@ type RegionTile = {
   labelKey: string
   hostHint: string
   hintKey: string
+  hintIcon: string
 }
 
 const TILES: readonly RegionTile[] = [
@@ -63,18 +74,23 @@ const TILES: readonly RegionTile[] = [
     labelKey: 'Taiwan',
     hostHint: 'tw.beanfun.com',
     hintKey: 'loginRegion.defaultBadge',
+    hintIcon: 'check_circle',
   },
   {
     region: 'HK',
     labelKey: 'HongKong',
     hostHint: 'hk.beanfun.com',
     hintKey: 'loginRegion.totpHint',
+    hintIcon: 'info',
   },
 ]
 
 const heading = computed(() => t('BeanfunRegionSelected'))
 const subline = computed(() => t('loginRegion.subline'))
 const tip = computed(() => t('loginRegion.tip'))
+
+/** The currently saved region from Config.xml, defaults to TW. */
+const currentRegion = computed(() => (config.get('loginRegion') as string | undefined) ?? 'TW')
 
 async function selectRegion(region: LoginRegion): Promise<void> {
   /*
@@ -106,19 +122,26 @@ async function selectRegion(region: LoginRegion): Promise<void> {
         :key="tile.region"
         type="button"
         class="region-tile"
+        :class="{ 'region-tile--current': currentRegion === tile.region }"
         :data-region="tile.region"
         @click="selectRegion(tile.region)"
       >
         <div class="region-tile__icon">
-          <span class="region-tile__region-code">{{ tile.region }}</span>
+          <span class="material-symbols-outlined region-tile__flag">flag</span>
         </div>
         <div class="region-tile__label">{{ t(tile.labelKey) }}</div>
         <div class="region-tile__host">{{ tile.hostHint }}</div>
-        <div class="region-tile__badge">{{ t(tile.hintKey) }}</div>
+        <div class="region-tile__badge">
+          <span class="material-symbols-outlined region-tile__badge-icon">{{ tile.hintIcon }}</span>
+          {{ t(tile.hintKey) }}
+        </div>
       </button>
     </div>
 
-    <p class="region-picker__tip">{{ tip }}</p>
+    <div class="region-picker__tip">
+      <span class="material-symbols-outlined region-picker__tip-icon">tips_and_updates</span>
+      <span>{{ tip }}</span>
+    </div>
   </section>
 </template>
 
@@ -135,9 +158,10 @@ async function selectRegion(region: LoginRegion): Promise<void> {
 
 .region-picker__heading {
   margin: 0;
-  font-size: 1.25rem;
-  font-weight: 700;
-  color: #1f1a16;
+  font-size: 1.5rem;
+  font-weight: 800;
+  letter-spacing: -0.01em;
+  color: var(--bf-on-surface, #1f1a16);
 }
 
 .region-picker__subline {
@@ -176,39 +200,40 @@ async function selectRegion(region: LoginRegion): Promise<void> {
 .region-tile:focus-visible {
   transform: translateY(-3px);
   background: rgba(255, 255, 255, 0.92);
-  box-shadow: 0 10px 24px color-mix(in srgb, var(--el-color-primary, #ff8201) 22%, transparent);
+  box-shadow: 0 10px 24px color-mix(in srgb, var(--bf-primary, #954a00) 22%, transparent);
   outline: none;
 }
 
 .region-tile:focus-visible {
-  border-color: var(--el-color-primary, #ff8201);
+  border-color: var(--bf-primary-container, #ff8201);
+}
+
+.region-tile--current {
+  border-color: var(--bf-primary-container, #ff8201);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--bf-primary-container, #ff8201) 30%, transparent);
 }
 
 .region-tile__icon {
-  width: 64px;
-  height: 64px;
-  border-radius: 16px;
+  width: 72px;
+  height: 72px;
+  border-radius: 18px;
   background: linear-gradient(
     135deg,
-    color-mix(in srgb, var(--el-color-primary, #ff8201) 65%, white 35%),
-    var(--el-color-primary, #ff8201)
+    var(--bf-primary-container, #ff8201),
+    var(--bf-primary, #954a00)
   );
   color: #fff;
   display: grid;
   place-items: center;
-  box-shadow: 0 8px 18px color-mix(in srgb, var(--el-color-primary, #ff8201) 32%, transparent);
+  box-shadow: 0 8px 20px color-mix(in srgb, var(--bf-primary, #954a00) 35%, transparent);
 }
 
-.region-tile__region-code {
-  font-size: 1.5rem;
-  font-weight: 900;
-  color: #fff;
-  letter-spacing: 0.05em;
-  line-height: 1;
+.region-tile__flag {
+  font-size: 36px;
 }
 
 .region-tile__label {
-  font-size: 1rem;
+  font-size: 1.125rem;
   font-weight: 700;
 }
 
@@ -220,12 +245,19 @@ async function selectRegion(region: LoginRegion): Promise<void> {
 
 .region-tile__badge {
   margin-top: 0.25rem;
-  font-size: 0.6875rem;
+  font-size: 0.75rem;
   padding: 0.25rem 0.5rem;
   border-radius: 9999px;
-  background: color-mix(in srgb, var(--el-color-primary, #ff8201) 20%, transparent);
-  color: var(--el-color-primary, #ff8201);
+  background: color-mix(in srgb, var(--bf-primary-container, #ff8201) 30%, transparent);
+  color: var(--bf-primary, #954a00);
   font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.region-tile__badge-icon {
+  font-size: 14px;
 }
 
 .region-picker__tip {
@@ -235,6 +267,14 @@ async function selectRegion(region: LoginRegion): Promise<void> {
   background: rgba(0, 0, 0, 0.04);
   font-size: 0.75rem;
   color: #54443a;
-  text-align: center;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.region-picker__tip-icon {
+  font-size: 18px;
+  color: var(--bf-primary-container, #ff8201);
+  flex-shrink: 0;
 }
 </style>

--- a/src/pages/ManageAccount.vue
+++ b/src/pages/ManageAccount.vue
@@ -105,6 +105,7 @@ import AddAccount from '../windows/AddAccount.vue'
 import ChangeAccount from '../windows/ChangeAccount.vue'
 import { useAccountStore } from '../stores/account'
 import type { Account } from '../types/bindings'
+import TitleBar from '../components/TitleBar.vue'
 
 defineOptions({ name: 'ManageAccount' })
 
@@ -498,208 +499,213 @@ function handleBack(): void {
 </script>
 
 <template>
-  <main class="manage bf-mica-bg">
-    <div class="manage__container">
-      <!-- Header -->
-      <header class="manage__header">
-        <div class="manage__header-icon" aria-hidden="true">
-          <el-icon :size="24"><UserFilled /></el-icon>
-        </div>
-        <div class="manage__header-text">
-          <h1 class="manage__title bf-text-gradient">{{ t('ManageAccount') }}</h1>
-          <p class="manage__subline">{{ t('manageAccount.subtitle') }}</p>
-        </div>
-      </header>
-
-      <!-- Toolbar: search + import / export / add -->
-      <section class="manage__toolbar bf-glass-panel">
-        <div class="manage__toolbar-search">
-          <el-input
-            v-model="query"
-            :placeholder="t('manageAccount.searchPlaceholder')"
-            :disabled="loadState === 'loading'"
-            clearable
-            data-test="manage-account-search"
-          >
-            <template #prefix>
-              <el-icon><Search /></el-icon>
-            </template>
-          </el-input>
-        </div>
-        <div class="manage__toolbar-actions">
-          <el-button
-            class="bf-btn-secondary manage__action-btn"
-            :disabled="importing"
-            data-test="manage-account-import"
-            @click="handleImport"
-          >
-            <el-icon><Upload /></el-icon>
-            <span>{{ t('manageAccount.import') }}</span>
-          </el-button>
-          <el-button
-            class="bf-btn-secondary manage__action-btn"
-            :disabled="exporting || account.accounts.length === 0"
-            data-test="manage-account-export"
-            @click="handleExport"
-          >
-            <el-icon><Download /></el-icon>
-            <span>{{ t('manageAccount.export') }}</span>
-          </el-button>
-          <el-button
-            class="bf-btn-secondary manage__action-btn"
-            data-test="manage-account-backup"
-            @click="openBackup"
-          >
-            <el-icon><Lock /></el-icon>
-            <span>{{ t('DataBackup') }}</span>
-          </el-button>
-          <button
-            type="button"
-            class="bf-btn-gradient manage__action-btn"
-            data-test="manage-account-add"
-            @click="openAdd"
-          >
-            <el-icon><Plus /></el-icon>
-            <span>{{ t('Add') }}</span>
-          </button>
-        </div>
-      </section>
-
-      <!-- Stats: single card (Q7) -->
-      <section class="manage__stats">
-        <div class="manage__stat-card bf-glass-card bf-ghost-border">
-          <el-icon class="manage__stat-icon" :size="20"><UserFilled /></el-icon>
-          <div class="manage__stat-text">
-            <span class="manage__stat-label">
-              {{ t('manageAccount.totalAccounts') }}
-            </span>
-            <span class="manage__stat-value" data-test="manage-account-total">
-              {{ totalAccounts }}
-            </span>
+  <main class="manage bf-glass-panel" data-window-root>
+    <TitleBar />
+    <div class="manage__scroll">
+      <div class="manage__container">
+        <!-- Header -->
+        <header class="manage__header">
+          <div class="manage__header-icon" aria-hidden="true">
+            <el-icon :size="24"><UserFilled /></el-icon>
           </div>
-        </div>
-      </section>
+          <div class="manage__header-text">
+            <h1 class="manage__title bf-text-gradient">{{ t('ManageAccount') }}</h1>
+            <p class="manage__subline">{{ t('manageAccount.subtitle') }}</p>
+          </div>
+        </header>
 
-      <!-- Table -->
-      <section class="manage__list bf-glass-panel">
-        <div class="manage__list-header">
-          <div class="manage__col-handle" />
-          <div class="manage__col-account">{{ t('manageAccount.colAccount') }}</div>
-          <div class="manage__col-remark">{{ t('manageAccount.colRemark') }}</div>
-          <div class="manage__col-region">{{ t('manageAccount.colRegion') }}</div>
-          <div class="manage__col-last">{{ t('manageAccount.colLastLogin') }}</div>
-          <div class="manage__col-actions">{{ t('manageAccount.colActions') }}</div>
-        </div>
-
-        <div class="manage__list-body bf-custom-scrollbar">
-          <p
-            v-if="loadState === 'loading'"
-            class="manage__list-state"
-            data-test="manage-account-loading"
-          >
-            {{ t('accountList.loading') }}
-          </p>
-
-          <div
-            v-else-if="loadState === 'error'"
-            class="manage__list-state manage__list-state--error"
-            data-test="manage-account-error"
-          >
-            <p>{{ loadError ?? t('accountList.loadFailed') }}</p>
+        <!-- Toolbar: search + import / export / add -->
+        <section class="manage__toolbar bf-glass-panel">
+          <div class="manage__toolbar-search">
+            <el-input
+              v-model="query"
+              :placeholder="t('manageAccount.searchPlaceholder')"
+              :disabled="loadState === 'loading'"
+              clearable
+              data-test="manage-account-search"
+            >
+              <template #prefix>
+                <el-icon><Search /></el-icon>
+              </template>
+            </el-input>
+          </div>
+          <div class="manage__toolbar-actions">
             <el-button
-              type="primary"
-              plain
-              size="small"
-              data-test="manage-account-retry"
-              @click="loadList"
+              class="bf-btn-secondary manage__action-btn"
+              :disabled="importing"
+              data-test="manage-account-import"
+              @click="handleImport"
             >
-              {{ t('accountList.retry') }}
+              <el-icon><Upload /></el-icon>
+              <span>{{ t('manageAccount.import') }}</span>
             </el-button>
-          </div>
-
-          <p
-            v-else-if="loadState === 'empty'"
-            class="manage__list-state"
-            data-test="manage-account-empty"
-          >
-            {{ t('manageAccount.empty') }}
-          </p>
-
-          <p
-            v-else-if="searchedAccounts.length === 0"
-            class="manage__list-state"
-            data-test="manage-account-no-search-result"
-          >
-            {{ t('manageAccount.noSearchResult') }}
-          </p>
-
-          <div
-            v-for="(row, index) in searchedAccounts"
-            v-else
-            :key="`${row.region}|${row.account_id}`"
-            class="manage__row"
-            :class="{ 'manage__row--last': index === searchedAccounts.length - 1 }"
-            :data-test="`manage-account-row-${row.region}-${row.account_id}`"
-          >
-            <span
-              class="manage__drag-handle"
-              :title="t('manageAccount.dragDisabledTip')"
-              data-test="manage-account-drag-handle"
+            <el-button
+              class="bf-btn-secondary manage__action-btn"
+              :disabled="exporting || account.accounts.length === 0"
+              data-test="manage-account-export"
+              @click="handleExport"
             >
-              <el-icon><Rank /></el-icon>
-            </span>
-            <div class="manage__cell-account">
-              <div class="manage__avatar" aria-hidden="true">{{ avatarGlyph(row) }}</div>
-              <span class="manage__account-id">{{ row.account_id }}</span>
-            </div>
-            <div class="manage__cell-remark">
-              <span v-if="row.account_name.trim().length > 0">{{ row.account_name }}</span>
-              <span v-else class="manage__remark-empty">
-                {{ t('manageAccount.remarkEmpty') }}
+              <el-icon><Download /></el-icon>
+              <span>{{ t('manageAccount.export') }}</span>
+            </el-button>
+            <el-button
+              class="bf-btn-secondary manage__action-btn"
+              data-test="manage-account-backup"
+              @click="openBackup"
+            >
+              <el-icon><Lock /></el-icon>
+              <span>{{ t('DataBackup') }}</span>
+            </el-button>
+            <button
+              type="button"
+              class="bf-btn-gradient manage__action-btn"
+              data-test="manage-account-add"
+              @click="openAdd"
+            >
+              <el-icon><Plus /></el-icon>
+              <span>{{ t('Add') }}</span>
+            </button>
+          </div>
+        </section>
+
+        <!-- Stats: single card (Q7) -->
+        <section class="manage__stats">
+          <div class="manage__stat-card bf-glass-card bf-ghost-border">
+            <el-icon class="manage__stat-icon" :size="20"><UserFilled /></el-icon>
+            <div class="manage__stat-text">
+              <span class="manage__stat-label">
+                {{ t('manageAccount.totalAccounts') }}
               </span>
-            </div>
-            <div class="manage__cell-region">
-              <span class="manage__chip" :class="{ 'manage__chip--primary': row.region === 'TW' }">
-                {{ regionLabel(row.region) }}
+              <span class="manage__stat-value" data-test="manage-account-total">
+                {{ totalAccounts }}
               </span>
-            </div>
-            <div class="manage__cell-last">
-              {{ t('manageAccount.lastLoginUnknown') }}
-            </div>
-            <div class="manage__cell-actions">
-              <button
-                type="button"
-                class="manage__icon-btn"
-                :title="t('manageAccount.editAction')"
-                :data-test="`manage-account-edit-${row.region}-${row.account_id}`"
-                @click="openEdit(row)"
-              >
-                <el-icon><EditPen /></el-icon>
-              </button>
-              <button
-                type="button"
-                class="manage__icon-btn"
-                :title="t('manageAccount.copyIdAction')"
-                :data-test="`manage-account-copy-${row.region}-${row.account_id}`"
-                @click="handleCopyId(row)"
-              >
-                <el-icon><DocumentCopy /></el-icon>
-              </button>
-              <button
-                type="button"
-                class="manage__icon-btn manage__icon-btn--danger"
-                :title="t('manageAccount.deleteAction')"
-                :data-test="`manage-account-delete-${row.region}-${row.account_id}`"
-                @click="handleDelete(row)"
-              >
-                <el-icon><Delete /></el-icon>
-              </button>
             </div>
           </div>
-        </div>
-      </section>
+        </section>
 
-      <!--
+        <!-- Table -->
+        <section class="manage__list bf-glass-panel">
+          <div class="manage__list-header">
+            <div class="manage__col-handle" />
+            <div class="manage__col-account">{{ t('manageAccount.colAccount') }}</div>
+            <div class="manage__col-remark">{{ t('manageAccount.colRemark') }}</div>
+            <div class="manage__col-region">{{ t('manageAccount.colRegion') }}</div>
+            <div class="manage__col-last">{{ t('manageAccount.colLastLogin') }}</div>
+            <div class="manage__col-actions">{{ t('manageAccount.colActions') }}</div>
+          </div>
+
+          <div class="manage__list-body bf-custom-scrollbar">
+            <p
+              v-if="loadState === 'loading'"
+              class="manage__list-state"
+              data-test="manage-account-loading"
+            >
+              {{ t('accountList.loading') }}
+            </p>
+
+            <div
+              v-else-if="loadState === 'error'"
+              class="manage__list-state manage__list-state--error"
+              data-test="manage-account-error"
+            >
+              <p>{{ loadError ?? t('accountList.loadFailed') }}</p>
+              <el-button
+                type="primary"
+                plain
+                size="small"
+                data-test="manage-account-retry"
+                @click="loadList"
+              >
+                {{ t('accountList.retry') }}
+              </el-button>
+            </div>
+
+            <p
+              v-else-if="loadState === 'empty'"
+              class="manage__list-state"
+              data-test="manage-account-empty"
+            >
+              {{ t('manageAccount.empty') }}
+            </p>
+
+            <p
+              v-else-if="searchedAccounts.length === 0"
+              class="manage__list-state"
+              data-test="manage-account-no-search-result"
+            >
+              {{ t('manageAccount.noSearchResult') }}
+            </p>
+
+            <div
+              v-for="(row, index) in searchedAccounts"
+              v-else
+              :key="`${row.region}|${row.account_id}`"
+              class="manage__row"
+              :class="{ 'manage__row--last': index === searchedAccounts.length - 1 }"
+              :data-test="`manage-account-row-${row.region}-${row.account_id}`"
+            >
+              <span
+                class="manage__drag-handle"
+                :title="t('manageAccount.dragDisabledTip')"
+                data-test="manage-account-drag-handle"
+              >
+                <el-icon><Rank /></el-icon>
+              </span>
+              <div class="manage__cell-account">
+                <div class="manage__avatar" aria-hidden="true">{{ avatarGlyph(row) }}</div>
+                <span class="manage__account-id">{{ row.account_id }}</span>
+              </div>
+              <div class="manage__cell-remark">
+                <span v-if="row.account_name.trim().length > 0">{{ row.account_name }}</span>
+                <span v-else class="manage__remark-empty">
+                  {{ t('manageAccount.remarkEmpty') }}
+                </span>
+              </div>
+              <div class="manage__cell-region">
+                <span
+                  class="manage__chip"
+                  :class="{ 'manage__chip--primary': row.region === 'TW' }"
+                >
+                  {{ regionLabel(row.region) }}
+                </span>
+              </div>
+              <div class="manage__cell-last">
+                {{ t('manageAccount.lastLoginUnknown') }}
+              </div>
+              <div class="manage__cell-actions">
+                <button
+                  type="button"
+                  class="manage__icon-btn"
+                  :title="t('manageAccount.editAction')"
+                  :data-test="`manage-account-edit-${row.region}-${row.account_id}`"
+                  @click="openEdit(row)"
+                >
+                  <el-icon><EditPen /></el-icon>
+                </button>
+                <button
+                  type="button"
+                  class="manage__icon-btn"
+                  :title="t('manageAccount.copyIdAction')"
+                  :data-test="`manage-account-copy-${row.region}-${row.account_id}`"
+                  @click="handleCopyId(row)"
+                >
+                  <el-icon><DocumentCopy /></el-icon>
+                </button>
+                <button
+                  type="button"
+                  class="manage__icon-btn manage__icon-btn--danger"
+                  :title="t('manageAccount.deleteAction')"
+                  :data-test="`manage-account-delete-${row.region}-${row.account_id}`"
+                  @click="handleDelete(row)"
+                >
+                  <el-icon><Delete /></el-icon>
+                </button>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <!--
         Footer: encryption hint (left) + Back button (right).
         Hint and back button share the same flex row so the
         layout collapses gracefully on narrow widths (the back
@@ -708,36 +714,54 @@ function handleBack(): void {
         (P12.4-followup-B-fix F6 — without this the page had no
         navigation affordance back to Settings).
       -->
-      <footer class="manage__footer">
-        <div class="manage__footer-hint">
-          <el-icon><InfoFilled /></el-icon>
-          <span>{{ t('manageAccount.footerHint') }}</span>
-        </div>
-        <el-button
-          class="bf-btn-secondary manage__back-btn"
-          data-test="manage-account-back"
-          @click="handleBack"
-        >
-          <el-icon><ArrowLeft /></el-icon>
-          <span>{{ t('Back') }}</span>
-        </el-button>
-      </footer>
+        <footer class="manage__footer">
+          <div class="manage__footer-hint">
+            <el-icon><InfoFilled /></el-icon>
+            <span>{{ t('manageAccount.footerHint') }}</span>
+          </div>
+          <el-button
+            class="bf-btn-secondary manage__back-btn"
+            data-test="manage-account-back"
+            @click="handleBack"
+          >
+            <el-icon><ArrowLeft /></el-icon>
+            <span>{{ t('Back') }}</span>
+          </el-button>
+        </footer>
 
-      <!-- Add / Edit / Recovery dialogs — mounted unconditionally for transitions. -->
-      <AddAccount v-model:visible="addVisible" />
-      <ChangeAccount v-model:visible="editVisible" :account="editTarget" />
-      <AccRecovery v-model:visible="accRecoveryVisible" @restored="handleRestored" />
+        <!-- Add / Edit / Recovery dialogs — mounted unconditionally for transitions. -->
+        <AddAccount v-model:visible="addVisible" />
+        <ChangeAccount v-model:visible="editVisible" :account="editTarget" />
+        <AccRecovery v-model:visible="accRecoveryVisible" @restored="handleRestored" />
+      </div>
     </div>
   </main>
 </template>
 
 <style scoped>
 .manage {
-  box-sizing: border-box;
-  min-height: 100vh;
-  padding: 2.5rem 1.5rem;
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  overflow: hidden;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.55) 0%, rgba(255, 255, 255, 0.45) 100%),
+    radial-gradient(
+      1200px 800px at 10% -10%,
+      color-mix(in srgb, var(--bf-primary-container) 30%, transparent) 0%,
+      transparent 60%
+    ),
+    radial-gradient(
+      900px 700px at 110% 110%,
+      color-mix(in srgb, var(--bf-primary) 22%, transparent) 0%,
+      transparent 55%
+    ),
+    linear-gradient(180deg, #f7f1ec 0%, #ece1d6 100%);
+}
+
+.manage__scroll {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1.5rem;
 }
 
 .manage__container {

--- a/src/pages/QrForm.vue
+++ b/src/pages/QrForm.vue
@@ -251,6 +251,7 @@ onBeforeUnmount(() => {
 
 const bitmap = computed(() => auth.qrChallenge?.bitmap_base64 ?? null)
 const deeplink = computed(() => auth.qrChallenge?.deeplink ?? null)
+const showEnlarged = ref(false)
 const canCopyDeeplink = computed(() => {
   const link = deeplink.value
   return typeof link === 'string' && link.length > 0
@@ -281,6 +282,19 @@ async function copyDeeplink(): Promise<void> {
 
 async function refresh(): Promise<void> {
   await doStart()
+}
+
+async function copyQrImage(): Promise<void> {
+  const src = bitmap.value
+  if (!src) return
+  try {
+    const resp = await fetch(src)
+    const blob = await resp.blob()
+    await navigator.clipboard.write([new ClipboardItem({ [blob.type]: blob })])
+    ElMessage.success(t('loginQr.copyQrSuccess'))
+  } catch {
+    ElMessage.error(t('CopyFailed'))
+  }
 }
 
 async function goBack(): Promise<void> {
@@ -322,13 +336,44 @@ function handleGameStart(): void {
       <div v-else class="qr-form__placeholder" />
     </div>
 
+    <div v-if="bitmap" class="qr-form__qr-actions">
+      <button
+        type="button"
+        class="qr-form__qr-btn"
+        data-testid="qr-enlarge"
+        @click="showEnlarged = true"
+      >
+        <span class="material-symbols-outlined">zoom_in</span>
+        {{ t('loginQr.enlarge') }}
+      </button>
+      <button
+        type="button"
+        class="qr-form__qr-btn"
+        data-testid="qr-copy-image"
+        @click="copyQrImage"
+      >
+        <span class="material-symbols-outlined">content_copy</span>
+        {{ t('loginQr.copyQr') }}
+      </button>
+    </div>
+
+    <!-- Enlarged QR dialog -->
+    <div v-if="showEnlarged" class="qr-form__overlay" @click="showEnlarged = false">
+      <div class="qr-form__enlarged" @click.stop>
+        <img :src="bitmap!" :alt="t('loginQr.title')" class="qr-form__enlarged-img" />
+        <button type="button" class="qr-form__enlarged-close" @click="showEnlarged = false">
+          <span class="material-symbols-outlined">close</span>
+        </button>
+      </div>
+    </div>
+
     <p v-if="connectionLost" class="qr-form__error" data-testid="qr-connection-lost">
       {{ t('loginQr.connectionLost') }}
     </p>
 
     <el-button
       class="qr-form__deeplink"
-      size="large"
+      size="default"
       :disabled="!canCopyDeeplink"
       data-testid="qr-copy-deeplink"
       @click="copyDeeplink"
@@ -337,13 +382,13 @@ function handleGameStart(): void {
     </el-button>
 
     <div class="qr-form__actions">
-      <el-button class="qr-form__back" size="large" data-testid="qr-back" @click="goBack">
+      <el-button class="qr-form__back" size="default" data-testid="qr-back" @click="goBack">
         {{ t('BackRegularLogin') }}
       </el-button>
       <el-button
         class="qr-form__refresh"
         type="primary"
-        size="large"
+        size="default"
         :loading="isStarting"
         data-testid="qr-refresh"
         @click="refresh"
@@ -354,7 +399,7 @@ function handleGameStart(): void {
 
     <el-button
       class="qr-form__game-start"
-      size="large"
+      size="default"
       data-testid="qr-game-start"
       @click="handleGameStart"
     >
@@ -369,6 +414,9 @@ function handleGameStart(): void {
   flex-direction: column;
   gap: 1rem;
   align-items: stretch;
+  box-sizing: border-box;
+  max-width: 100%;
+  overflow: hidden;
 }
 
 .qr-form__header {
@@ -452,5 +500,78 @@ function handleGameStart(): void {
 .qr-form__game-start {
   width: 100%;
   font-weight: 700;
+}
+
+.qr-form__qr-actions {
+  display: flex;
+  justify-content: center;
+  gap: 0.75rem;
+}
+
+.qr-form__qr-btn {
+  appearance: none;
+  background: rgba(255, 255, 255, 0.6);
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 8px;
+  padding: 0.375rem 0.75rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--bf-on-surface-variant, #54443a);
+  transition: background 150ms ease;
+}
+.qr-form__qr-btn .material-symbols-outlined {
+  font-size: 16px;
+}
+.qr-form__qr-btn:hover {
+  background: rgba(255, 255, 255, 0.9);
+}
+
+.qr-form__overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 10000;
+  background: rgba(0, 0, 0, 0.5);
+  display: grid;
+  place-items: center;
+}
+
+.qr-form__enlarged {
+  position: relative;
+  background: #fff;
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+}
+
+.qr-form__enlarged-img {
+  width: 360px;
+  height: 360px;
+  image-rendering: pixelated;
+  display: block;
+}
+
+.qr-form__enlarged-close {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  appearance: none;
+  background: rgba(0, 0, 0, 0.06);
+  border: none;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  color: #333;
+  transition: background 150ms ease;
+}
+.qr-form__enlarged-close:hover {
+  background: rgba(0, 0, 0, 0.12);
 }
 </style>

--- a/src/pages/Settings.vue
+++ b/src/pages/Settings.vue
@@ -132,6 +132,7 @@ import { useGameStore } from '../stores/game'
 import { useUiStore, type AppLocale, type LoginMethodValue, type UpdateChannel } from '../stores/ui'
 import { TOOLS_GAME_CODES } from '../constants/tools'
 import ToolsDialogStack from '../windows/ToolsDialogStack.vue'
+import TitleBar from '../components/TitleBar.vue'
 
 defineOptions({ name: 'SettingsPage' })
 
@@ -614,229 +615,234 @@ onMounted(() => {
 </script>
 
 <template>
-  <main class="settings bf-mica-bg">
-    <div class="settings__container">
-      <!-- Header -->
-      <header class="settings__header">
-        <div class="settings__header-icon" aria-hidden="true">
-          <el-icon :size="24"><SettingIcon /></el-icon>
-        </div>
-        <div class="settings__header-text">
-          <h1 class="settings__title bf-text-gradient">{{ t('Settings') }}</h1>
-          <p class="settings__subline">{{ t('settings.subtitle') }}</p>
-        </div>
-      </header>
-
-      <!-- App section -->
-      <section class="settings__section bf-glass-panel" data-test="settings-app-section">
-        <header class="settings__section-header">
-          <el-icon><User /></el-icon>
-          <span>{{ t('AppName') }}</span>
+  <main class="settings bf-glass-panel" data-window-root>
+    <TitleBar />
+    <div class="settings__scroll">
+      <div class="settings__container">
+        <!-- Header -->
+        <header class="settings__header">
+          <div class="settings__header-icon" aria-hidden="true">
+            <el-icon :size="24"><SettingIcon /></el-icon>
+          </div>
+          <div class="settings__header-text">
+            <h1 class="settings__title bf-text-gradient">{{ t('Settings') }}</h1>
+            <p class="settings__subline">{{ t('settings.subtitle') }}</p>
+          </div>
         </header>
 
-        <div class="settings__grid settings__grid--two-col">
-          <!-- Left column: Manage account + 3 selects -->
-          <div class="settings__col">
-            <div class="settings__row">
-              <el-button
-                class="bf-btn-secondary settings__inline-btn"
-                data-test="settings-manage-account"
-                @click="handleManageAccount"
-              >
-                {{ t('ManageAccount') }}
-              </el-button>
-            </div>
-
-            <div class="settings__row">
-              <label class="settings__label">{{ t('UpdateChannel') }}</label>
-              <el-select
-                :model-value="ui.updateChannel"
-                class="settings__select"
-                data-test="settings-update-channel"
-                @change="handleUpdateChannelChange"
-              >
-                <el-option
-                  v-for="opt in UPDATE_CHANNEL_OPTIONS"
-                  :key="opt.value"
-                  :value="opt.value"
-                  :label="t(opt.labelKey)"
-                />
-              </el-select>
-            </div>
-
-            <div class="settings__row">
-              <label class="settings__label">{{ t('Language') }}</label>
-              <el-select
-                :model-value="ui.language"
-                class="settings__select"
-                data-test="settings-language"
-                @change="handleLanguageChange"
-              >
-                <el-option
-                  v-for="opt in LANGUAGE_OPTIONS"
-                  :key="opt.value"
-                  :value="opt.value"
-                  :label="opt.label"
-                />
-              </el-select>
-            </div>
-
-            <div class="settings__row">
-              <label class="settings__label">{{ t('ThemeColor') }}</label>
-              <div class="settings__theme-row">
-                <el-input
-                  :model-value="ui.themeColor"
-                  class="settings__theme-input"
-                  data-test="settings-theme-input"
-                  @change="handleThemeColorChange"
-                />
-                <el-color-picker
-                  :model-value="ui.themeColor"
-                  data-test="settings-theme-picker"
-                  @change="handleThemeColorChange"
-                />
-              </div>
-            </div>
-
-            <div
-              v-if="showLoginModePanel"
-              class="settings__row"
-              data-test="settings-login-mode-row"
-            >
-              <label class="settings__label">{{ t('LoginMode') }}</label>
-              <el-select
-                :model-value="ui.loginMethod"
-                class="settings__select"
-                data-test="settings-login-mode"
-                @change="handleLoginMethodChange"
-              >
-                <el-option
-                  v-for="opt in LOGIN_METHOD_OPTIONS"
-                  :key="opt.value"
-                  :value="opt.value"
-                  :label="t(opt.labelKey)"
-                />
-              </el-select>
-            </div>
-          </div>
-
-          <!-- Right column: 4 boolean checkboxes (D4) -->
-          <div class="settings__col">
-            <div class="settings__row settings__row--checkbox">
-              <el-checkbox
-                :model-value="ui.askUpdate"
-                data-test="settings-ask-update"
-                @change="(value) => ui.setAskUpdate(Boolean(value))"
-              >
-                {{ t('AutoCheckUpdate') }}
-              </el-checkbox>
-            </div>
-
-            <div class="settings__row settings__row--checkbox">
-              <el-checkbox
-                :model-value="ui.autoStartGame"
-                data-test="settings-auto-start-game"
-                @change="(value) => ui.setAutoStartGame(Boolean(value))"
-              >
-                {{ t('RunAfterLogin') }}
-              </el-checkbox>
-            </div>
-
-            <div class="settings__row settings__row--checkbox">
-              <el-checkbox
-                :model-value="ui.minimizeToTray"
-                data-test="settings-minimize-to-tray"
-                @change="(value) => ui.setMinimizeToTray(Boolean(value))"
-              >
-                {{ t('MinimizeToTaskbar') }}
-              </el-checkbox>
-            </div>
-
-            <div class="settings__row settings__row--checkbox">
-              <el-tooltip placement="right" :content="t('settings.disableHardwareAccelerationTip')">
-                <el-checkbox
-                  :model-value="ui.disableHwAccel"
-                  data-test="settings-disable-hw-accel"
-                  @change="(value) => handleDisableHwAccelChange(Boolean(value))"
-                >
-                  {{ t('DisableHardwareAcceleration') }}
-                </el-checkbox>
-              </el-tooltip>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <!-- Game section (D5) — only when a game is selected (WPF parity: if no game, t_GamePath is empty + the section is uninteractive). -->
-      <section
-        v-if="game.selectedGame"
-        class="settings__section bf-glass-panel"
-        data-test="settings-game-section"
-      >
-        <header class="settings__section-header">
-          <el-icon><Operation /></el-icon>
-          <span>{{ t('Game') }}</span>
-        </header>
-
-        <div class="settings__grid">
-          <div class="settings__row">
-            <label class="settings__label">{{ t('GamePath') }}</label>
-            <el-input
-              :model-value="gamePath"
-              readonly
-              :placeholder="t('settings.gamePathPlaceholder')"
-              class="settings__game-path-input"
-              data-test="settings-game-path"
-              @click="pickGamePath"
-            >
-              <template #suffix>
-                <el-icon class="settings__game-path-icon"><FolderOpened /></el-icon>
-              </template>
-            </el-input>
-          </div>
+        <!-- App section -->
+        <section class="settings__section bf-glass-panel" data-test="settings-app-section">
+          <header class="settings__section-header">
+            <el-icon><User /></el-icon>
+            <span>{{ t('AppName') }}</span>
+          </header>
 
           <div class="settings__grid settings__grid--two-col">
+            <!-- Left column: Manage account + 3 selects -->
+            <div class="settings__col">
+              <div class="settings__row">
+                <el-button
+                  class="bf-btn-secondary settings__inline-btn"
+                  data-test="settings-manage-account"
+                  @click="handleManageAccount"
+                >
+                  {{ t('ManageAccount') }}
+                </el-button>
+              </div>
+
+              <div class="settings__row">
+                <label class="settings__label">{{ t('UpdateChannel') }}</label>
+                <el-select
+                  :model-value="ui.updateChannel"
+                  class="settings__select"
+                  data-test="settings-update-channel"
+                  @change="handleUpdateChannelChange"
+                >
+                  <el-option
+                    v-for="opt in UPDATE_CHANNEL_OPTIONS"
+                    :key="opt.value"
+                    :value="opt.value"
+                    :label="t(opt.labelKey)"
+                  />
+                </el-select>
+              </div>
+
+              <div class="settings__row">
+                <label class="settings__label">{{ t('Language') }}</label>
+                <el-select
+                  :model-value="ui.language"
+                  class="settings__select"
+                  data-test="settings-language"
+                  @change="handleLanguageChange"
+                >
+                  <el-option
+                    v-for="opt in LANGUAGE_OPTIONS"
+                    :key="opt.value"
+                    :value="opt.value"
+                    :label="opt.label"
+                  />
+                </el-select>
+              </div>
+
+              <div class="settings__row">
+                <label class="settings__label">{{ t('ThemeColor') }}</label>
+                <div class="settings__theme-row">
+                  <el-input
+                    :model-value="ui.themeColor"
+                    class="settings__theme-input"
+                    data-test="settings-theme-input"
+                    @change="handleThemeColorChange"
+                  />
+                  <el-color-picker
+                    :model-value="ui.themeColor"
+                    data-test="settings-theme-picker"
+                    @change="handleThemeColorChange"
+                  />
+                </div>
+              </div>
+
+              <div
+                v-if="showLoginModePanel"
+                class="settings__row"
+                data-test="settings-login-mode-row"
+              >
+                <label class="settings__label">{{ t('LoginMode') }}</label>
+                <el-select
+                  :model-value="ui.loginMethod"
+                  class="settings__select"
+                  data-test="settings-login-mode"
+                  @change="handleLoginMethodChange"
+                >
+                  <el-option
+                    v-for="opt in LOGIN_METHOD_OPTIONS"
+                    :key="opt.value"
+                    :value="opt.value"
+                    :label="t(opt.labelKey)"
+                  />
+                </el-select>
+              </div>
+            </div>
+
+            <!-- Right column: 4 boolean checkboxes (D4) -->
             <div class="settings__col">
               <div class="settings__row settings__row--checkbox">
-                <el-tooltip placement="right" :content="t('settings.tradLoginTip')">
-                  <el-checkbox
-                    :model-value="ui.tradLogin"
-                    data-test="settings-trad-login"
-                    @change="(value) => ui.setTradLogin(Boolean(value))"
-                  >
-                    {{ t('TraditionalLoginMode') }}
-                  </el-checkbox>
-                </el-tooltip>
+                <el-checkbox
+                  :model-value="ui.askUpdate"
+                  data-test="settings-ask-update"
+                  @change="(value) => ui.setAskUpdate(Boolean(value))"
+                >
+                  {{ t('AutoCheckUpdate') }}
+                </el-checkbox>
               </div>
 
               <div class="settings__row settings__row--checkbox">
-                <el-tooltip placement="right" :content="t('settings.killPatcherTip')">
+                <el-checkbox
+                  :model-value="ui.autoStartGame"
+                  data-test="settings-auto-start-game"
+                  @change="(value) => ui.setAutoStartGame(Boolean(value))"
+                >
+                  {{ t('RunAfterLogin') }}
+                </el-checkbox>
+              </div>
+
+              <div class="settings__row settings__row--checkbox">
+                <el-checkbox
+                  :model-value="ui.minimizeToTray"
+                  data-test="settings-minimize-to-tray"
+                  @change="(value) => ui.setMinimizeToTray(Boolean(value))"
+                >
+                  {{ t('MinimizeToTaskbar') }}
+                </el-checkbox>
+              </div>
+
+              <div class="settings__row settings__row--checkbox">
+                <el-tooltip
+                  placement="right"
+                  :content="t('settings.disableHardwareAccelerationTip')"
+                >
                   <el-checkbox
-                    :model-value="ui.autoKillPatcher"
-                    data-test="settings-auto-kill-patcher"
-                    @change="(value) => ui.setAutoKillPatcher(Boolean(value))"
+                    :model-value="ui.disableHwAccel"
+                    data-test="settings-disable-hw-accel"
+                    @change="(value) => handleDisableHwAccelChange(Boolean(value))"
                   >
-                    {{ t('KillPatcher') }}
+                    {{ t('DisableHardwareAcceleration') }}
                   </el-checkbox>
                 </el-tooltip>
               </div>
             </div>
+          </div>
+        </section>
 
-            <div class="settings__col">
-              <div class="settings__row settings__row--checkbox">
-                <el-tooltip placement="right" :content="t('settings.skipPlayWindowTip')">
-                  <el-checkbox
-                    :model-value="ui.skipPlayWnd"
-                    data-test="settings-skip-play-wnd"
-                    @change="(value) => ui.setSkipPlayWnd(Boolean(value))"
-                  >
-                    {{ t('SkipPlayWindow') }}
-                  </el-checkbox>
-                </el-tooltip>
+        <!-- Game section (D5) — only when a game is selected (WPF parity: if no game, t_GamePath is empty + the section is uninteractive). -->
+        <section
+          v-if="game.selectedGame"
+          class="settings__section bf-glass-panel"
+          data-test="settings-game-section"
+        >
+          <header class="settings__section-header">
+            <el-icon><Operation /></el-icon>
+            <span>{{ t('Game') }}</span>
+          </header>
+
+          <div class="settings__grid">
+            <div class="settings__row">
+              <label class="settings__label">{{ t('GamePath') }}</label>
+              <el-input
+                :model-value="gamePath"
+                readonly
+                :placeholder="t('settings.gamePathPlaceholder')"
+                class="settings__game-path-input"
+                data-test="settings-game-path"
+                @click="pickGamePath"
+              >
+                <template #suffix>
+                  <el-icon class="settings__game-path-icon"><FolderOpened /></el-icon>
+                </template>
+              </el-input>
+            </div>
+
+            <div class="settings__grid settings__grid--two-col">
+              <div class="settings__col">
+                <div class="settings__row settings__row--checkbox">
+                  <el-tooltip placement="right" :content="t('settings.tradLoginTip')">
+                    <el-checkbox
+                      :model-value="ui.tradLogin"
+                      data-test="settings-trad-login"
+                      @change="(value) => ui.setTradLogin(Boolean(value))"
+                    >
+                      {{ t('TraditionalLoginMode') }}
+                    </el-checkbox>
+                  </el-tooltip>
+                </div>
+
+                <div class="settings__row settings__row--checkbox">
+                  <el-tooltip placement="right" :content="t('settings.killPatcherTip')">
+                    <el-checkbox
+                      :model-value="ui.autoKillPatcher"
+                      data-test="settings-auto-kill-patcher"
+                      @change="(value) => ui.setAutoKillPatcher(Boolean(value))"
+                    >
+                      {{ t('KillPatcher') }}
+                    </el-checkbox>
+                  </el-tooltip>
+                </div>
               </div>
 
-              <div v-if="showToolsButton" class="settings__row" data-test="settings-tools-row">
-                <!--
+              <div class="settings__col">
+                <div class="settings__row settings__row--checkbox">
+                  <el-tooltip placement="right" :content="t('settings.skipPlayWindowTip')">
+                    <el-checkbox
+                      :model-value="ui.skipPlayWnd"
+                      data-test="settings-skip-play-wnd"
+                      @change="(value) => ui.setSkipPlayWnd(Boolean(value))"
+                    >
+                      {{ t('SkipPlayWindow') }}
+                    </el-checkbox>
+                  </el-tooltip>
+                </div>
+
+                <div v-if="showToolsButton" class="settings__row" data-test="settings-tools-row">
+                  <!--
                   P12.5 D7: WPF parity gate — the Tools button is only
                   rendered for the three tools-bearing game codes
                   (`MainWindow.xaml.cs` L621 / L630-633 hides it for
@@ -845,65 +851,82 @@ onMounted(() => {
                   cleanly when the button is absent (mirrors WPF
                   `Visibility.Collapsed` semantics, not `Hidden`).
                 -->
-                <el-button
-                  class="bf-btn-secondary settings__inline-btn"
-                  data-test="settings-tools"
-                  @click="handleTools"
-                >
-                  {{ t('Tools') }}
-                </el-button>
+                  <el-button
+                    class="bf-btn-secondary settings__inline-btn"
+                    data-test="settings-tools"
+                    @click="handleTools"
+                  >
+                    {{ t('Tools') }}
+                  </el-button>
+                </div>
               </div>
             </div>
           </div>
-        </div>
-      </section>
+        </section>
 
-      <!-- Game section empty banner (no selected game) — informational, mirrors WPF's empty t_GamePath fallback semantically. -->
-      <section
-        v-else
-        class="settings__section bf-glass-panel settings__section--empty"
-        data-test="settings-game-section-empty"
-      >
-        <el-icon class="settings__empty-icon" :size="20"><InfoFilled /></el-icon>
-        <p class="settings__empty-text">{{ t('settings.gameSectionEmpty') }}</p>
-      </section>
-
-      <!-- Footer: Back button -->
-      <footer class="settings__footer">
-        <el-button
-          class="bf-btn-secondary settings__back-btn"
-          data-test="settings-back"
-          @click="handleBack"
+        <!-- Game section empty banner (no selected game) — informational, mirrors WPF's empty t_GamePath fallback semantically. -->
+        <section
+          v-else
+          class="settings__section bf-glass-panel settings__section--empty"
+          data-test="settings-game-section-empty"
         >
-          <el-icon><ArrowLeft /></el-icon>
-          <span>{{ t('Back') }}</span>
-        </el-button>
-      </footer>
+          <el-icon class="settings__empty-icon" :size="20"><InfoFilled /></el-icon>
+          <p class="settings__empty-text">{{ t('settings.gameSectionEmpty') }}</p>
+        </section>
 
-      <!-- P12.5 D7: Tools dialog stack — same wrapper component the
+        <!-- Footer: Back button -->
+        <footer class="settings__footer">
+          <el-button
+            class="bf-btn-secondary settings__back-btn"
+            data-test="settings-back"
+            @click="handleBack"
+          >
+            <el-icon><ArrowLeft /></el-icon>
+            <span>{{ t('Back') }}</span>
+          </el-button>
+        </footer>
+
+        <!-- P12.5 D7: Tools dialog stack — same wrapper component the
            AccountList page mounts. See `pages/AccountList.vue`'s
            ToolsDialogStack mount comment + `windows/ToolsDialogStack.vue`
            top docblock for the full design discussion. The wrapper
            mounts unconditionally so its internal dialog mounts can
            play their open transitions on first open; per-dialog
            visibility is owned inside the wrapper. -->
-      <ToolsDialogStack ref="toolsDialogRef" />
+        <ToolsDialogStack ref="toolsDialogRef" />
+      </div>
     </div>
   </main>
 </template>
 
 <style scoped>
 .settings {
-  box-sizing: border-box;
-  min-height: 100vh;
-  padding: 2.5rem 1.5rem;
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  overflow: hidden;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.55) 0%, rgba(255, 255, 255, 0.45) 100%),
+    radial-gradient(
+      1200px 800px at 10% -10%,
+      color-mix(in srgb, var(--bf-primary-container) 30%, transparent) 0%,
+      transparent 60%
+    ),
+    radial-gradient(
+      900px 700px at 110% 110%,
+      color-mix(in srgb, var(--bf-primary) 22%, transparent) 0%,
+      transparent 55%
+    ),
+    linear-gradient(180deg, #f7f1ec 0%, #ece1d6 100%);
+}
+
+.settings__scroll {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1.5rem;
 }
 
 .settings__container {
   width: 100%;
-  max-width: 880px;
   display: flex;
   flex-direction: column;
   gap: 1rem;

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -78,7 +78,20 @@
 import type { RouteRecordRaw, Router } from 'vue-router'
 import { createRouter, createWebHashHistory } from 'vue-router'
 
+import { getCurrentWindow } from '@tauri-apps/api/window'
+import { LogicalSize } from '@tauri-apps/api/dpi'
+
 import { registerSessionExpiredHandler } from '../services/invoke'
+
+/**
+ * Resize the Tauri window to the given logical dimensions.
+ * Exported so individual pages can call it on mount when their
+ * content height differs from the route meta default (e.g.
+ * Settings page without the Game section when unauthenticated).
+ */
+export function resizeWindow(width: number, height: number): void {
+  void getCurrentWindow().setSize(new LogicalSize(width, height))
+}
 
 import LoginPage from '../pages/LoginPage.vue'
 import LoginRegionSelection from '../pages/LoginRegionSelection.vue'
@@ -144,36 +157,73 @@ const loginChildren: RouteRecordRaw[] = [
     path: '',
     name: ROUTE_NAMES.LoginRegion,
     component: LoginRegionSelection,
+    meta: {
+      titleKey: 'titleBar.regionSelection',
+      titleIcon: 'public',
+      windowWidth: 560,
+      windowHeight: 480,
+    },
   },
   {
     path: 'id-pass',
     name: ROUTE_NAMES.LoginIdPass,
     component: IdPassForm,
+    meta: { titleKey: 'titleBar.login', titleIcon: 'login', windowWidth: 560, windowHeight: 520 },
   },
   {
     path: 'qr',
     name: ROUTE_NAMES.LoginQr,
     component: QrForm,
+    meta: {
+      titleKey: 'titleBar.login',
+      titleIcon: 'qr_code_2',
+      windowWidth: 560,
+      windowHeight: 680,
+    },
   },
   {
     path: 'gamepass',
     name: ROUTE_NAMES.LoginGamepass,
     component: GamepassForm,
+    meta: {
+      titleKey: 'titleBar.login',
+      titleIcon: 'verified_user',
+      windowWidth: 560,
+      windowHeight: 460,
+    },
   },
   {
     path: 'totp',
     name: ROUTE_NAMES.LoginTotp,
     component: LoginTotp,
+    meta: {
+      titleKey: 'titleBar.totp',
+      titleIcon: 'encrypted',
+      windowWidth: 520,
+      windowHeight: 380,
+    },
   },
   {
     path: 'wait',
     name: ROUTE_NAMES.LoginWait,
     component: LoginWait,
+    meta: {
+      titleKey: 'titleBar.loginWait',
+      titleIcon: 'login',
+      windowWidth: 480,
+      windowHeight: 360,
+    },
   },
   {
     path: 'verify',
     name: ROUTE_NAMES.LoginVerify,
     component: VerifyPage,
+    meta: {
+      titleKey: 'titleBar.verify',
+      titleIcon: 'shield_lock',
+      windowWidth: 560,
+      windowHeight: 480,
+    },
   },
 ]
 
@@ -198,12 +248,24 @@ export const routes: RouteRecordRaw[] = [
      * (P12.2 D-step) can land the user back on the page they
      * originally targeted.
      */
-    meta: { requiresAuth: true },
+    meta: {
+      requiresAuth: true,
+      titleKey: 'titleBar.accounts',
+      titleIcon: 'sports_esports',
+      windowWidth: 560,
+      windowHeight: 640,
+    },
   },
   {
     path: '/settings',
     name: ROUTE_NAMES.Settings,
     component: SettingsPage,
+    meta: {
+      titleKey: 'titleBar.settings',
+      titleIcon: 'settings',
+      windowWidth: 880,
+      windowHeight: 680,
+    },
     /*
      * P12.4 D6: Settings page is reachable from both the
      * post-login `AccountList` top-bar icon and (per WPF parity
@@ -222,6 +284,7 @@ export const routes: RouteRecordRaw[] = [
     path: '/about',
     name: ROUTE_NAMES.About,
     component: AboutPage,
+    meta: { titleKey: 'titleBar.about', titleIcon: 'info', windowWidth: 560, windowHeight: 680 },
     /*
      * P12.4 D7: same public-route rationale as `/settings` —
      * WPF allowed the About page from both pre-login and
@@ -245,7 +308,13 @@ export const routes: RouteRecordRaw[] = [
      * accounts are session-scoped UX (the page only makes sense for
      * a logged-in user managing the credentials they just used).
      */
-    meta: { requiresAuth: true },
+    meta: {
+      requiresAuth: true,
+      titleKey: 'titleBar.manageAccount',
+      titleIcon: 'manage_accounts',
+      windowWidth: 880,
+      windowHeight: 640,
+    },
   },
   {
     path: '/:pathMatch(.*)*',
@@ -291,6 +360,26 @@ declare module 'vue-router' {
      * `/login` → redirect to `/login` → ...).
      */
     requiresAuth?: boolean
+    /**
+     * i18n key for the custom title bar text. When unset, the
+     * title bar falls back to `t('AppName')`.
+     */
+    titleKey?: string
+    /**
+     * Material Symbols icon name for the custom title bar.
+     * When unset, falls back to `'coffee'`.
+     */
+    titleIcon?: string
+    /**
+     * Desired window width in logical pixels for this route.
+     * The router afterEach hook calls `appWindow.setSize()` when
+     * the value differs from the current route.
+     */
+    windowWidth?: number
+    /**
+     * Desired window height in logical pixels for this route.
+     */
+    windowHeight?: number
   }
 }
 
@@ -388,5 +477,43 @@ export function installRouterGuards(router: Router, deps: RouterGuardDeps): void
       path: '/login',
       query: { sessionExpired: '1' },
     })
+  })
+
+  /*
+   * Auto-fit window size to content. Uses a ResizeObserver on the
+   * `[data-window-root]` element so the window tracks content
+   * height changes (e.g. sections appearing/disappearing, async
+   * data loading). Width comes from route meta.
+   */
+  const appWindow = getCurrentWindow()
+  let currentWidth = 560
+  let observer: ResizeObserver | null = null
+
+  function fitWindow(): void {
+    const root = document.querySelector('[data-window-root]') as HTMLElement | null
+    if (!root) return
+    // Remove height lock to measure natural content height
+    root.style.height = 'auto'
+    const h = Math.max(300, Math.min(Math.ceil(root.scrollHeight), 900))
+    void appWindow.setSize(new LogicalSize(currentWidth, h)).then(() => {
+      // Lock height to viewport so flex scroll areas work
+      root.style.height = '100vh'
+    })
+  }
+
+  function setupObserver(): void {
+    if (observer) observer.disconnect()
+    const root = document.querySelector('[data-window-root]') as HTMLElement | null
+    if (!root) return
+    observer = new ResizeObserver(() => fitWindow())
+    observer.observe(root)
+    fitWindow()
+  }
+
+  router.afterEach((to) => {
+    const w = to.meta.windowWidth as number | undefined
+    if (w) currentWidth = w
+    // Give Vue time to mount the new route component
+    setTimeout(setupObserver, 80)
   })
 }

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,44 @@
+/**
+ * Global test setup — mocks for Tauri APIs that are unavailable
+ * in the jsdom test environment.
+ */
+
+import { vi } from 'vitest'
+import { config } from '@vue/test-utils'
+import { defineComponent, h } from 'vue'
+
+/* Mock @tauri-apps/api/window used by TitleBar.vue */
+vi.mock('@tauri-apps/api/window', () => ({
+  getCurrentWindow: () => ({
+    minimize: vi.fn(),
+    close: vi.fn(),
+    startDragging: vi.fn(),
+    setSize: vi.fn(),
+  }),
+}))
+
+vi.mock('@tauri-apps/api/dpi', () => ({
+  LogicalSize: class LogicalSize {
+    width: number
+    height: number
+    constructor(w: number, h: number) {
+      this.width = w
+      this.height = h
+    }
+  },
+}))
+
+/*
+ * Globally stub TitleBar so page-level tests that mock
+ * element-plus / vue-router don't break on TitleBar's imports.
+ */
+config.global.stubs = {
+  ...config.global.stubs,
+  TitleBar: defineComponent({
+    name: 'TitleBarStub',
+    setup:
+      (_, { slots }) =>
+      () =>
+        h('div', { class: 'bf-titlebar' }, slots.default?.()),
+  }),
+}

--- a/tests/unit/i18n/index.spec.ts
+++ b/tests/unit/i18n/index.spec.ts
@@ -129,9 +129,9 @@ describe('locale assets', () => {
 
   it('merges WPF flat keys with frontend-only nested keys', () => {
     expect(i18nMessages['zh-TW']).toHaveProperty('AppName', '繽放')
-    expect(i18nMessages['zh-TW'].loginShell).toHaveProperty('heading')
+    expect(i18nMessages['zh-TW'].titleBar).toHaveProperty('minimize')
     expect(i18nMessages['en-US']).toHaveProperty('AppName')
-    expect(i18nMessages['en-US'].loginShell).toHaveProperty('heading')
+    expect(i18nMessages['en-US'].titleBar).toHaveProperty('minimize')
   })
 })
 
@@ -139,13 +139,13 @@ describe('createAppI18n', () => {
   it('boots with zh-TW as the default locale and zh-TW messages applied', () => {
     const i18n = createAppI18n()
     expect(i18n.global.locale.value).toBe('zh-TW')
-    expect(i18n.global.t('loginShell.heading')).toBe(i18nMessages['zh-TW'].loginShell.heading)
+    expect(i18n.global.t('titleBar.minimize')).toBe(i18nMessages['zh-TW'].titleBar.minimize)
   })
 
   it('renders zh-CN messages when locale switches', () => {
     const i18n = createAppI18n()
     setLocale(i18n, 'zh-CN')
-    expect(i18n.global.t('loginShell.heading')).toBe(i18nMessages['zh-CN'].loginShell.heading)
+    expect(i18n.global.t('titleBar.minimize')).toBe(i18nMessages['zh-CN'].titleBar.minimize)
   })
 
   it('substitutes positional placeholders ({0}) in WPF-style messages', () => {
@@ -163,9 +163,9 @@ describe('createAppI18n', () => {
 
   it('setLocale switches the rendered language end-to-end', () => {
     const i18n = createAppI18n()
-    expect(i18n.global.t('loginShell.heading')).toBe(i18nMessages['zh-TW'].loginShell.heading)
+    expect(i18n.global.t('titleBar.minimize')).toBe(i18nMessages['zh-TW'].titleBar.minimize)
     setLocale(i18n, 'en-US')
-    expect(i18n.global.t('loginShell.heading')).toBe(i18nMessages['en-US'].loginShell.heading)
+    expect(i18n.global.t('titleBar.minimize')).toBe(i18nMessages['en-US'].titleBar.minimize)
   })
 
   it('zh-CN falls back to zh-TW (NOT en-US) for keys missing in zh-Hans.xaml (WPF parity)', () => {

--- a/tests/unit/i18n/key-usage.spec.ts
+++ b/tests/unit/i18n/key-usage.spec.ts
@@ -217,6 +217,13 @@ const DYNAMIC_KEY_CONSUMERS: readonly DynamicConsumer[] = [
     reason: 'Region tile hint key is read dynamically from TILES[i].hintKey.',
     usedBy: 'src/pages/LoginRegionSelection.vue::TILES',
   },
+  {
+    kind: 'prefix',
+    prefix: 'titleBar.',
+    reason:
+      'Resolved at runtime from route.meta.titleKey in TitleBar.vue (e.g. route meta sets titleKey to "titleBar.regionSelection").',
+    usedBy: 'src/components/TitleBar.vue::titleText computed',
+  },
 ]
 
 function isCoveredByDynamicConsumer(path: string): boolean {

--- a/tests/unit/pages/LoginPage.spec.ts
+++ b/tests/unit/pages/LoginPage.spec.ts
@@ -1,23 +1,21 @@
 /**
  * P12.1 D1 — login shell render guard.
  *
- * Three concerns this spec locks down:
+ * Two concerns this spec locks down:
  *
- * 1. The shell renders the localized brand heading + subline (proves
- *    `loginShell.*` keys flow through and the template binds to them).
- * 2. The shell exposes a `<RouterView />` slot — D2-D8 will rely on
+ * 1. The shell exposes a `<RouterView />` slot — D2-D8 will rely on
  *    this to mount their respective forms.
- * 3. Locale switches re-render the brand text live (proves the shell
- *    isn't accidentally caching the initial translation).
+ * 2. The shell renders a TitleBar component for window chrome.
  */
 
 import { describe, expect, it } from 'vitest'
-import { defineComponent, h, nextTick } from 'vue'
+import { defineComponent, h } from 'vue'
 import { mount } from '@vue/test-utils'
 import { createMemoryHistory, createRouter } from 'vue-router'
+import { createPinia } from 'pinia'
 
 import LoginPage from '../../../src/pages/LoginPage.vue'
-import { createAppI18n, i18nMessages, setLocale } from '../../../src/i18n'
+import { createAppI18n } from '../../../src/i18n'
 
 const ChildStub = defineComponent({
   name: 'ChildStub',
@@ -37,6 +35,7 @@ function mountLoginPage(initialPath = '/login/_test') {
   })
 
   const i18n = createAppI18n()
+  const pinia = createPinia()
 
   return {
     router,
@@ -45,7 +44,7 @@ function mountLoginPage(initialPath = '/login/_test') {
       await router.push(initialPath)
       await router.isReady()
       const wrapper = mount(LoginPage, {
-        global: { plugins: [router, i18n] },
+        global: { plugins: [router, i18n, pinia] },
       })
       return wrapper
     },
@@ -53,16 +52,11 @@ function mountLoginPage(initialPath = '/login/_test') {
 }
 
 describe('LoginPage shell', () => {
-  it('renders the localized brand heading + subline', async () => {
+  it('renders the TitleBar component', async () => {
     const ctx = mountLoginPage()
     const wrapper = await ctx.mount()
 
-    expect(wrapper.find('.login-shell__title').text()).toBe(
-      i18nMessages['zh-TW'].loginShell.heading,
-    )
-    expect(wrapper.find('.login-shell__subline').text()).toBe(
-      i18nMessages['zh-TW'].loginShell.subline,
-    )
+    expect(wrapper.find('.bf-titlebar').exists()).toBe(true)
   })
 
   it('exposes a <RouterView /> slot for child routes', async () => {
@@ -71,24 +65,5 @@ describe('LoginPage shell', () => {
 
     expect(wrapper.find('[data-testid="child"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="child"]').text()).toBe('child route content')
-  })
-
-  it('re-renders brand text after a runtime locale switch', async () => {
-    const ctx = mountLoginPage()
-    const wrapper = await ctx.mount()
-
-    expect(wrapper.find('.login-shell__title').text()).toBe(
-      i18nMessages['zh-TW'].loginShell.heading,
-    )
-
-    setLocale(ctx.i18n, 'en-US')
-    await nextTick()
-
-    expect(wrapper.find('.login-shell__title').text()).toBe(
-      i18nMessages['en-US'].loginShell.heading,
-    )
-    expect(wrapper.find('.login-shell__subline').text()).toBe(
-      i18nMessages['en-US'].loginShell.subline,
-    )
   })
 })

--- a/tests/unit/pages/LoginRegionSelection.spec.ts
+++ b/tests/unit/pages/LoginRegionSelection.spec.ts
@@ -130,7 +130,9 @@ describe('LoginRegionSelection', () => {
     expect(wrapper.find('.region-picker__subline').text()).toBe(
       i18nMessages['zh-TW'].loginRegion.subline,
     )
-    expect(wrapper.find('.region-picker__tip').text()).toBe(i18nMessages['zh-TW'].loginRegion.tip)
+    expect(wrapper.find('.region-picker__tip').text()).toContain(
+      i18nMessages['zh-TW'].loginRegion.tip,
+    )
   })
 
   it('persists "TW" to loginRegion when the Taiwan tile is clicked', async () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
+    setupFiles: ['tests/setup.ts'],
     include: ['tests/unit/**/*.spec.ts'],
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
Replace the OS-provided window decoration with a custom titlebar embedded inside each page's glass-panel, matching the mockup design system. The glass-panel card IS the window — no extra background visible.
<img width="560" height="424" alt="image" src="https://github.com/user-attachments/assets/4d8cb71e-67f8-461e-ba1e-72b314daa8a3" />
<img width="880" height="547" alt="image" src="https://github.com/user-attachments/assets/a0f732b1-2abd-4cf7-914c-24c4dd83baa9" />


## Changes

### Tauri config (`src-tauri/`)
- `decorations: false`, `transparent: true`, `resizable: false`
- Window permissions: `allow-minimize`, `allow-close`, `allow-start-dragging`, `allow-set-size`

### TitleBar component (`src/components/TitleBar.vue`)
- Drag via `startDragging()` API, minimize/close buttons
- Route-aware title + Material Symbols icon from `route.meta`
- Default slot for per-page action buttons

### App shell (`src/App.vue`, `index.html`, `src/main.ts`)
- Material Symbols Outlined font loaded
- Transparent background, disabled text selection + right-click
- Thin custom scrollbar (6px, rounded)
- Element Plus MessageBox glass-style override

### Router (`src/router/index.ts`)
- `RouteMeta` extended: `titleKey`, `titleIcon`, `windowWidth`, `windowHeight`
- `afterEach` hook: auto-resize window via `ResizeObserver` on `[data-window-root]`
- Exported `resizeWindow()` helper

### Pages (LoginPage, AccountList, Settings, About, ManageAccount)
- Glass-panel fills window with mica gradient background baked in
- TitleBar as first child, scroll area below
- LoginPage: region switcher (TW/HK toggle) + settings/about buttons in titlebar
- AccountList: settings/about buttons moved to titlebar (Material Symbols)

### LoginRegionSelection
- Material Symbols `flag` icon, `check_circle`/`info` badges, `tips_and_updates` hint
- Skip picker if region already saved, highlight current region

### QrForm
- Enlarge button (360px overlay dialog) + Copy QR (clipboard API)
- Smaller action buttons (`size="default"`)

### i18n (`src/i18n/messages.ts`)
- Added `titleBar.*` keys (3 locales), `loginQr.enlarge/copyQr/copyQrSuccess`
- Removed dead `loginShell.*`, `accountList.title/subtitle`
- `warnHtmlMessage: false` for AboutText

### Tests

- [X] - Global setup: mocks for `@tauri-apps/api/window`, `@tauri-apps/api/dpi`, TitleBar stub
- [X] - Updated LoginPage, LoginRegionSelection, i18n, key-usage specs
- [X] - All 585 tests pass ✅