### PR TITLE
fix: custom titlebar + glass-panel shell + minimize-to-tray regression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ sync-upstream.ps1
 
 # Project-local task list (Cursor AI)
 Todo.md
+
+#project template
+mockups/

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@
 
 前往 **[最新發行版 (Releases)](https://github.com/pungin/Beanfun/releases/latest)** 下載：
 
-| 版本 | 檔案 | 說明 |
-| --- | --- | --- |
-| **免安裝版** | `Beanfun.exe` | 放至任意全英文路徑的資料夾，直接執行即可。需系統已安裝 WebView2 Runtime。 |
-| **安裝版** | `Beanfun_x.x.x_x64-setup.exe` | 適用於精簡版 Windows 等未預裝 WebView2 的環境，安裝過程會自動安裝 WebView2 Runtime。 |
+| 版本         | 檔案                          | 說明                                                                                 |
+| ------------ | ----------------------------- | ------------------------------------------------------------------------------------ |
+| **免安裝版** | `Beanfun.exe`                 | 放至任意全英文路徑的資料夾，直接執行即可。需系統已安裝 WebView2 Runtime。            |
+| **安裝版**   | `Beanfun_x.x.x_x64-setup.exe` | 適用於精簡版 Windows 等未預裝 WebView2 的環境，安裝過程會自動安裝 WebView2 Runtime。 |
 
 > **⚠ 注意事項說明：**
 >

--- a/README.md
+++ b/README.md
@@ -21,8 +21,12 @@
 
 ### 使用方法 (Usage)
 
-1. 前往 **[最新發行版 (Releases)](https://github.com/pungin/Beanfun/releases/latest)** 下載最新的 `Beanfun.exe`。
-2. 下載後放至任意全英文路徑的資料夾，直接執行即可。
+前往 **[最新發行版 (Releases)](https://github.com/pungin/Beanfun/releases/latest)** 下載：
+
+| 版本 | 檔案 | 說明 |
+| --- | --- | --- |
+| **免安裝版** | `Beanfun.exe` | 放至任意全英文路徑的資料夾，直接執行即可。需系統已安裝 WebView2 Runtime。 |
+| **安裝版** | `Beanfun_x.x.x_x64-setup.exe` | 適用於精簡版 Windows 等未預裝 WebView2 的環境，安裝過程會自動安裝 WebView2 Runtime。 |
 
 > **⚠ 注意事項說明：**
 >

--- a/index.html
+++ b/index.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200"
+      rel="stylesheet"
+    />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Tauri + Vue + Typescript App</title>
   </head>

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,14 +15,15 @@
         "element-plus": "^2.13.7",
         "pinia": "^3.0.4",
         "pinia-plugin-persistedstate": "^4.7.1",
+        "sortablejs": "^1.15.7",
         "vue": "^3.5.13",
         "vue-i18n": "^11.3.2",
-        "vue-router": "^4.6.4",
-        "vuedraggable": "^4.1.0"
+        "vue-router": "^4.6.4"
       },
       "devDependencies": {
         "@tauri-apps/cli": "^2",
         "@types/node": "^25.6.0",
+        "@types/sortablejs": "^1.15.9",
         "@vitejs/plugin-vue": "^5.2.1",
         "@vue/eslint-config-prettier": "^10.2.0",
         "@vue/eslint-config-typescript": "^14.7.0",
@@ -1862,6 +1863,13 @@
       "dependencies": {
         "undici-types": "~7.19.0"
       }
+    },
+    "node_modules/@types/sortablejs": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/@types/sortablejs/-/sortablejs-1.15.9.tgz",
+      "integrity": "sha512-7HP+rZGE2p886PKV9c9OJzLBI6BBJu1O7lJGYnPyG3fS4/duUCcngkNCjsLwIMV+WMqANe3tt4irrXHSIe68OQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/web-bluetooth": {
       "version": "0.0.20",
@@ -4767,9 +4775,9 @@
       }
     },
     "node_modules/sortablejs": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.14.0.tgz",
-      "integrity": "sha512-pBXvQCs5/33fdN1/39pPL0NZF20LeRbLQ5jtnheIPN9JQAaufGjKdWduZn4U7wCtVuzKhmRkI0DFYHYRbB2H1w==",
+      "version": "1.15.7",
+      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.7.tgz",
+      "integrity": "sha512-Kk8wLQPlS+yi1ZEf48a4+fzHa4yxjC30M/Sr2AnQu+f/MPwvvX9XjZ6OWejiz8crBsLwSq8GHqaxaET7u6ux0A==",
       "license": "MIT"
     },
     "node_modules/source-map-js": {
@@ -5485,18 +5493,6 @@
       },
       "peerDependencies": {
         "typescript": ">=5.0.0"
-      }
-    },
-    "node_modules/vuedraggable": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/vuedraggable/-/vuedraggable-4.1.0.tgz",
-      "integrity": "sha512-FU5HCWBmsf20GpP3eudURW3WdWTKIbEIQxh9/8GE806hydR9qZqRRxRE3RjqX7PkuLuMQG/A7n3cfj9rCEchww==",
-      "license": "MIT",
-      "dependencies": {
-        "sortablejs": "1.14.0"
-      },
-      "peerDependencies": {
-        "vue": "^3.0.1"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/package.json
+++ b/package.json
@@ -24,14 +24,15 @@
     "element-plus": "^2.13.7",
     "pinia": "^3.0.4",
     "pinia-plugin-persistedstate": "^4.7.1",
+    "sortablejs": "^1.15.7",
     "vue": "^3.5.13",
     "vue-i18n": "^11.3.2",
-    "vue-router": "^4.6.4",
-    "vuedraggable": "^4.1.0"
+    "vue-router": "^4.6.4"
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2",
     "@types/node": "^25.6.0",
+    "@types/sortablejs": "^1.15.9",
     "@vitejs/plugin-vue": "^5.2.1",
     "@vue/eslint-config-prettier": "^10.2.0",
     "@vue/eslint-config-typescript": "^14.7.0",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -330,7 +330,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "beanfun"
-version = "6.0.0"
+version = "5.9.2"
 dependencies = [
  "aes",
  "anyhow",

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -3,5 +3,13 @@
   "identifier": "default",
   "description": "Capability for the main window",
   "windows": ["main"],
-  "permissions": ["core:default", "opener:default", "dialog:default"]
+  "permissions": [
+    "core:default",
+    "core:window:allow-minimize",
+    "core:window:allow-close",
+    "core:window:allow-start-dragging",
+    "core:window:allow-set-size",
+    "opener:default",
+    "dialog:default"
+  ]
 }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -255,6 +255,13 @@ pub fn build_specta_builder<R: tauri::Runtime>() -> Builder<R> {
         otp::get_otp,
         // system (P10.3 — D1 open_url)
         system::open_url,
+        // system (TitleBar minimize-to-tray bridge)
+        //
+        // Generic over `R: tauri::Runtime` because it takes an
+        // `AppHandle<R>` (to drive the window + tray side effects);
+        // see the `auth::login_gamepass_start` comment for the full
+        // E0401 / runtime-agnostic bindings rationale.
+        system::minimize_main_window::<tauri::Wry>,
         // config (P10.3 — D2)
         config::get_config_value,
         config::get_all_config,
@@ -444,6 +451,8 @@ mod bindings_file_tests {
         "getOtp",
         // --- P10.3 — D1 system ---------------------------------------
         "openUrl",
+        // --- TitleBar minimize-to-tray bridge ------------------------
+        "minimizeMainWindow",
         // --- P10.3 — D2 config ---------------------------------------
         "getConfigValue",
         "getAllConfig",

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -303,6 +303,7 @@ pub fn build_specta_builder<R: tauri::Runtime>() -> Builder<R> {
         // sentinel test) never crosses IPC. Same `tauri::Wry`
         // turbofish rationale applies.
         web_browser::open_member_center_browser::<tauri::Wry>,
+        web_browser::open_gash_recharge_browser::<tauri::Wry>,
     ])
 }
 
@@ -481,6 +482,8 @@ mod bindings_file_tests {
         "openInAppBrowser",
         // --- P12.4-followup-B-fix F9 — Member Center ----------------
         "openMemberCenterBrowser",
+        // --- Gash recharge (WPF bfb_Gash_Click parity) ---------------
+        "openGashRechargeBrowser",
     ];
 
     /// DTO type names the frontend imports from `bindings.ts`.

--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -50,9 +50,12 @@
 
 use serde::Serialize;
 use specta::Type;
+use tauri::{AppHandle, Manager, State};
 
 use crate::commands::error::CommandError;
+use crate::commands::state::AppState;
 use crate::services::system;
+use crate::tray;
 
 /// Compile-time build metadata returned by [`version`].
 ///
@@ -138,6 +141,74 @@ pub async fn ping(message: String) -> Result<String, CommandError> {
 #[specta::specta]
 pub async fn open_url(url: String) -> Result<(), CommandError> {
     system::open_url(&url).await?;
+    Ok(())
+}
+
+/// Minimize the main window, honouring the `minimize_to_tray`
+/// config setting.
+///
+/// Driven by the custom `TitleBar` minimize button in the
+/// frontend. Replaces the legacy `appWindow.minimize()` direct call
+/// because the post-PR-228 borderless + transparent + non-resizable
+/// window no longer reliably produces the `WindowEvent::Resized(0, 0)`
+/// signal Windows used to fire on minimize, which broke the
+/// fallback path in [`crate::tray::handle_minimize_to_tray`].
+///
+/// Behaviour:
+///
+/// - If `minimize_to_tray = true` in `Config.xml` **and** the tray
+///   icon was created successfully at boot — hide the window and
+///   reveal the tray icon (delegated to [`tray::hide_to_tray`] so
+///   the side effect stays single-sourced with the window-event
+///   fallback path).
+/// - Otherwise — fall through to a normal `window.minimize()`.
+///
+/// # Errors
+///
+/// - `system.window_not_found` — the `main` webview window is not
+///   currently registered with the app handle. Should never happen
+///   in steady state (the window is created at boot).
+/// - `system.minimize_failed` — Tauri's `window.minimize()` returned
+///   an error from the underlying OS call.
+#[tauri::command]
+#[specta::specta]
+pub async fn minimize_main_window<R: tauri::Runtime>(
+    app_handle: AppHandle<R>,
+    state: State<'_, AppState>,
+    tray_state: State<'_, tray::TrayState>,
+) -> Result<(), CommandError> {
+    let storage_root = state.storage_root.clone();
+    let should_tray = tray::is_minimize_to_tray_enabled(&storage_root).await;
+
+    if should_tray {
+        // Snapshot the ID under the lock then drop the guard before
+        // any further work — keeps the critical section to a memcpy.
+        let tray_id = tray_state.0.lock().unwrap().clone();
+        if let Some(tray_id) = tray_id {
+            tray::hide_to_tray(&app_handle, &tray_id);
+            return Ok(());
+        }
+        // Tray creation failed at boot (logged there). Fall through
+        // to a normal minimize so the button still does *something*
+        // useful instead of becoming a silent no-op.
+        tracing::warn!(
+            step = "Tray.MinimizeFallthrough",
+            "minimize_to_tray=true but tray icon unavailable; minimizing normally"
+        );
+    }
+
+    let win = app_handle.get_webview_window("main").ok_or_else(|| {
+        CommandError::new(
+            "system.window_not_found",
+            "main webview window is not currently registered",
+        )
+    })?;
+    win.minimize().map_err(|err| {
+        CommandError::new(
+            "system.minimize_failed",
+            format!("failed to minimize main window: {err}"),
+        )
+    })?;
     Ok(())
 }
 

--- a/src-tauri/src/commands/web_browser.rs
+++ b/src-tauri/src/commands/web_browser.rs
@@ -592,6 +592,58 @@ pub async fn open_member_center_browser<R: tauri::Runtime>(
     open_url_in_webview(&app, target_url, Some(client)).await
 }
 
+/// Build the WPF-equivalent Gash recharge URL for the given session.
+/// Mirrors WPF `Pages/AccountList.xaml.cs::bfb_Gash_Click`:
+///
+/// ```text
+/// TW: https://tw.beanfun.com/TW/auth.aspx?channel=gash
+///       &page_and_query=default.aspx%3Fservice_code%3D999999%26service_region%3DT0
+///       &web_token={WebToken}
+/// HK: https://bfweb.hk.beanfun.com/HK/auth.aspx?channel=gash
+///       &page_and_query=default.aspx%3Fservice_code%3D999999%26service_region%3DT0
+///       &web_token={WebToken}
+/// ```
+///
+/// Both regions share the same `page_and_query` (unlike Member Center
+/// where TW uses `index_new.aspx`). The only difference is the base
+/// host (`tw.beanfun.com` vs `bfweb.hk.beanfun.com`).
+fn build_gash_recharge_url(session: &Session) -> String {
+    let base = match session.region {
+        LoginRegion::TW => "https://tw.beanfun.com/TW/",
+        LoginRegion::HK => "https://bfweb.hk.beanfun.com/HK/",
+    };
+    format!(
+        "{base}auth.aspx?channel=gash&page_and_query=default.aspx%3Fservice_code%3D999999%26service_region%3DT0&web_token={}",
+        session.web_token
+    )
+}
+
+/// Open the Beanfun **Gash recharge** page in a dedicated in-app
+/// webview window. Mirrors WPF
+/// `Pages/AccountList.xaml.cs::bfb_Gash_Click`.
+///
+/// Same security rationale as [`open_member_center_browser`] — the
+/// URL embeds `web_token`, so it must be built backend-side to keep
+/// the secret confined to Rust.
+///
+/// # Errors
+///
+/// - `auth.session_required` — no active session.
+/// - [`INVALID_URL_CODE`] — `build_gash_recharge_url` produced a
+///   URL outside the allowlist (defensive — should be unreachable).
+/// - `ui.window_create_failed` — see [`open_url_in_webview`].
+#[tauri::command]
+#[specta::specta]
+pub async fn open_gash_recharge_browser<R: tauri::Runtime>(
+    app: AppHandle<R>,
+    state: State<'_, AppState>,
+) -> Result<(), CommandError> {
+    let (client, session) = require_auth(state.inner()).await?;
+    let url_str = build_gash_recharge_url(&session);
+    let target_url = parse_and_validate(&url_str)?;
+    open_url_in_webview(&app, target_url, Some(client)).await
+}
+
 #[cfg(test)]
 mod tests {
     //! Pure-helper tests. The full IPC path through
@@ -800,6 +852,50 @@ mod tests {
         let url = build_member_center_url(&session);
         assert!(
             url.contains("web_token=VERY_DISTINCT_TOKEN_VALUE_42"),
+            "URL must embed the session's actual web_token; got: {url}"
+        );
+        assert!(
+            !url.contains("web_token=&") && !url.ends_with("web_token="),
+            "URL must not contain an empty web_token query value; got: {url}"
+        );
+    }
+
+    #[test]
+    fn build_gash_recharge_url_tw_mirrors_wpf_byte_for_byte() {
+        let session = sample_session(LoginRegion::TW, "WTOKEN_TW_GASH");
+        let url = build_gash_recharge_url(&session);
+        assert_eq!(
+            url,
+            "https://tw.beanfun.com/TW/auth.aspx?channel=gash&page_and_query=default.aspx%3Fservice_code%3D999999%26service_region%3DT0&web_token=WTOKEN_TW_GASH"
+        );
+    }
+
+    #[test]
+    fn build_gash_recharge_url_hk_mirrors_wpf_byte_for_byte() {
+        let session = sample_session(LoginRegion::HK, "WTOKEN_HK_GASH");
+        let url = build_gash_recharge_url(&session);
+        assert_eq!(
+            url,
+            "https://bfweb.hk.beanfun.com/HK/auth.aspx?channel=gash&page_and_query=default.aspx%3Fservice_code%3D999999%26service_region%3DT0&web_token=WTOKEN_HK_GASH"
+        );
+    }
+
+    #[test]
+    fn build_gash_recharge_url_passes_allowlist_for_both_regions() {
+        for region in [LoginRegion::TW, LoginRegion::HK] {
+            let session = sample_session(region, "WTOKEN_GASH_PARSE_OK");
+            let url = build_gash_recharge_url(&session);
+            parse_and_validate(&url)
+                .unwrap_or_else(|e| panic!("region {region:?} URL must validate: {e:?}"));
+        }
+    }
+
+    #[test]
+    fn build_gash_recharge_url_embeds_web_token_verbatim() {
+        let session = sample_session(LoginRegion::TW, "DISTINCT_GASH_TOKEN_99");
+        let url = build_gash_recharge_url(&session);
+        assert!(
+            url.contains("web_token=DISTINCT_GASH_TOKEN_99"),
             "URL must embed the session's actual web_token; got: {url}"
         );
         assert!(

--- a/src-tauri/src/commands/web_browser.rs
+++ b/src-tauri/src/commands/web_browser.rs
@@ -832,7 +832,7 @@ mod tests {
         // must pass `is_allowed_host`. Sourced from:
         // - `src/constants/login.ts::LOGIN_EXTERNAL_URLS`
         //   (RegisterAccount / ForgotPassword in IdPassForm)
-        // - `src/windows/MapleTools.vue` (PLAYER_REPORT_URL)
+        // - `src/windows/MapleTools.vue` (PLAYER_REPORT_URL, VIDEO_REPORT_URL)
         // - `src/windows/KartTools.vue` (KART_TOOLS_ACTIONS)
         for url in [
             "https://tw.beanfun.com/TW/signup/Join_beanfun_signup.aspx",
@@ -840,6 +840,7 @@ mod tests {
             "https://tw.beanfun.com/member/forgot_pwd.aspx",
             "https://hk.beanfun.com/member/forgot_pwd.aspx",
             "https://event.beanfun.com/customerservice/PluginReporting/PlayerReport.aspx",
+            "https://beanfun-event.beanfun.com/EventAD_Mobile/EventAD?eventAdId=3453",
             "https://tw.beanfun.com/KartRider/guild/maneger_data.aspx",
             "https://tw.beanfun.com/kartrider/guild/rank.aspx",
             "https://tw.beanfun.com/KartRider/guild/rank_team_in.aspx",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -309,17 +309,24 @@ pub fn run() {
     let invoke_handler = specta_builder.invoke_handler();
 
     let storage_root_for_tray = app_state.storage_root.clone();
-    let tray_state = std::sync::Arc::new(std::sync::Mutex::new(None::<tauri::tray::TrayIconId>));
-    let tray_state_for_event = tray_state.clone();
+    let tray_state_arc =
+        std::sync::Arc::new(std::sync::Mutex::new(None::<tauri::tray::TrayIconId>));
+    let tray_state_for_setup = tray_state_arc.clone();
+    let tray_state_for_event = tray_state_arc.clone();
 
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
         .manage(app_state)
+        // Tauri-managed handle to the tray ID so commands (e.g.
+        // `system::minimize_main_window`) can drive the tray without
+        // re-discovering the ID. Same `Arc` the setup / window-event
+        // closures hold — single source of truth.
+        .manage(tray::TrayState(tray_state_arc))
         .invoke_handler(invoke_handler)
         .setup(move |app| {
             if let Some(tray_id) = tray::build_tray(app) {
-                *tray_state.lock().unwrap() = Some(tray_id);
+                *tray_state_for_setup.lock().unwrap() = Some(tray_id);
             }
             Ok(())
         })

--- a/src-tauri/src/services/beanfun/account.rs
+++ b/src-tauri/src/services/beanfun/account.rs
@@ -148,7 +148,7 @@ use crate::core::time::dt_compact_now;
 
 use super::client::{BeanfunClient, LoginRegion};
 use super::error::LoginError;
-use super::login::ensure_success;
+use super::login::{ensure_success, read_bfwebtoken_from_jar};
 use super::session::Session;
 
 // -----------------------------------------------------------------------------
@@ -276,6 +276,13 @@ pub async fn get_accounts(
     auth_aspx(client, session, service_code, service_region).await?;
     let body = fetch_account_list_html(client, service_code, service_region).await?;
 
+    tracing::debug!(
+        service_code,
+        service_region,
+        body_len = body.len(),
+        "get_accounts: fetched account list HTML"
+    );
+
     let mut accounts: Vec<ServiceAccount> = Vec::new();
     for row in extract_service_accounts(&body) {
         let screatetime = get_create_time(client, service_code, service_region, &row.ssn).await;
@@ -296,6 +303,23 @@ pub async fn get_accounts(
     accounts.sort_by(|a, b| a.ssn.cmp(&b.ssn));
 
     let amount_limit_notice = classify_amount_limit_notice(&body);
+
+    tracing::debug!(
+        service_code,
+        service_region,
+        account_count = accounts.len(),
+        "get_accounts: parsed result"
+    );
+
+    if accounts.is_empty() {
+        tracing::warn!(
+            service_code,
+            service_region,
+            body_len = body.len(),
+            body_preview = &body[..body.len().min(500)],
+            "get_accounts: returned 0 accounts — possible stale cookie issue"
+        );
+    }
 
     Ok(AccountListResult {
         accounts,
@@ -568,17 +592,48 @@ async fn auth_aspx(
     // URL; reqwest's `.query()` URL-encodes it for us, producing the
     // exact `%3F` / `%3D` byte sequence WPF builds inline.
     let inner = format!("game_start.aspx?service_code_and_region={service_code}_{service_region}");
+
+    // Prefer the live bfWebToken cookie from the jar over the static
+    // snapshot stored at login time. The auth.aspx redirect chain for
+    // certain games may update the bfWebToken cookie; using the stale
+    // session value afterward causes the server to return an empty
+    // account page on the next game switch.
+    let live_token = read_bfwebtoken_from_jar(client);
+    let web_token = live_token.as_deref().unwrap_or(session.web_token.as_str());
+
+    let jar_before = read_bfwebtoken_from_jar(client);
+    tracing::debug!(
+        service_code,
+        service_region,
+        session_web_token = session.web_token.as_str(),
+        jar_web_token = ?jar_before,
+        used_web_token = web_token,
+        "auth_aspx: before request"
+    );
+
     let resp = client
         .http()
         .get(url)
         .query(&[
             ("channel", "game_zone"),
             ("page_and_query", inner.as_str()),
-            ("web_token", session.web_token.as_str()),
+            ("web_token", web_token),
         ])
         .send()
         .await?;
     ensure_success(&resp, "auth.aspx")?;
+
+    let jar_after = read_bfwebtoken_from_jar(client);
+    if jar_before != jar_after {
+        tracing::warn!(
+            service_code,
+            service_region,
+            before = ?jar_before,
+            after = ?jar_after,
+            "auth_aspx: bfWebToken cookie changed during request"
+        );
+    }
+
     // Body intentionally not consumed: WPF discards it too.
     Ok(())
 }

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -5,28 +5,91 @@
 //! checkbox is checked, the window hides and the tray icon appears.
 //! Left-clicking the tray icon restores the window and hides the icon.
 //!
-//! Tauri v2 has no dedicated `WindowEvent::Minimized` variant. On
-//! Windows the OS fires `Resized(0, 0)` when a window is minimized,
-//! so we detect that as the minimize signal.
+//! # Two entry points into "hide to tray"
+//!
+//! 1. **Frontend command** ([`crate::commands::system::minimize_main_window`])
+//!    — primary path. The custom `TitleBar` minimize button calls
+//!    this command, which reads the `minimize_to_tray` config and
+//!    either hides+shows-tray or falls through to a normal
+//!    `window.minimize()`. This path is reliable regardless of
+//!    `decorations` / `transparent` / `resizable` settings.
+//! 2. **Window event listener** ([`handle_minimize_to_tray`]) —
+//!    defensive fallback. Tauri v2 has no dedicated
+//!    `WindowEvent::Minimized` variant; on Windows the OS *usually*
+//!    fires `Resized(0, 0)` when a window is minimized, but this
+//!    signal is unreliable for borderless / transparent windows
+//!    (the reason path 1 was added). Kept so any external trigger
+//!    that does end up minimizing the window (e.g., taskbar
+//!    interaction) still respects the config.
 
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
 
-use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
-use tauri::{App, Manager, PhysicalSize, WindowEvent, Wry};
+use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent, TrayIconId};
+use tauri::{App, AppHandle, Manager, PhysicalSize, WindowEvent, Wry};
 
 use crate::services::config;
 
 const CONFIG_FILE_NAME: &str = "Config.xml";
 const MINIMIZE_TO_TRAY_KEY: &str = "minimize_to_tray";
 
+/// Tauri-managed handle to the tray icon ID.
+///
+/// Wraps the same `Arc<Mutex<Option<TrayIconId>>>` the boot path in
+/// [`crate::run`] hands to the `setup` and `on_window_event`
+/// closures, so commands that need to drive the tray (e.g.
+/// [`crate::commands::system::minimize_main_window`]) can reach the
+/// ID via `State<'_, TrayState>` without re-discovering it from the
+/// `AppHandle`.
+///
+/// `Option<TrayIconId>` because tray creation is allowed to fail
+/// non-fatally — see [`build_tray`].
+pub struct TrayState(pub Arc<Mutex<Option<TrayIconId>>>);
+
 fn config_xml_path(storage_root: &Path) -> PathBuf {
     storage_root.join(CONFIG_FILE_NAME)
 }
 
-async fn is_minimize_to_tray_enabled(storage_root: &Path) -> bool {
+/// Read the `minimize_to_tray` checkbox state from `Config.xml`.
+///
+/// `pub(crate)` so command-layer code (e.g.
+/// [`crate::commands::system::minimize_main_window`]) shares the
+/// same parsing logic as the window-event fallback path
+/// ([`handle_minimize_to_tray`]).
+pub(crate) async fn is_minimize_to_tray_enabled(storage_root: &Path) -> bool {
     let path = config_xml_path(storage_root);
     let val = config::get_value(&path, MINIMIZE_TO_TRAY_KEY).await;
     val.eq_ignore_ascii_case("true")
+}
+
+/// Hide the main window and reveal the tray icon — the actual
+/// "minimize to tray" side effect.
+///
+/// Extracted from [`handle_minimize_to_tray`] so the new
+/// command-driven entry point (driven by the custom TitleBar
+/// minimize button) and the legacy window-event fallback share one
+/// implementation. `pub(crate)` because the command layer is the
+/// only external caller; UI / domain code never touches this
+/// directly.
+///
+/// Generic over `R: tauri::Runtime` so the
+/// [`crate::commands::system::minimize_main_window`] command can
+/// stay generic too — `tauri-specta`'s `collect_commands!` macro
+/// requires every command's `AppHandle` parameter to be generic
+/// even though production only ever instantiates the builder with
+/// [`Wry`]. See the `auth::login_gamepass_start` doc comment for
+/// the full rationale.
+pub(crate) fn hide_to_tray<R: tauri::Runtime>(app_handle: &AppHandle<R>, tray_id: &TrayIconId) {
+    if let Some(win) = app_handle.get_webview_window("main") {
+        let _ = win.hide();
+    }
+    if let Some(tray) = app_handle.tray_by_id(tray_id) {
+        let _ = tray.set_visible(true);
+    }
+    tracing::info!(
+        step = "Tray.MinimizedToTray",
+        "main window hidden, tray icon shown"
+    );
 }
 
 /// Build the tray icon and register the left-click restore handler.
@@ -34,7 +97,7 @@ async fn is_minimize_to_tray_enabled(storage_root: &Path) -> bool {
 /// side (which must go on `tauri::Builder`, not on `AppHandle`).
 ///
 /// Returns `None` if tray creation fails (logged, non-fatal).
-pub fn build_tray(app: &App<Wry>) -> Option<tauri::tray::TrayIconId> {
+pub fn build_tray(app: &App<Wry>) -> Option<TrayIconId> {
     let tray: tauri::tray::TrayIcon<Wry> = match TrayIconBuilder::new()
         .icon(
             app.default_window_icon()
@@ -83,10 +146,19 @@ pub fn build_tray(app: &App<Wry>) -> Option<tauri::tray::TrayIconId> {
 }
 
 /// Handle `WindowEvent::Resized(0, 0)` — the Windows signal for
-/// minimize. Checks config, hides window, shows tray icon.
+/// minimize on a decorated window. Checks config, hides window,
+/// shows tray icon.
+///
+/// **Defensive fallback**: with the post-PR-228 borderless +
+/// transparent + non-resizable window config, Windows no longer
+/// reliably fires `Resized(0, 0)` for `window.minimize()` calls,
+/// which is why
+/// [`crate::commands::system::minimize_main_window`] is the primary
+/// path now. This listener stays so that any *other* trigger that
+/// does end up minimizing the window still respects the config.
 pub fn handle_minimize_to_tray(
-    app_handle: tauri::AppHandle<Wry>,
-    tray_id: tauri::tray::TrayIconId,
+    app_handle: AppHandle<Wry>,
+    tray_id: TrayIconId,
     storage_root: PathBuf,
     event: &WindowEvent,
 ) {
@@ -99,16 +171,7 @@ pub fn handle_minimize_to_tray(
             if !is_minimize_to_tray_enabled(&storage_root).await {
                 return;
             }
-            if let Some(win) = app_handle.get_webview_window("main") {
-                let _ = win.hide();
-            }
-            if let Some(tray) = app_handle.tray_by_id(&tray_id) {
-                let _ = tray.set_visible(true);
-            }
-            tracing::info!(
-                step = "Tray.MinimizedToTray",
-                "main window hidden, tray icon shown"
-            );
+            hide_to_tray(&app_handle, &tray_id);
         });
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -13,8 +13,11 @@
     "windows": [
       {
         "title": "Beanfun",
-        "width": 720,
-        "height": 720
+        "width": 560,
+        "height": 480,
+        "decorations": false,
+        "transparent": true,
+        "resizable": false
       }
     ],
     "security": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -23,7 +23,12 @@
   },
   "bundle": {
     "active": true,
-    "targets": [],
+    "targets": ["nsis"],
+    "windows": {
+      "webviewInstallMode": {
+        "type": "embedBootstrapper"
+      }
+    },
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/src-tauri/tests/storage_users_dat.rs
+++ b/src-tauri/tests/storage_users_dat.rs
@@ -32,13 +32,23 @@ use beanfun_lib::services::storage::{
 use tempfile::TempDir;
 
 /// Parent registry path under which every test sub-key is created.
-/// Best-effort cleaned up in `RegistryScope::drop` once its last
-/// child has been removed.
+///
+/// Intentionally **not** deleted in `RegistryScope::drop`: doing so
+/// races with concurrent tests (cargo test runs test fns in parallel
+/// by default), producing
+/// `ERROR_KEY_DELETED (1018, "Illegal operation attempted on a registry
+/// key that has been marked for deletion.")` when test B opens a
+/// child under PARENT while test A's Drop is in the middle of
+/// deleting the (empty) PARENT. An orphaned empty parent key in
+/// `HKCU\SOFTWARE\BEANFUN_NEXT_TEST` is harmless — it's sandboxed
+/// under a test-only prefix and every future test run recreates its
+/// own unique sub-key under it (which is recursively cleaned on
+/// drop).
 const TEST_REGISTRY_PARENT: &str = "SOFTWARE\\BEANFUN_NEXT_TEST";
 
 /// Per-test registry isolation guard. Allocates a unique sub-key
-/// under `SOFTWARE\BEANFUN_NEXT_TEST\users_<name>_<pid>` and best-
-/// effort deletes it (and the empty parent) on drop.
+/// under `SOFTWARE\BEANFUN_NEXT_TEST\users_<name>_<pid>` and
+/// recursively deletes that sub-key on drop.
 struct RegistryScope {
     subkey: String,
 }
@@ -57,7 +67,6 @@ impl RegistryScope {
 impl Drop for RegistryScope {
     fn drop(&mut self) {
         let _ = delete_subkey(&self.subkey);
-        let _ = delete_subkey_non_recursive(TEST_REGISTRY_PARENT);
     }
 }
 
@@ -66,13 +75,6 @@ fn delete_subkey(path: &str) -> std::io::Result<()> {
     use winreg::RegKey;
     let hkcu = RegKey::predef(HKEY_CURRENT_USER);
     hkcu.delete_subkey_all(path)
-}
-
-fn delete_subkey_non_recursive(path: &str) -> std::io::Result<()> {
-    use winreg::enums::HKEY_CURRENT_USER;
-    use winreg::RegKey;
-    let hkcu = RegKey::predef(HKEY_CURRENT_USER);
-    hkcu.delete_subkey(path)
 }
 
 fn sample_records() -> Records {

--- a/src/App.vue
+++ b/src/App.vue
@@ -116,7 +116,7 @@ onMounted(async () => {
   font-size: 14px;
   line-height: 1.5;
   color: #1f2329;
-  background-color: #f5f6f8;
+  background-color: transparent;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -132,5 +132,82 @@ body,
   padding: 0;
   height: 100%;
   width: 100%;
+  overflow: hidden;
+  background: transparent;
+}
+
+/* ---- Native app feel: no text selection, no right-click menu ---- */
+body {
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+/* Allow selection inside actual input / textarea elements */
+input,
+textarea,
+[contenteditable='true'] {
+  -webkit-user-select: text;
+  user-select: text;
+}
+
+/* ---- Scrollbar — thin, rounded, matches mockup design system ---- */
+::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+::-webkit-scrollbar-thumb {
+  background-color: rgba(0, 0, 0, 0.15);
+  border-radius: 3px;
+}
+::-webkit-scrollbar-thumb:hover {
+  background-color: rgba(0, 0, 0, 0.3);
+}
+
+/* ---- Element Plus MessageBox — glass-style override ---- */
+.el-overlay {
+  background: rgba(0, 0, 0, 0.35) !important;
+  backdrop-filter: blur(4px);
+}
+
+.el-message-box {
+  border-radius: var(--bf-radius-panel, 12px) !important;
+  border: 1px solid rgba(255, 255, 255, 0.6) !important;
+  box-shadow:
+    0 20px 48px rgba(0, 0, 0, 0.18),
+    0 4px 12px rgba(0, 0, 0, 0.1) !important;
+  padding: 1.25rem !important;
+}
+
+.el-message-box__header {
+  padding: 0 0 0.75rem !important;
+}
+
+.el-message-box__title {
+  font-size: 1rem !important;
+  font-weight: 700 !important;
+}
+
+.el-message-box__content {
+  padding: 0 !important;
+  font-size: 0.875rem !important;
+}
+
+.el-message-box__btns {
+  padding: 1rem 0 0 !important;
+}
+
+.el-message-box__btns .el-button--primary {
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--bf-primary-container, #ff8201) 85%, white 15%),
+    color-mix(in srgb, var(--bf-primary, #954a00) 92%, black 8%)
+  ) !important;
+  border-color: color-mix(in srgb, var(--bf-primary, #954a00) 50%, transparent) !important;
+  color: var(--bf-on-primary, #fff) !important;
+  border-radius: var(--bf-radius-button, 8px) !important;
+  font-weight: 600 !important;
 }
 </style>

--- a/src/components/TitleBar.vue
+++ b/src/components/TitleBar.vue
@@ -3,6 +3,7 @@ import { computed } from 'vue'
 import { useRoute } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { getCurrentWindow } from '@tauri-apps/api/window'
+import { commands } from '../types/bindings'
 
 const route = useRoute()
 const { t } = useI18n()
@@ -24,8 +25,18 @@ function handleDrag(e: MouseEvent): void {
   }
 }
 
-function handleMinimize(): void {
-  appWindow.minimize()
+async function handleMinimize(): Promise<void> {
+  // Delegate to backend so the `minimize_to_tray` config is honoured.
+  // The legacy `appWindow.minimize()` direct call no longer works for
+  // the post-PR-228 borderless+transparent window because Windows
+  // stops emitting the `Resized(0, 0)` signal `tray::handle_minimize_to_tray`
+  // listens for. The new command checks the config and either
+  // hides+shows-tray or falls through to a plain minimize.
+  const result = await commands.minimizeMainWindow()
+  if (result.status === 'error') {
+    console.error('[TitleBar] minimize_main_window failed:', result.error)
+    appWindow.minimize()
+  }
 }
 
 function handleClose(): void {

--- a/src/components/TitleBar.vue
+++ b/src/components/TitleBar.vue
@@ -1,0 +1,131 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useRoute } from 'vue-router'
+import { useI18n } from 'vue-i18n'
+import { getCurrentWindow } from '@tauri-apps/api/window'
+
+const route = useRoute()
+const { t } = useI18n()
+const appWindow = getCurrentWindow()
+
+const titleText = computed(() => {
+  const key = route.meta.titleKey as string | undefined
+  return key ? t(key) : t('AppName')
+})
+
+const titleIcon = computed(() => {
+  return (route.meta.titleIcon as string | undefined) ?? 'coffee'
+})
+
+function handleDrag(e: MouseEvent): void {
+  if (e.buttons === 1) {
+    e.preventDefault()
+    appWindow.startDragging()
+  }
+}
+
+function handleMinimize(): void {
+  appWindow.minimize()
+}
+
+function handleClose(): void {
+  appWindow.close()
+}
+</script>
+
+<template>
+  <div class="bf-titlebar" @mousedown="handleDrag">
+    <div class="bf-titlebar__left">
+      <span class="material-symbols-outlined bf-titlebar__icon">{{ titleIcon }}</span>
+      <span class="bf-titlebar__title">{{ titleText }}</span>
+    </div>
+    <div class="bf-titlebar__right">
+      <div v-if="$slots.default" class="bf-titlebar__actions" @mousedown.stop>
+        <slot />
+      </div>
+      <button
+        type="button"
+        class="bf-titlebar__btn"
+        :title="t('titleBar.minimize')"
+        @mousedown.stop
+        @click="handleMinimize"
+      >
+        <span class="material-symbols-outlined">minimize</span>
+      </button>
+      <button
+        type="button"
+        class="bf-titlebar__btn bf-titlebar__btn--close"
+        :title="t('titleBar.close')"
+        @mousedown.stop
+        @click="handleClose"
+      >
+        <span class="material-symbols-outlined">close</span>
+      </button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.bf-titlebar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 40px;
+  padding: 0 0.375rem 0 1rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.4);
+  user-select: none;
+  cursor: default;
+  flex-shrink: 0;
+}
+.bf-titlebar__left {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  pointer-events: none;
+}
+.bf-titlebar__icon {
+  font-size: 20px;
+  color: var(--bf-primary-container, #ff8201);
+}
+.bf-titlebar__title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--bf-on-surface, #221a11);
+}
+.bf-titlebar__right {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+.bf-titlebar__actions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  margin-right: 4px;
+}
+.bf-titlebar__btn {
+  appearance: none;
+  background: transparent;
+  border: none;
+  width: 32px;
+  height: 32px;
+  display: grid;
+  place-items: center;
+  border-radius: 6px;
+  cursor: pointer;
+  color: var(--bf-on-surface, #221a11);
+  transition: background 150ms ease;
+  font: inherit;
+  padding: 0;
+}
+.bf-titlebar__btn .material-symbols-outlined {
+  font-size: 18px;
+}
+.bf-titlebar__btn:hover {
+  background: rgba(0, 0, 0, 0.06);
+}
+.bf-titlebar__btn--close:hover {
+  background: rgba(220, 38, 38, 0.8);
+  color: #fff;
+}
+</style>

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -105,6 +105,7 @@ export function createAppI18n() {
     messages: i18nMessages,
     missingWarn: isDev,
     fallbackWarn: isDev,
+    warnHtmlMessage: false,
   })
 }
 

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -259,9 +259,18 @@ type KeysMatch<T, U> = keyof T extends keyof U ? (keyof U extends keyof T ? unkn
 /* -------- zh-TW (canonical / authoritative source) -------- */
 
 const zhTW = {
-  loginShell: {
-    heading: '繽放',
-    subline: '歡迎登入',
+  titleBar: {
+    minimize: '最小化',
+    close: '關閉',
+    regionSelection: '選擇登入地區',
+    login: '登入',
+    totp: '雙重驗證',
+    loginWait: '登入中',
+    verify: '進階驗證',
+    accounts: '遊戲帳號',
+    settings: '設定',
+    about: '關於 beanfun! Next',
+    manageAccount: '管理帳號',
   },
   loginRegion: {
     subline: '請選擇您要登入的 Beanfun 服務地區。',
@@ -274,6 +283,9 @@ const zhTW = {
     subtitle: '開啟 Beanfun 行動版 App 掃描下方 QR Code 即可登入。',
     unsupportedHK: 'QR 登入僅支援台灣區，已返回登入入口。',
     connectionLost: '無法取得登入狀態，請點選重新整理重試。',
+    enlarge: '放大',
+    copyQr: '複製 QR',
+    copyQrSuccess: 'QR Code 已複製到剪貼簿。',
   },
   loginTotp: {
     title: '雙重驗證',
@@ -459,9 +471,18 @@ const zhTW = {
 /* -------- zh-CN (Simplified) -------- */
 
 const zhCN = {
-  loginShell: {
-    heading: '缤放',
-    subline: '欢迎登录',
+  titleBar: {
+    minimize: '最小化',
+    close: '关闭',
+    regionSelection: '选择登录地区',
+    login: '登录',
+    totp: '双重验证',
+    loginWait: '登录中',
+    verify: '进阶验证',
+    accounts: '游戏帐号',
+    settings: '设置',
+    about: '关于 beanfun! Next',
+    manageAccount: '管理帐号',
   },
   loginRegion: {
     subline: '请选择您要登录的 Beanfun 服务地区。',
@@ -474,6 +495,9 @@ const zhCN = {
     subtitle: '打开 Beanfun 移动版 App 扫描下方 QR Code 即可登录。',
     unsupportedHK: 'QR 登录仅支持台湾区，已返回登录入口。',
     connectionLost: '无法获取登录状态，请点选重新加载重试。',
+    enlarge: '放大',
+    copyQr: '复制 QR',
+    copyQrSuccess: 'QR Code 已复制到剪贴板。',
   },
   loginTotp: {
     title: '双重验证',
@@ -659,9 +683,18 @@ const zhCN = {
 /* -------- en-US -------- */
 
 const enUS = {
-  loginShell: {
-    heading: 'Beanfun',
-    subline: 'Welcome — please sign in',
+  titleBar: {
+    minimize: 'Minimize',
+    close: 'Close',
+    regionSelection: 'Select Region',
+    login: 'Sign In',
+    totp: 'Two-Factor Auth',
+    loginWait: 'Signing In',
+    verify: 'Verification',
+    accounts: 'Game Accounts',
+    settings: 'Settings',
+    about: 'About beanfun! Next',
+    manageAccount: 'Manage Accounts',
   },
   loginRegion: {
     subline: 'Pick the beanfun! region you want to sign in to.',
@@ -674,6 +707,9 @@ const enUS = {
     subtitle: 'Open the beanfun! mobile app and scan the QR code below to sign in.',
     unsupportedHK: 'QR login is only available in Taiwan; redirected back to the login entry.',
     connectionLost: 'Unable to reach the login service. Please tap Reload and try again.',
+    enlarge: 'Enlarge',
+    copyQr: 'Copy QR',
+    copyQrSuccess: 'QR code copied to clipboard.',
   },
   loginTotp: {
     title: 'Two-factor authentication',

--- a/src/main.ts
+++ b/src/main.ts
@@ -108,4 +108,6 @@ installRouterGuards(router, {
   },
 })
 
+document.addEventListener('contextmenu', (e) => e.preventDefault())
+
 app.mount('#app')

--- a/src/pages/About.vue
+++ b/src/pages/About.vue
@@ -65,6 +65,7 @@ import { useUiStore } from '../stores/ui'
 import { commands } from '../types/bindings'
 import { safeInvoke } from '../services/invoke'
 import iconUrl from '../assets/icon.png'
+import TitleBar from '../components/TitleBar.vue'
 
 defineOptions({ name: 'AboutPage' })
 
@@ -254,102 +255,109 @@ onMounted(() => {
 </script>
 
 <template>
-  <main class="about bf-mica-bg">
-    <div class="about__container">
-      <!-- Header: app icon + name + author -->
-      <header class="about__header bf-glass-panel">
-        <img
-          :src="iconUrl"
-          alt="Beanfun"
-          class="about__icon"
-          width="56"
-          height="56"
-          data-test="about-icon"
-        />
-        <div class="about__header-text">
-          <div class="about__title-row">
-            <h1 class="about__title bf-text-gradient">{{ t('AppName') }}</h1>
-            <span class="about__author">By Pungin and YCC3741</span>
+  <main class="about bf-glass-window" data-window-root>
+    <TitleBar />
+    <div class="about__scroll">
+      <div class="about__container">
+        <!-- Header: app icon + name + author -->
+        <header class="about__header bf-glass-panel">
+          <img
+            :src="iconUrl"
+            alt="Beanfun"
+            class="about__icon"
+            width="56"
+            height="56"
+            data-test="about-icon"
+          />
+          <div class="about__header-text">
+            <div class="about__title-row">
+              <h1 class="about__title bf-text-gradient">{{ t('AppName') }}</h1>
+              <span class="about__author">By Pungin and YCC3741</span>
+            </div>
+            <p class="about__version-row" data-test="about-version-row">
+              <span>{{ t('Version') }}</span>
+              <span class="about__version-value" data-test="about-version-value">
+                {{ versionString }}
+              </span>
+              <a
+                href="#"
+                class="about__check-update"
+                :class="{ 'about__check-update--disabled': checkingUpdate }"
+                data-test="about-check-update"
+                @click.prevent="handleCheckUpdate"
+              >
+                {{ t('CheckUpdate') }}
+              </a>
+            </p>
           </div>
-          <p class="about__version-row" data-test="about-version-row">
-            <span>{{ t('Version') }}</span>
-            <span class="about__version-value" data-test="about-version-value">
-              {{ versionString }}
-            </span>
-            <a
-              href="#"
-              class="about__check-update"
-              :class="{ 'about__check-update--disabled': checkingUpdate }"
-              data-test="about-check-update"
-              @click.prevent="handleCheckUpdate"
-            >
-              {{ t('CheckUpdate') }}
-            </a>
-          </p>
-        </div>
-      </header>
+        </header>
 
-      <!-- Body: about text + contact + footer -->
-      <section class="about__body bf-glass-panel">
-        <p class="about__text" data-test="about-text">{{ aboutTextPlain }}</p>
+        <!-- Body: about text + contact + footer -->
+        <section class="about__body bf-glass-panel">
+          <p class="about__text" data-test="about-text">{{ aboutTextPlain }}</p>
 
-        <div class="about__separator" />
+          <div class="about__separator" />
 
-        <div class="about__contact" data-test="about-contact">
-          <span class="about__contact-label">{{ t('Contact') }}</span>
-          <div class="about__contact-col">
-            <a
-              href="#"
-              class="about__contact-link"
-              data-test="about-email-pungin"
-              @click.prevent="handleEmail('pungin@msn.com')"
-            >
-              <el-icon><Message /></el-icon>
-              <span>Pungin</span>
-            </a>
-            <a
-              href="#"
-              class="about__contact-link"
-              data-test="about-email-ycc3741"
-              @click.prevent="handleEmail('mo0307b1006@gmail.com')"
-            >
-              <el-icon><Message /></el-icon>
-              <span>YCC3741</span>
-            </a>
-            <a
-              href="#"
-              class="about__contact-link"
-              data-test="about-github"
-              @click.prevent="handleGithub"
-            >
-              <el-icon><InfoFilled /></el-icon>
-              <span>Github</span>
-            </a>
+          <div class="about__contact" data-test="about-contact">
+            <span class="about__contact-label">{{ t('Contact') }}</span>
+            <div class="about__contact-col">
+              <a
+                href="#"
+                class="about__contact-link"
+                data-test="about-email-pungin"
+                @click.prevent="handleEmail('pungin@msn.com')"
+              >
+                <el-icon><Message /></el-icon>
+                <span>Pungin</span>
+              </a>
+              <a
+                href="#"
+                class="about__contact-link"
+                data-test="about-email-ycc3741"
+                @click.prevent="handleEmail('mo0307b1006@gmail.com')"
+              >
+                <el-icon><Message /></el-icon>
+                <span>YCC3741</span>
+              </a>
+              <a
+                href="#"
+                class="about__contact-link"
+                data-test="about-github"
+                @click.prevent="handleGithub"
+              >
+                <el-icon><InfoFilled /></el-icon>
+                <span>Github</span>
+              </a>
+            </div>
           </div>
-        </div>
 
-        <footer class="about__footer">
-          <el-button
-            class="bf-btn-secondary about__back-btn"
-            data-test="about-back"
-            @click="handleBack"
-          >
-            <el-icon><ArrowLeft /></el-icon>
-            <span>{{ t('Back') }}</span>
-          </el-button>
-        </footer>
-      </section>
+          <footer class="about__footer">
+            <el-button
+              class="bf-btn-secondary about__back-btn"
+              data-test="about-back"
+              @click="handleBack"
+            >
+              <el-icon><ArrowLeft /></el-icon>
+              <span>{{ t('Back') }}</span>
+            </el-button>
+          </footer>
+        </section>
+      </div>
     </div>
   </main>
 </template>
 
 <style scoped>
 .about {
-  box-sizing: border-box;
-  min-height: 100vh;
-  padding: 2.5rem 1.5rem;
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.about__scroll {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1.5rem;
 }
 
 .about__container {

--- a/src/pages/AccountList.vue
+++ b/src/pages/AccountList.vue
@@ -103,6 +103,7 @@ import {
   DocumentCopy,
   EditPen,
   InfoFilled,
+  Iphone,
   Key,
   Message,
   MoreFilled,
@@ -114,6 +115,7 @@ import {
   SwitchButton,
   User,
   VideoPlay,
+  Wallet,
 } from '@element-plus/icons-vue'
 import Sortable from 'sortablejs'
 
@@ -436,6 +438,35 @@ async function handleCustomerService(): Promise<void> {
     return
   }
   await inAppBrowser.open(CUSTOMER_SERVICE_URLS[region])
+}
+
+/* --- Gash Recharge / App Gash Recharge (WPF bfb_Gash_Click + btn_Deposite_Click parity) --- */
+
+/**
+ * Open the Beanfun **Gash recharge** page. Mirrors WPF
+ * `Pages/AccountList.xaml.cs::bfb_Gash_Click`.
+ *
+ * Same pattern as {@link handleMemberCenter} — the URL embeds
+ * `web_token`, so a dedicated backend command keeps the secret
+ * confined to Rust.
+ */
+async function handleGashRecharge(): Promise<void> {
+  const result = await safeInvoke(commands.openGashRechargeBrowser())
+  if (!result.ok) {
+    ElMessage.error(result.error.message || t('inAppBrowser.openFailed'))
+  }
+}
+
+/**
+ * Open the **beanfun! App Gash deposit** page. Mirrors WPF
+ * `Pages/AccountList.xaml.cs::btn_Deposite_Click`.
+ *
+ * No `web_token` needed — the URL is a static `m.beanfun.com`
+ * endpoint. Dispatched through {@link inAppBrowser} (same pattern
+ * as {@link handleCustomerService}).
+ */
+async function handleAppGashRecharge(): Promise<void> {
+  await inAppBrowser.open('https://m.beanfun.com/Deposite')
 }
 
 /* --------------- P12.5 D7 — Tools button real handler --------------- */
@@ -1968,6 +1999,24 @@ onBeforeUnmount(destroySortable)
             <el-icon><Refresh /></el-icon>
           </button>
         </div>
+        <button
+          type="button"
+          class="account-list__quick-link bf-glass-card bf-ghost-border"
+          data-test="account-list-gash-recharge"
+          @click="handleGashRecharge"
+        >
+          <el-icon><Wallet /></el-icon>
+          <span>{{ t('GashRecharge') }}</span>
+        </button>
+        <button
+          type="button"
+          class="account-list__quick-link bf-glass-card bf-ghost-border"
+          data-test="account-list-app-gash-recharge"
+          @click="handleAppGashRecharge"
+        >
+          <el-icon><Iphone /></el-icon>
+          <span>{{ t('AppGashRecharge') }}</span>
+        </button>
         <button
           type="button"
           class="account-list__quick-link bf-glass-card bf-ghost-border"

--- a/src/pages/AccountList.vue
+++ b/src/pages/AccountList.vue
@@ -50,7 +50,7 @@
  * | Auto-paste preference                               | **REAL since P12.2 D5** (`useConfigStore` `autoPaste` key, lazy-write + AutoPasteTip on first toggle) |
  * | OTP value + Get OTP + Copy                          | **REAL since P12.2 D5** (`account.getOtp` + `commands.autoPaste` + clipboard fallback) |
  * | Add Service Account button                          | **REAL since P12.2 D3** (`windows/AddServiceAccount.vue`) |
- * | Drag handle (reorder)                               | **REAL since P12.2 D7** (vuedraggable + `Config.xml` `AccountOrder_<gameCode>` persistence) |
+ * | Drag handle (reorder)                               | **REAL since P12.2 D7** (SortableJS + `Config.xml` `AccountOrder_<gameCode>` persistence) |
  * | Per-row context menu (more_vert)                    | **REAL since P12.2 D4** (`Change Alias` + `Account Info` + `Check Email` items wired; other items land in their own D-steps) |
  *
  * Stubs render the mockup affordance verbatim so visual QA on D1
@@ -86,7 +86,7 @@
  *   Game CTA, so the bottom dock has no UX purpose.
  */
 
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 import {
@@ -115,7 +115,7 @@ import {
   User,
   VideoPlay,
 } from '@element-plus/icons-vue'
-import draggable from 'vuedraggable'
+import Sortable from 'sortablejs'
 
 import { useAuthStore } from '../stores/auth'
 import { useAccountStore } from '../stores/account'
@@ -701,6 +701,7 @@ async function selectActiveGame(
        */
       return
     }
+    auth.updateSessionService(serviceCode, serviceRegion)
   }
 
   /*
@@ -881,6 +882,47 @@ const formattedRemainPoint = computed(() => {
 })
 
 /* --------------- add service account (D3 + D8g unconnected branch) --------------- */
+
+/**
+ * Extract the numeric limit from the server notice text
+ * (e.g. "此遊戲最多允許新增帳號數:2" → 2). Returns `null` when
+ * no number is found or the notice is not the `other` variant.
+ */
+const accountLimit = computed<number | null>(() => {
+  const notice = account.amountLimitNotice
+  if (notice.kind !== 'other') return null
+  const match = notice.data.match(/\d+/)
+  return match ? parseInt(match[0], 10) : null
+})
+
+/**
+ * Whether the add-account button should be disabled.
+ * - `auth_re_login_required` → always disabled (need verification)
+ * - `other` with parseable limit → disabled only when current
+ *   account count >= the limit
+ * - `none` / unparseable → enabled (let server reject if needed)
+ */
+const isAddAccountDisabled = computed(() => {
+  const notice = account.amountLimitNotice
+  if (notice.kind === 'auth_re_login_required') return true
+  if (accountLimit.value !== null) {
+    return account.serviceAccounts.length >= accountLimit.value
+  }
+  return false
+})
+
+/**
+ * Human-readable limit notice text for the UI.
+ * - `auth_re_login_required` → localised `AuthReLogin` string
+ * - `other` → server's verbatim text (e.g. "此遊戲最多允許新增帳號數:2")
+ * - `none` → null (nothing to show)
+ */
+const limitNoticeText = computed<string | null>(() => {
+  const notice = account.amountLimitNotice
+  if (notice.kind === 'auth_re_login_required') return t('AuthReLogin')
+  if (notice.kind === 'other') return notice.data
+  return null
+})
 
 /**
  * `<AddServiceAccount />` modal visibility. Driven by the Plus
@@ -1629,11 +1671,9 @@ function handleCopyOtp(): void {
  * L137-139 call site that runs ApplyAccountOrder immediately
  * after the server-side `OrderBy(ssn)`.
  *
- * # Why vuedraggable (and not native HTML5 drag-drop)
+ * # Why SortableJS (and not native HTML5 drag-drop)
  *
- * `vuedraggable@4.1.0` is already in `package.json` (Vue 3 peer)
- * but had no consumers — using it here turns a dead dependency
- * into a load-bearing one and gives us:
+ * SortableJS gives us:
  *
  * - The `handle` selector that mirrors WPF's `_isHandlePressed`
  *   gate (`MouseLeftButtonDown` only on the grip, never the row)
@@ -1642,25 +1682,15 @@ function handleCopyOtp(): void {
  * - Sortable.js' built-in animation, ghost element, and same-list
  *   reorder semantics — re-implementing those over native dnd is
  *   ~200 lines of fiddly DOM measurement code.
- * - In-place mutation of the bound array via `:list`, which keeps
- *   Pinia reactivity end-to-end without needing a v-model
- *   computed setter just to satisfy the bind contract.
  *
- * D7.3 sanity check (Vue 3.5 + Vite 6 + Vitest 4) confirmed the
- * UMD bundle imports and mounts cleanly under our toolchain.
+ * # Why the @end handler manually splices the array
  *
- * # Why we still call `setServiceAccountOrder` after the @end event
- *
- * `<draggable :list>` mutates `account.serviceAccounts` in place,
- * so by the time `@end` fires the visible order is already
- * correct. The follow-up `account.setServiceAccountOrder` call
- * is **idempotent** in that case but earns its keep as the single
- * canonical reorder funnel: the spy in the page-level test (D7.5
- * case 2) asserts the store action receives the expected sid
- * order, which gives us a stable seam against future refactors
- * (e.g. adding analytics, deduplication, or a derived state
- * mirror — all would belong inside the action, not next to every
- * call site).
+ * SortableJS manipulates the DOM during drag — the
+ * backing data must be updated manually via `oldIndex` /
+ * `newIndex` from the event. The handler splices the Pinia
+ * array in place, then funnels through `setServiceAccountOrder`
+ * as the canonical reorder action (keeps the spy seam for tests
+ * and any future invariants like analytics or dedup).
  *
  * # Why persist failures are silent (Q8)
  *
@@ -1726,10 +1756,8 @@ async function persistAccountOrder(key: string, csv: string): Promise<void> {
 }
 
 /**
- * Vuedraggable `@end` handler. Vuedraggable's `:list` binding has
- * already mutated `account.serviceAccounts` in place by the time
- * this fires (Sortable.js' `onEnd` runs after the splice), so the
- * visible UI is already correct.
+ * SortableJS `@end` handler. Receives `oldIndex` / `newIndex`
+ * from the event, splices the Pinia array in place, then persists.
  *
  * Two follow-up writes:
  *
@@ -1742,14 +1770,61 @@ async function persistAccountOrder(key: string, csv: string): Promise<void> {
  *    under the per-game key. Skipped when no session is active;
  *    silent on failure (mirrors WPF).
  */
-function handleDragEnd(): void {
+function handleDragEnd(event: Sortable.SortableEvent): void {
   const key = accountOrderConfigKey.value
   if (!key) return
 
-  const orderedSids = account.serviceAccounts.map((a) => a.sid)
-  account.setServiceAccountOrder(orderedSids)
-  void persistAccountOrder(key, orderedSids.join(','))
+  const { oldIndex, newIndex, item, from } = event
+  if (oldIndex == null || newIndex == null || oldIndex === newIndex) return
+
+  /*
+   * SortableJS physically moved the DOM element during drag.
+   * Revert that manipulation so Vue's reactivity system is the
+   * sole owner of the DOM — otherwise the subsequent array
+   * splice triggers a Vue re-render that conflicts with the
+   * already-moved element, producing incorrect final positions.
+   */
+  from.removeChild(item)
+  from.insertBefore(item, from.children[oldIndex] ?? null)
+
+  const list = account.serviceAccounts
+  const [moved] = list.splice(oldIndex, 1)
+  list.splice(newIndex, 0, moved)
+
+  account.setServiceAccountOrder(list.map((a) => a.sid))
+  void persistAccountOrder(key, list.map((a) => a.sid).join(','))
 }
+
+/* SortableJS instance lifecycle */
+
+const rowsRef = ref<HTMLElement | null>(null)
+let sortableInstance: Sortable | null = null
+
+function initSortable(): void {
+  destroySortable()
+  if (!rowsRef.value) return
+  sortableInstance = Sortable.create(rowsRef.value, {
+    handle: '.account-list__row-grip',
+    animation: 150,
+    ghostClass: 'account-list__row--ghost',
+    forceFallback: true,
+    onEnd: handleDragEnd,
+  })
+}
+
+function destroySortable(): void {
+  if (sortableInstance) {
+    sortableInstance.destroy()
+    sortableInstance = null
+  }
+}
+
+watch(rowsRef, (el) => {
+  if (el) initSortable()
+  else destroySortable()
+})
+
+onBeforeUnmount(destroySortable)
 </script>
 
 <template>
@@ -1959,121 +2034,121 @@ function handleDragEnd(): void {
           </p>
 
           <!--
-            D7: vuedraggable wraps the row list. `:list` binds the
-            actual mutable Pinia state array (not the read-only
-            `serviceAccounts` computed) so Sortable.js' in-place
-            splice flows through Pinia reactivity. The `handle`
-            selector mirrors WPF's `_isHandlePressed` gate — only
-            mouse-down on the grip starts a drag; any other click
-            on the row falls through to `selectRow`. `ghost-class`
-            styles the placeholder slot during drag (defined at the
-            bottom of <style scoped>).
+            D7: SortableJS (via `rowsRef` + `watch`) makes the row
+            list drag-sortable. The `handle` option mirrors WPF's
+            `_isHandlePressed` gate — only mouse-down on the grip
+            starts a drag; any other click on the row falls through
+            to `selectRow`. `ghostClass` styles the placeholder
+            slot during drag (defined at bottom of <style scoped>).
           -->
-          <draggable
+          <ul
             v-else
-            :list="account.serviceAccounts"
-            tag="ul"
-            item-key="sid"
-            handle=".account-list__row-grip"
-            :animation="150"
-            ghost-class="account-list__row--ghost"
+            ref="rowsRef"
             class="account-list__rows"
             data-test="account-list-rows"
-            @end="handleDragEnd"
           >
-            <template #item="{ element: a, index: idx }">
-              <li
-                class="account-list__row"
-                :class="{
-                  'account-list__row--selected': isSelected(a),
-                  'account-list__row--banned': !a.is_enable,
-                }"
-                :data-test="`account-row-${a.sid}`"
-                @click="selectRow(a)"
+            <li
+              v-for="(a, idx) in serviceAccounts"
+              :key="a.sid"
+              class="account-list__row"
+              :class="{
+                'account-list__row--selected': isSelected(a),
+                'account-list__row--banned': !a.is_enable,
+              }"
+              :data-test="`account-row-${a.sid}`"
+              @click="selectRow(a)"
+            >
+              <span
+                class="account-list__row-grip"
+                :title="t('accountList.dragHandle')"
+                aria-hidden="true"
+                >⋮⋮</span
               >
-                <span
-                  class="account-list__row-grip"
-                  :title="t('accountList.dragHandle')"
-                  aria-hidden="true"
-                  >⋮⋮</span
-                >
-                <span class="account-list__row-num">{{ idx + 1 }}</span>
-                <div class="account-list__row-info">
-                  <p class="account-list__row-name">{{ a.sname }}</p>
-                  <p class="account-list__row-sub">
-                    <template v-if="a.is_enable">ID: {{ a.sid }}</template>
-                    <template v-else>{{ t('accountList.statusBanned') }}</template>
-                  </p>
-                </div>
-                <el-dropdown
-                  trigger="click"
-                  placement="bottom-end"
-                  :hide-on-click="true"
-                  popper-class="account-list__row-menu-popper"
+              <span class="account-list__row-num">{{ idx + 1 }}</span>
+              <div class="account-list__row-info">
+                <p class="account-list__row-name">{{ a.sname }}</p>
+                <p class="account-list__row-sub">
+                  <template v-if="a.is_enable">ID: {{ a.sid }}</template>
+                  <template v-else>{{ t('accountList.statusBanned') }}</template>
+                </p>
+              </div>
+              <el-dropdown
+                trigger="click"
+                placement="bottom-end"
+                :hide-on-click="true"
+                popper-class="account-list__row-menu-popper"
+                @click.stop
+              >
+                <button
+                  type="button"
+                  class="account-list__row-more"
+                  :title="t('accountList.moreActions')"
+                  :data-test="`account-row-more-${a.sid}`"
                   @click.stop
                 >
-                  <button
-                    type="button"
-                    class="account-list__row-more"
-                    :title="t('accountList.moreActions')"
-                    :data-test="`account-row-more-${a.sid}`"
-                    @click.stop
-                  >
-                    <el-icon><MoreFilled /></el-icon>
-                  </button>
-                  <template #dropdown>
-                    <el-dropdown-menu>
-                      <el-dropdown-item
-                        :data-test="`account-row-change-alias-${a.sid}`"
-                        @click="handleChangeAlias(a)"
-                      >
-                        <el-icon><EditPen /></el-icon>
-                        <span>{{ t('ChangeAccountName') }}</span>
-                      </el-dropdown-item>
-                      <el-dropdown-item
-                        :data-test="`account-row-info-${a.sid}`"
-                        @click="handleAccountInfo(a)"
-                      >
-                        <el-icon><InfoFilled /></el-icon>
-                        <span>{{ t('GameAccountInfo') }}</span>
-                      </el-dropdown-item>
-                      <el-dropdown-item
-                        :data-test="`account-row-get-email-${a.sid}`"
-                        @click="handleGetEmail"
-                      >
-                        <el-icon><Message /></el-icon>
-                        <span>{{ t('CheckEmail') }}</span>
-                      </el-dropdown-item>
-                      <!--
-                        D8h: Change Password menu item only appears for
-                        unconnected games (mirrors WPF
-                        `m_ChangePassword.Visibility` toggled by
-                        `selectedGameChanged()` on the same predicate).
-                        Connected games delegate password changes to
-                        the Beanfun member centre web flow, which is
-                        opened from the page-level chrome — no
-                        per-row affordance is needed there.
-                      -->
-                      <el-dropdown-item
-                        v-if="game.isUnconnectedGame"
-                        :data-test="`account-row-change-password-${a.sid}`"
-                        @click="handleChangePassword(a)"
-                      >
-                        <el-icon><Key /></el-icon>
-                        <span>{{ t('ChangePassword') }}</span>
-                      </el-dropdown-item>
-                    </el-dropdown-menu>
-                  </template>
-                </el-dropdown>
-              </li>
-            </template>
-          </draggable>
+                  <el-icon><MoreFilled /></el-icon>
+                </button>
+                <template #dropdown>
+                  <el-dropdown-menu>
+                    <el-dropdown-item
+                      :data-test="`account-row-change-alias-${a.sid}`"
+                      @click="handleChangeAlias(a)"
+                    >
+                      <el-icon><EditPen /></el-icon>
+                      <span>{{ t('ChangeAccountName') }}</span>
+                    </el-dropdown-item>
+                    <el-dropdown-item
+                      :data-test="`account-row-info-${a.sid}`"
+                      @click="handleAccountInfo(a)"
+                    >
+                      <el-icon><InfoFilled /></el-icon>
+                      <span>{{ t('GameAccountInfo') }}</span>
+                    </el-dropdown-item>
+                    <el-dropdown-item
+                      :data-test="`account-row-get-email-${a.sid}`"
+                      @click="handleGetEmail"
+                    >
+                      <el-icon><Message /></el-icon>
+                      <span>{{ t('CheckEmail') }}</span>
+                    </el-dropdown-item>
+                    <!--
+                      D8h: Change Password menu item only appears for
+                      unconnected games (mirrors WPF
+                      `m_ChangePassword.Visibility` toggled by
+                      `selectedGameChanged()` on the same predicate).
+                      Connected games delegate password changes to
+                      the Beanfun member centre web flow, which is
+                      opened from the page-level chrome — no
+                      per-row affordance is needed there.
+                    -->
+                    <el-dropdown-item
+                      v-if="game.isUnconnectedGame"
+                      :data-test="`account-row-change-password-${a.sid}`"
+                      @click="handleChangePassword(a)"
+                    >
+                      <el-icon><Key /></el-icon>
+                      <span>{{ t('ChangePassword') }}</span>
+                    </el-dropdown-item>
+                  </el-dropdown-menu>
+                </template>
+              </el-dropdown>
+            </li>
+          </ul>
         </div>
 
         <footer class="account-list__list-footer">
+          <p
+            v-if="limitNoticeText"
+            class="account-list__limit-notice"
+            data-test="account-list-limit-notice"
+          >
+            {{ limitNoticeText }}
+          </p>
           <button
             type="button"
             class="account-list__add-btn"
+            :class="{ 'account-list__add-btn--disabled': isAddAccountDisabled }"
+            :disabled="isAddAccountDisabled"
             data-test="account-list-add"
             @click="handleAddAccount"
           >
@@ -2593,7 +2668,7 @@ function handleDragEnd(): void {
  */
 
 /*
- * Vuedraggable ghost-class — applied to the placeholder element
+ * SortableJS ghost-class — applied to the placeholder element
  * Sortable.js inserts at the projected drop location during drag.
  * Subdued styling so the ghost reads as "destination" rather
  * than competing with the live row being dragged.
@@ -2709,9 +2784,22 @@ function handleDragEnd(): void {
     background var(--bf-motion-fast);
 }
 
-.account-list__add-btn:hover {
+.account-list__add-btn:hover:not(:disabled) {
   border-color: var(--bf-primary);
   background: color-mix(in srgb, var(--bf-primary) 6%, transparent);
+}
+
+.account-list__add-btn--disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.account-list__limit-notice {
+  margin: 0 0 0.5rem;
+  padding: 0.375rem 0.75rem;
+  font-size: 0.75rem;
+  color: var(--el-color-warning, #e6a23c);
+  text-align: center;
 }
 
 /* --------------- OTP section --------------- */

--- a/src/pages/AccountList.vue
+++ b/src/pages/AccountList.vue
@@ -111,7 +111,6 @@ import {
   Plus,
   Refresh,
   Service,
-  Setting as SettingIcon,
   SwitchButton,
   User,
   VideoPlay,
@@ -140,6 +139,7 @@ import ToolsDialogStack from '../windows/ToolsDialogStack.vue'
 import UnconnectedGameAddAccount from '../windows/UnconnectedGame_AddAccount.vue'
 import UnconnectedGameChangePassword from '../windows/UnconnectedGame_ChangePassword.vue'
 import { TOOLS_GAME_CODES } from '../constants/tools'
+import TitleBar from '../components/TitleBar.vue'
 import { useGameLauncher } from '../composables/useGameLauncher'
 
 defineOptions({ name: 'AccountList' })
@@ -1859,42 +1859,35 @@ onBeforeUnmount(destroySortable)
 </script>
 
 <template>
-  <main class="account-list bf-mica-bg">
-    <div class="account-list__container">
-      <header class="account-list__header">
-        <div class="account-list__header-text">
-          <h1 class="account-list__title bf-text-gradient">{{ t('accountList.title') }}</h1>
-          <p class="account-list__subline">{{ t('accountList.subtitle') }}</p>
-        </div>
-        <!--
-          P12.4 D6: Settings + About entry buttons. Mirrors WPF
-          `MainWindow.xaml` titlebar L112-139 — both icons sit in the
-          window chrome alongside Logout / Min / Close. We reuse the
-          existing `bf-btn-ghost-icon` styling that the in-row Tools
-          + Logout buttons already use so the chrome stays visually
-          consistent across the page.
-        -->
-        <div class="account-list__header-actions">
-          <button
-            type="button"
-            class="bf-btn-ghost-icon account-list__icon-btn"
-            :title="t('Settings')"
-            data-test="account-list-settings"
-            @click="handleOpenSettings"
-          >
-            <el-icon><SettingIcon /></el-icon>
-          </button>
-          <button
-            type="button"
-            class="bf-btn-ghost-icon account-list__icon-btn"
-            :title="t('settings.aboutLink')"
-            data-test="account-list-about"
-            @click="handleOpenAbout"
-          >
-            <el-icon><InfoFilled /></el-icon>
-          </button>
-        </div>
-      </header>
+  <main class="account-list bf-glass-window" data-window-root>
+    <TitleBar>
+      <button
+        type="button"
+        class="account-list__titlebar-btn"
+        :title="t('Settings')"
+        data-test="account-list-settings"
+        @click="handleOpenSettings"
+      >
+        <span class="material-symbols-outlined">settings</span>
+      </button>
+      <button
+        type="button"
+        class="account-list__titlebar-btn"
+        :title="t('settings.aboutLink')"
+        data-test="account-list-about"
+        @click="handleOpenAbout"
+      >
+        <span class="material-symbols-outlined">info</span>
+      </button>
+    </TitleBar>
+    <div class="account-list__scroll">
+      <div class="account-list__container">
+        <header class="account-list__header">
+          <div class="account-list__header-text">
+            <h1 class="account-list__title bf-text-gradient">{{ t('accountList.title') }}</h1>
+            <p class="account-list__subline">{{ t('accountList.subtitle') }}</p>
+          </div>
+        </header>
 
       <!-- Game info bar (D8d) — real game name + image + change-game button. -->
       <section class="account-list__game bf-glass-panel">
@@ -2339,17 +2332,43 @@ onBeforeUnmount(destroySortable)
           </button>
         </div>
       </section>
+      </div>
     </div>
   </main>
 </template>
 
 <style scoped>
 .account-list {
-  box-sizing: border-box;
-  min-height: 100vh;
-  padding: 2.5rem 1.5rem;
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.account-list__titlebar-btn {
+  appearance: none;
+  background: transparent;
+  border: none;
+  width: 28px;
+  height: 28px;
+  display: grid;
+  place-items: center;
+  border-radius: 6px;
+  cursor: pointer;
+  color: var(--bf-on-surface-variant, #54443a);
+  transition: background 150ms ease;
+  padding: 0;
+}
+.account-list__titlebar-btn .material-symbols-outlined {
+  font-size: 18px;
+}
+.account-list__titlebar-btn:hover {
+  background: rgba(0, 0, 0, 0.06);
+}
+
+.account-list__scroll {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1.5rem;
 }
 
 .account-list__container {
@@ -2375,12 +2394,6 @@ onBeforeUnmount(destroySortable)
   min-width: 0;
 }
 
-.account-list__header-actions {
-  display: flex;
-  align-items: center;
-  gap: 0.25rem;
-  flex-shrink: 0;
-}
 
 .account-list__title {
   margin: 0;

--- a/src/pages/AccountList.vue
+++ b/src/pages/AccountList.vue
@@ -1889,12 +1889,12 @@ onBeforeUnmount(destroySortable)
           </div>
         </header>
 
-      <!-- Game info bar (D8d) — real game name + image + change-game button. -->
-      <section class="account-list__game bf-glass-panel">
-        <div class="account-list__game-row">
-          <div class="account-list__game-meta">
-            <div class="account-list__game-icon" aria-hidden="true">
-              <!--
+        <!-- Game info bar (D8d) — real game name + image + change-game button. -->
+        <section class="account-list__game bf-glass-panel">
+          <div class="account-list__game-row">
+            <div class="account-list__game-meta">
+              <div class="account-list__game-icon" aria-hidden="true">
+                <!--
                 D8d: prefer the per-game banner image when the catalogue
                 has hydrated; fall back to the generic VideoPlay glyph
                 so the layout doesn't collapse during the brief setup
@@ -1902,33 +1902,33 @@ onBeforeUnmount(destroySortable)
                 container size is fixed regardless so the row height
                 stays stable across the swap.
               -->
-              <img
-                v-if="gameImageUrl"
-                :src="gameImageUrl"
-                :alt="gameNameDisplay"
-                class="account-list__game-icon-img"
-                data-test="account-list-game-image"
-              />
-              <el-icon v-else :size="24"><VideoPlay /></el-icon>
+                <img
+                  v-if="gameImageUrl"
+                  :src="gameImageUrl"
+                  :alt="gameNameDisplay"
+                  class="account-list__game-icon-img"
+                  data-test="account-list-game-image"
+                />
+                <el-icon v-else :size="24"><VideoPlay /></el-icon>
+              </div>
+              <button
+                type="button"
+                class="account-list__game-info"
+                :title="t('accountList.changeGame')"
+                data-test="account-list-change-game"
+                @click="handleChangeGame"
+              >
+                <span class="account-list__game-name" data-test="account-list-game-name">
+                  {{ gameNameDisplay }}
+                </span>
+                <span class="account-list__game-status">
+                  <span class="account-list__game-status-dot" />
+                  {{ t('accountList.statusOnline') }}
+                </span>
+              </button>
             </div>
-            <button
-              type="button"
-              class="account-list__game-info"
-              :title="t('accountList.changeGame')"
-              data-test="account-list-change-game"
-              @click="handleChangeGame"
-            >
-              <span class="account-list__game-name" data-test="account-list-game-name">
-                {{ gameNameDisplay }}
-              </span>
-              <span class="account-list__game-status">
-                <span class="account-list__game-status-dot" />
-                {{ t('accountList.statusOnline') }}
-              </span>
-            </button>
-          </div>
-          <div class="account-list__game-actions">
-            <!--
+            <div class="account-list__game-actions">
+              <!--
               D8e: Tools button is only rendered for the three game
               codes WPF whitelisted (`610074_T9` / `610075_T9` /
               `610096_TE`). Hidden via `v-if` rather than `display:
@@ -1936,146 +1936,146 @@ onBeforeUnmount(destroySortable)
               that isn't reachable, and so the surrounding flex row
               tightens up cleanly when the button is absent.
             -->
-            <button
-              v-if="showToolsButton"
-              type="button"
-              class="bf-btn-ghost-icon account-list__icon-btn"
-              :title="t('accountList.toolsButton')"
-              data-test="account-list-tools"
-              @click="handleTools"
-            >
-              <el-icon><Operation /></el-icon>
-            </button>
-            <button
-              type="button"
-              class="bf-btn-ghost-icon account-list__icon-btn account-list__icon-btn--danger"
-              :title="t('Logout')"
-              data-test="account-list-logout"
-              @click="handleLogout"
-            >
-              <el-icon><SwitchButton /></el-icon>
-            </button>
-          </div>
-        </div>
-        <button
-          type="button"
-          class="bf-btn-gradient account-list__start-btn"
-          :disabled="startGameDisabled"
-          data-test="account-list-start"
-          @click="handleStartGame"
-        >
-          <el-icon><VideoPlay /></el-icon>
-          <span>{{ t('GameStart') }}</span>
-        </button>
-      </section>
-
-      <!-- Quick actions row: balance + member center + support (all stubs) -->
-      <section class="account-list__quick">
-        <div class="account-list__balance bf-glass-card bf-ghost-border">
-          <div class="account-list__balance-text">
-            <span class="account-list__balance-label">
-              {{ t('accountList.gashBalance') }}
-            </span>
-            <span class="account-list__balance-value" data-test="account-list-balance-value">
-              {{ formattedRemainPoint }}
-            </span>
+              <button
+                v-if="showToolsButton"
+                type="button"
+                class="bf-btn-ghost-icon account-list__icon-btn"
+                :title="t('accountList.toolsButton')"
+                data-test="account-list-tools"
+                @click="handleTools"
+              >
+                <el-icon><Operation /></el-icon>
+              </button>
+              <button
+                type="button"
+                class="bf-btn-ghost-icon account-list__icon-btn account-list__icon-btn--danger"
+                :title="t('Logout')"
+                data-test="account-list-logout"
+                @click="handleLogout"
+              >
+                <el-icon><SwitchButton /></el-icon>
+              </button>
+            </div>
           </div>
           <button
             type="button"
-            class="account-list__balance-refresh"
-            :class="{ 'account-list__balance-refresh--spinning': refreshing }"
-            :title="t('accountList.refreshBalance')"
-            :disabled="refreshing"
-            data-test="account-list-refresh-balance"
-            @click="handleRefreshBalance"
+            class="bf-btn-gradient account-list__start-btn"
+            :disabled="startGameDisabled"
+            data-test="account-list-start"
+            @click="handleStartGame"
           >
-            <el-icon><Refresh /></el-icon>
+            <el-icon><VideoPlay /></el-icon>
+            <span>{{ t('GameStart') }}</span>
           </button>
-        </div>
-        <button
-          type="button"
-          class="account-list__quick-link bf-glass-card bf-ghost-border"
-          data-test="account-list-gash-recharge"
-          @click="handleGashRecharge"
-        >
-          <el-icon><Wallet /></el-icon>
-          <span>{{ t('GashRecharge') }}</span>
-        </button>
-        <button
-          type="button"
-          class="account-list__quick-link bf-glass-card bf-ghost-border"
-          data-test="account-list-app-gash-recharge"
-          @click="handleAppGashRecharge"
-        >
-          <el-icon><Iphone /></el-icon>
-          <span>{{ t('AppGashRecharge') }}</span>
-        </button>
-        <button
-          type="button"
-          class="account-list__quick-link bf-glass-card bf-ghost-border"
-          data-test="account-list-member-center"
-          @click="handleMemberCenter"
-        >
-          <el-icon><User /></el-icon>
-          <span>{{ t('accountList.memberCenter') }}</span>
-        </button>
-        <button
-          type="button"
-          class="account-list__quick-link bf-glass-card bf-ghost-border"
-          data-test="account-list-customer-service"
-          @click="handleCustomerService"
-        >
-          <el-icon><Service /></el-icon>
-          <span>{{ t('accountList.customerService') }}</span>
-        </button>
-      </section>
+        </section>
 
-      <!-- Service accounts list — 4 rendered states (REAL) -->
-      <section class="account-list__list bf-glass-panel">
-        <header class="account-list__list-header">
-          <h2 class="account-list__list-title">
-            {{ t('accountList.serviceAccountsHeading') }}
-          </h2>
-          <span class="account-list__list-count" data-test="account-list-count">
-            {{ t('accountList.accountCount', { count: accountCount }) }}
-          </span>
-        </header>
-
-        <div class="account-list__list-body bf-custom-scrollbar">
-          <p
-            v-if="loadState === 'loading'"
-            class="account-list__list-state"
-            data-test="account-list-loading"
-          >
-            {{ t('accountList.loading') }}
-          </p>
-
-          <div
-            v-else-if="loadState === 'error'"
-            class="account-list__list-state account-list__list-state--error"
-            data-test="account-list-error"
-          >
-            <p>{{ loadError ?? t('accountList.loadFailed') }}</p>
-            <el-button
-              type="primary"
-              plain
-              size="small"
-              data-test="account-list-retry"
-              @click="loadList"
+        <!-- Quick actions row: balance + member center + support (all stubs) -->
+        <section class="account-list__quick">
+          <div class="account-list__balance bf-glass-card bf-ghost-border">
+            <div class="account-list__balance-text">
+              <span class="account-list__balance-label">
+                {{ t('accountList.gashBalance') }}
+              </span>
+              <span class="account-list__balance-value" data-test="account-list-balance-value">
+                {{ formattedRemainPoint }}
+              </span>
+            </div>
+            <button
+              type="button"
+              class="account-list__balance-refresh"
+              :class="{ 'account-list__balance-refresh--spinning': refreshing }"
+              :title="t('accountList.refreshBalance')"
+              :disabled="refreshing"
+              data-test="account-list-refresh-balance"
+              @click="handleRefreshBalance"
             >
-              {{ t('accountList.retry') }}
-            </el-button>
+              <el-icon><Refresh /></el-icon>
+            </button>
           </div>
-
-          <p
-            v-else-if="serviceAccounts.length === 0"
-            class="account-list__list-state"
-            data-test="account-list-empty"
+          <button
+            type="button"
+            class="account-list__quick-link bf-glass-card bf-ghost-border"
+            data-test="account-list-gash-recharge"
+            @click="handleGashRecharge"
           >
-            {{ t('accountList.empty') }}
-          </p>
+            <el-icon><Wallet /></el-icon>
+            <span>{{ t('GashRecharge') }}</span>
+          </button>
+          <button
+            type="button"
+            class="account-list__quick-link bf-glass-card bf-ghost-border"
+            data-test="account-list-app-gash-recharge"
+            @click="handleAppGashRecharge"
+          >
+            <el-icon><Iphone /></el-icon>
+            <span>{{ t('AppGashRecharge') }}</span>
+          </button>
+          <button
+            type="button"
+            class="account-list__quick-link bf-glass-card bf-ghost-border"
+            data-test="account-list-member-center"
+            @click="handleMemberCenter"
+          >
+            <el-icon><User /></el-icon>
+            <span>{{ t('accountList.memberCenter') }}</span>
+          </button>
+          <button
+            type="button"
+            class="account-list__quick-link bf-glass-card bf-ghost-border"
+            data-test="account-list-customer-service"
+            @click="handleCustomerService"
+          >
+            <el-icon><Service /></el-icon>
+            <span>{{ t('accountList.customerService') }}</span>
+          </button>
+        </section>
 
-          <!--
+        <!-- Service accounts list — 4 rendered states (REAL) -->
+        <section class="account-list__list bf-glass-panel">
+          <header class="account-list__list-header">
+            <h2 class="account-list__list-title">
+              {{ t('accountList.serviceAccountsHeading') }}
+            </h2>
+            <span class="account-list__list-count" data-test="account-list-count">
+              {{ t('accountList.accountCount', { count: accountCount }) }}
+            </span>
+          </header>
+
+          <div class="account-list__list-body bf-custom-scrollbar">
+            <p
+              v-if="loadState === 'loading'"
+              class="account-list__list-state"
+              data-test="account-list-loading"
+            >
+              {{ t('accountList.loading') }}
+            </p>
+
+            <div
+              v-else-if="loadState === 'error'"
+              class="account-list__list-state account-list__list-state--error"
+              data-test="account-list-error"
+            >
+              <p>{{ loadError ?? t('accountList.loadFailed') }}</p>
+              <el-button
+                type="primary"
+                plain
+                size="small"
+                data-test="account-list-retry"
+                @click="loadList"
+              >
+                {{ t('accountList.retry') }}
+              </el-button>
+            </div>
+
+            <p
+              v-else-if="serviceAccounts.length === 0"
+              class="account-list__list-state"
+              data-test="account-list-empty"
+            >
+              {{ t('accountList.empty') }}
+            </p>
+
+            <!--
             D7: SortableJS (via `rowsRef` + `watch`) makes the row
             list drag-sortable. The `handle` option mirrors WPF's
             `_isHandlePressed` gate — only mouse-down on the grip
@@ -2083,77 +2083,72 @@ onBeforeUnmount(destroySortable)
             to `selectRow`. `ghostClass` styles the placeholder
             slot during drag (defined at bottom of <style scoped>).
           -->
-          <ul
-            v-else
-            ref="rowsRef"
-            class="account-list__rows"
-            data-test="account-list-rows"
-          >
-            <li
-              v-for="(a, idx) in serviceAccounts"
-              :key="a.sid"
-              class="account-list__row"
-              :class="{
-                'account-list__row--selected': isSelected(a),
-                'account-list__row--banned': !a.is_enable,
-              }"
-              :data-test="`account-row-${a.sid}`"
-              @click="selectRow(a)"
-            >
-              <span
-                class="account-list__row-grip"
-                :title="t('accountList.dragHandle')"
-                aria-hidden="true"
-                >⋮⋮</span
+            <ul v-else ref="rowsRef" class="account-list__rows" data-test="account-list-rows">
+              <li
+                v-for="(a, idx) in serviceAccounts"
+                :key="a.sid"
+                class="account-list__row"
+                :class="{
+                  'account-list__row--selected': isSelected(a),
+                  'account-list__row--banned': !a.is_enable,
+                }"
+                :data-test="`account-row-${a.sid}`"
+                @click="selectRow(a)"
               >
-              <span class="account-list__row-num">{{ idx + 1 }}</span>
-              <div class="account-list__row-info">
-                <p class="account-list__row-name">{{ a.sname }}</p>
-                <p class="account-list__row-sub">
-                  <template v-if="a.is_enable">ID: {{ a.sid }}</template>
-                  <template v-else>{{ t('accountList.statusBanned') }}</template>
-                </p>
-              </div>
-              <el-dropdown
-                trigger="click"
-                placement="bottom-end"
-                :hide-on-click="true"
-                popper-class="account-list__row-menu-popper"
-                @click.stop
-              >
-                <button
-                  type="button"
-                  class="account-list__row-more"
-                  :title="t('accountList.moreActions')"
-                  :data-test="`account-row-more-${a.sid}`"
+                <span
+                  class="account-list__row-grip"
+                  :title="t('accountList.dragHandle')"
+                  aria-hidden="true"
+                  >⋮⋮</span
+                >
+                <span class="account-list__row-num">{{ idx + 1 }}</span>
+                <div class="account-list__row-info">
+                  <p class="account-list__row-name">{{ a.sname }}</p>
+                  <p class="account-list__row-sub">
+                    <template v-if="a.is_enable">ID: {{ a.sid }}</template>
+                    <template v-else>{{ t('accountList.statusBanned') }}</template>
+                  </p>
+                </div>
+                <el-dropdown
+                  trigger="click"
+                  placement="bottom-end"
+                  :hide-on-click="true"
+                  popper-class="account-list__row-menu-popper"
                   @click.stop
                 >
-                  <el-icon><MoreFilled /></el-icon>
-                </button>
-                <template #dropdown>
-                  <el-dropdown-menu>
-                    <el-dropdown-item
-                      :data-test="`account-row-change-alias-${a.sid}`"
-                      @click="handleChangeAlias(a)"
-                    >
-                      <el-icon><EditPen /></el-icon>
-                      <span>{{ t('ChangeAccountName') }}</span>
-                    </el-dropdown-item>
-                    <el-dropdown-item
-                      :data-test="`account-row-info-${a.sid}`"
-                      @click="handleAccountInfo(a)"
-                    >
-                      <el-icon><InfoFilled /></el-icon>
-                      <span>{{ t('GameAccountInfo') }}</span>
-                    </el-dropdown-item>
-                    <el-dropdown-item
-                      :data-test="`account-row-get-email-${a.sid}`"
-                      @click="handleGetEmail"
-                    >
-                      <el-icon><Message /></el-icon>
-                      <span>{{ t('CheckEmail') }}</span>
-                    </el-dropdown-item>
-                    <!--
+                  <button
+                    type="button"
+                    class="account-list__row-more"
+                    :title="t('accountList.moreActions')"
+                    :data-test="`account-row-more-${a.sid}`"
+                    @click.stop
+                  >
+                    <el-icon><MoreFilled /></el-icon>
+                  </button>
+                  <template #dropdown>
+                    <el-dropdown-menu>
+                      <el-dropdown-item
+                        :data-test="`account-row-change-alias-${a.sid}`"
+                        @click="handleChangeAlias(a)"
+                      >
+                        <el-icon><EditPen /></el-icon>
+                        <span>{{ t('ChangeAccountName') }}</span>
+                      </el-dropdown-item>
+                      <el-dropdown-item
+                        :data-test="`account-row-info-${a.sid}`"
+                        @click="handleAccountInfo(a)"
+                      >
+                        <el-icon><InfoFilled /></el-icon>
+                        <span>{{ t('GameAccountInfo') }}</span>
+                      </el-dropdown-item>
+                      <el-dropdown-item
+                        :data-test="`account-row-get-email-${a.sid}`"
+                        @click="handleGetEmail"
+                      >
+                        <el-icon><Message /></el-icon>
+                        <span>{{ t('CheckEmail') }}</span>
+                      </el-dropdown-item>
+                      <!--
                       D8h: Change Password menu item only appears for
                       unconnected games (mirrors WPF
                       `m_ChangePassword.Visibility` toggled by
@@ -2163,68 +2158,68 @@ onBeforeUnmount(destroySortable)
                       opened from the page-level chrome — no
                       per-row affordance is needed there.
                     -->
-                    <el-dropdown-item
-                      v-if="game.isUnconnectedGame"
-                      :data-test="`account-row-change-password-${a.sid}`"
-                      @click="handleChangePassword(a)"
-                    >
-                      <el-icon><Key /></el-icon>
-                      <span>{{ t('ChangePassword') }}</span>
-                    </el-dropdown-item>
-                  </el-dropdown-menu>
-                </template>
-              </el-dropdown>
-            </li>
-          </ul>
-        </div>
+                      <el-dropdown-item
+                        v-if="game.isUnconnectedGame"
+                        :data-test="`account-row-change-password-${a.sid}`"
+                        @click="handleChangePassword(a)"
+                      >
+                        <el-icon><Key /></el-icon>
+                        <span>{{ t('ChangePassword') }}</span>
+                      </el-dropdown-item>
+                    </el-dropdown-menu>
+                  </template>
+                </el-dropdown>
+              </li>
+            </ul>
+          </div>
 
-        <footer class="account-list__list-footer">
-          <p
-            v-if="limitNoticeText"
-            class="account-list__limit-notice"
-            data-test="account-list-limit-notice"
-          >
-            {{ limitNoticeText }}
-          </p>
-          <button
-            type="button"
-            class="account-list__add-btn"
-            :class="{ 'account-list__add-btn--disabled': isAddAccountDisabled }"
-            :disabled="isAddAccountDisabled"
-            data-test="account-list-add"
-            @click="handleAddAccount"
-          >
-            <el-icon><Plus /></el-icon>
-            <span>{{ t('AddServiceAccount') }}</span>
-          </button>
-        </footer>
-      </section>
+          <footer class="account-list__list-footer">
+            <p
+              v-if="limitNoticeText"
+              class="account-list__limit-notice"
+              data-test="account-list-limit-notice"
+            >
+              {{ limitNoticeText }}
+            </p>
+            <button
+              type="button"
+              class="account-list__add-btn"
+              :class="{ 'account-list__add-btn--disabled': isAddAccountDisabled }"
+              :disabled="isAddAccountDisabled"
+              data-test="account-list-add"
+              @click="handleAddAccount"
+            >
+              <el-icon><Plus /></el-icon>
+              <span>{{ t('AddServiceAccount') }}</span>
+            </button>
+          </footer>
+        </section>
 
-      <!-- Add Service Account modal (D3) — mounted unconditionally so its
+        <!-- Add Service Account modal (D3) — mounted unconditionally so its
            transitions can play; visibility is driven by `addAccountVisible`. -->
-      <AddServiceAccount v-model:visible="addAccountVisible" />
+        <AddServiceAccount v-model:visible="addAccountVisible" />
 
-      <!-- Change Service Account display-name modal (D4) — same mount-always
+        <!-- Change Service Account display-name modal (D4) — same mount-always
            pattern as D3. `changeAliasTarget` is cleared by the watcher above
            so stale account refs don't leak between sessions. -->
-      <ChangeServiceAccountDisplayName
-        v-model:visible="changeAliasVisible"
-        :account="changeAliasTarget"
-      />
+        <ChangeServiceAccountDisplayName
+          v-model:visible="changeAliasVisible"
+          :account="changeAliasTarget"
+        />
 
-      <!-- Service Account read-only info modal (D6) — same mount-always
+        <!-- Service Account read-only info modal (D6) — same mount-always
            pattern as D3 / D4. `accountInfoTarget` is cleared by the
            watcher above so stale account refs don't leak between sessions. -->
-      <ServiceAccountInfo v-model:visible="accountInfoVisible" :account="accountInfoTarget" />
+        <ServiceAccountInfo v-model:visible="accountInfoVisible" :account="accountInfoTarget" />
 
-      <!-- Generic copy-box dialog (D10.1) — currently driven by Get Email
+        <!-- Generic copy-box dialog (D10.1) — currently driven by Get Email
            (D10.5); future per-row context-menu items that need a similar
            "show + copy" affordance can reuse the same single mount by
            writing into `copyBoxTitle` / `copyBoxValue` before flipping
            `copyBoxVisible`. -->
-      <CopyBox v-model:visible="copyBoxVisible" :title="copyBoxTitle" :value="copyBoxValue" />
+        <CopyBox v-model:visible="copyBoxVisible" :title="copyBoxTitle" :value="copyBoxValue" />
 
-      <!-- D8c: Game picker dialog. Driven by either the Change Game
+        <!-- D8c: Game picker dialog. Driven by either the Change Game
            button on the game info bar or the mount-time auto-open
            inside `setupGameOnMount` (when no valid `loginGame`
            resolves against the loaded catalogue). The dialog
@@ -2240,36 +2235,36 @@ onBeforeUnmount(destroySortable)
            fallback (see `gameImageUrl` for the same defensive
            pattern); the gate is the cleaner option here because
            the dialog can't usefully open without a region anyway. -->
-      <GameList
-        v-if="auth.session"
-        v-model:visible="gameListVisible"
-        :region="auth.session.region"
-        @select="handleGameSelected"
-      />
+        <GameList
+          v-if="auth.session"
+          v-model:visible="gameListVisible"
+          :region="auth.session.region"
+          @select="handleGameSelected"
+        />
 
-      <!-- D8g: Unconnected-game Add Account dialog. Mounted alongside
+        <!-- D8g: Unconnected-game Add Account dialog. Mounted alongside
            the regular `<AddServiceAccount />` above; `handleAddAccount`
            dispatches between the two on `game.isUnconnectedGame`.
            The `created` event refreshes the row list so the new
            account appears immediately. -->
-      <UnconnectedGameAddAccount
-        v-model:visible="unconnectedAddVisible"
-        @created="handleUnconnectedAccountCreated"
-      />
+        <UnconnectedGameAddAccount
+          v-model:visible="unconnectedAddVisible"
+          @created="handleUnconnectedAccountCreated"
+        />
 
-      <!-- D8h: Unconnected-game Change Password dialog. Driven by the
+        <!-- D8h: Unconnected-game Change Password dialog. Driven by the
            per-row Change Password menu item (which is itself
            `v-if`-gated on `game.isUnconnectedGame`). The `accountIndex`
            prop is the row's 0-based index in `account.serviceAccounts`,
            captured at menu-trigger time so a downstream selection /
            reorder can't misroute the change-password POST. -->
-      <UnconnectedGameChangePassword
-        v-model:visible="changePasswordVisible"
-        :account-index="changePasswordAccountIndex"
-        @verify-code-sent="handleChangePasswordSent"
-      />
+        <UnconnectedGameChangePassword
+          v-model:visible="changePasswordVisible"
+          :account-index="changePasswordAccountIndex"
+          @verify-code-sent="handleChangePasswordSent"
+        />
 
-      <!-- P12.5 D7: Tools dialog stack — single mount that hosts
+        <!-- P12.5 D7: Tools dialog stack — single mount that hosts
            MapleTools / KartTools / EquipCalculator /
            CoreCalculator (in-app browser routed via composable;
            see followup-B B7). Opened imperatively by `handleTools` via
@@ -2279,59 +2274,59 @@ onBeforeUnmount(destroySortable)
            internal dialog mounts can play their open transitions
            on first open; per-dialog visibility is owned inside
            the wrapper. -->
-      <ToolsDialogStack ref="toolsDialogRef" />
+        <ToolsDialogStack ref="toolsDialogRef" />
 
-      <!-- OTP section (D5: REAL Get OTP / clipboard / auto-paste flow) -->
-      <section class="account-list__otp bf-glass-panel">
-        <header class="account-list__otp-header">
-          <h2 class="account-list__otp-title">{{ t('accountList.otpHeading') }}</h2>
-          <!--
+        <!-- OTP section (D5: REAL Get OTP / clipboard / auto-paste flow) -->
+        <section class="account-list__otp bf-glass-panel">
+          <header class="account-list__otp-header">
+            <h2 class="account-list__otp-title">{{ t('accountList.otpHeading') }}</h2>
+            <!--
             D5: bind via :model-value + @change (not v-model) so the
             persistence + first-time-AutoPasteTip side effects only run
             on the user's gesture, not on the setup-time hydration of
             the local ref from configStore.
           -->
-          <el-checkbox
-            :model-value="autoPaste"
-            size="small"
-            data-test="account-list-auto-paste"
-            @change="handleAutoPasteToggle"
-          >
-            {{ t('accountList.autoPaste') }}
-          </el-checkbox>
-        </header>
-        <div class="account-list__otp-row">
-          <div class="account-list__otp-input">
-            <input
-              type="text"
-              readonly
-              :value="otpValue"
-              :placeholder="t('accountList.otpPlaceholder')"
-              class="account-list__otp-field"
-              data-test="account-list-otp-field"
-            />
+            <el-checkbox
+              :model-value="autoPaste"
+              size="small"
+              data-test="account-list-auto-paste"
+              @change="handleAutoPasteToggle"
+            >
+              {{ t('accountList.autoPaste') }}
+            </el-checkbox>
+          </header>
+          <div class="account-list__otp-row">
+            <div class="account-list__otp-input">
+              <input
+                type="text"
+                readonly
+                :value="otpValue"
+                :placeholder="t('accountList.otpPlaceholder')"
+                class="account-list__otp-field"
+                data-test="account-list-otp-field"
+              />
+              <button
+                type="button"
+                class="account-list__otp-copy"
+                :title="t('accountList.copyOtp')"
+                :disabled="!otpValue"
+                data-test="account-list-otp-copy"
+                @click="handleCopyOtp"
+              >
+                <el-icon><DocumentCopy /></el-icon>
+              </button>
+            </div>
             <button
               type="button"
-              class="account-list__otp-copy"
-              :title="t('accountList.copyOtp')"
-              :disabled="!otpValue"
-              data-test="account-list-otp-copy"
-              @click="handleCopyOtp"
+              class="bf-btn-gradient account-list__otp-get"
+              :disabled="gettingOtp"
+              data-test="account-list-otp-get"
+              @click="handleGetOtp"
             >
-              <el-icon><DocumentCopy /></el-icon>
+              {{ gettingOtp ? t('GettingOtp') : t('GetOtp') }}
             </button>
           </div>
-          <button
-            type="button"
-            class="bf-btn-gradient account-list__otp-get"
-            :disabled="gettingOtp"
-            data-test="account-list-otp-get"
-            @click="handleGetOtp"
-          >
-            {{ gettingOtp ? t('GettingOtp') : t('GetOtp') }}
-          </button>
-        </div>
-      </section>
+        </section>
       </div>
     </div>
   </main>
@@ -2393,7 +2388,6 @@ onBeforeUnmount(destroySortable)
   flex: 1;
   min-width: 0;
 }
-
 
 .account-list__title {
   margin: 0;

--- a/src/pages/GamepassForm.vue
+++ b/src/pages/GamepassForm.vue
@@ -271,7 +271,7 @@ onMounted(async () => {
   if (region !== 'TW') {
     ElMessage.info(t('loginGamepass.unsupportedHK'))
     disposed = true
-    await router.push('/login')
+    await router.push({ path: '/login', query: { pick: '1' } })
     return
   }
   // Event listeners MUST register before `doStart` invokes
@@ -312,7 +312,7 @@ async function refresh(): Promise<void> {
 
 async function goBack(): Promise<void> {
   disposed = true
-  await router.push('/login')
+  await router.push({ path: '/login', query: { pick: '1' } })
 }
 </script>
 

--- a/src/pages/IdPassForm.vue
+++ b/src/pages/IdPassForm.vue
@@ -248,12 +248,11 @@ function prefillFromStoredRecord(): void {
 
 function goBack(): void {
   /*
-   * Use explicit `push('/login')` instead of `router.back()` — browser
-   * history may contain `/login/qr` or other siblings if the user
-   * landed here via forward-nav, and "back" in the WPF sense always
-   * means the region picker.
+   * Navigate to the region picker with `?pick=1` so the auto-
+   * redirect guard in `LoginRegionSelection.vue` does not fire —
+   * the user explicitly wants to change their region.
    */
-  void router.push('/login')
+  void router.push({ path: '/login', query: { pick: '1' } })
 }
 
 function switchToQr(): void {

--- a/src/pages/LoginPage.vue
+++ b/src/pages/LoginPage.vue
@@ -2,122 +2,128 @@
 /**
  * Login shell — the WPF `LoginPage.xaml` equivalent.
  *
- * # Why a shell instead of one big page?
- *
- * The WPF original is a near-empty `<Frame>` that hosts one of three
- * forms (`id_pass_form`, `qr_form`, `gamepass_form`) plus the modal
- * sub-flows (TOTP, captcha, wait spinner). Mirroring that structure
- * with `<RouterView />` keeps each form a self-contained route:
- *
- * - `/login/region`    — region picker (TW / HK), entry point
- * - `/login/id-pass`   — account+password form
- * - `/login/qr`        — QR-code login
- * - `/login/gamepass`  — GamePass login (opens Tauri WebviewWindow)
- * - `/login/totp`      — TOTP challenge
- * - `/login/wait`      — pending callback / handshake spinner
- * - `/login/verify`    — captcha + verify code
- *
- * Children are added route-by-route in P12.1 D2-D8; this D1 commit
- * only ships the shell + the empty `<RouterView />` slot so each
- * subsequent D-step has a stable mount point.
- *
- * # Title bar
- *
- * Currently relies on the OS-provided window decoration (Tauri
- * default). Migrating to a custom drag-region title bar (matching the
- * mockup's `title-bar` div) is a P12.4 concern — it touches every
- * page, not just login, so it lives in the Settings / shell-overhaul
- * D-step rather than here.
+ * The glass-panel IS the window body. Tauri runs with
+ * `decorations: false` + `transparent: true` so only the rounded
+ * card is visible. TitleBar provides drag + minimize / close.
  */
 
 import { computed } from 'vue'
-import { useI18n } from 'vue-i18n'
-
-import iconUrl from '../assets/icon-outline.png'
+import { useRoute, useRouter } from 'vue-router'
+import TitleBar from '../components/TitleBar.vue'
+import { useConfigStore } from '../stores/config'
+import type { LoginRegion } from '../types/bindings'
 
 defineOptions({ name: 'LoginPage' })
 
-const { t } = useI18n()
+const route = useRoute()
+const router = useRouter()
+const config = useConfigStore()
 
-const heading = computed(() => t('loginShell.heading'))
-const subline = computed(() => t('loginShell.subline'))
+const currentRegion = computed(() => (config.get('loginRegion') as LoginRegion | undefined) ?? 'TW')
+
+/** True when we're on the region picker itself — hide the switcher there. */
+const isRegionPage = computed(() => route.name === 'login-region')
+
+async function toggleRegion(): Promise<void> {
+  const next: LoginRegion = currentRegion.value === 'TW' ? 'HK' : 'TW'
+  await config.set('loginRegion', next)
+  // Navigate back to id-pass so any active QR/GamePass session is abandoned
+  if (route.path !== '/login/id-pass') {
+    await router.replace('/login/id-pass')
+  }
+}
+
+function handleOpenSettings(): void {
+  void router.push('/settings')
+}
+
+function handleOpenAbout(): void {
+  void router.push('/about')
+}
 </script>
 
 <template>
-  <main class="login-shell bf-mica-bg">
-    <section class="login-shell__panel bf-glass-panel">
-      <header class="login-shell__header">
-        <div class="login-shell__brand">
-          <img :src="iconUrl" alt="Beanfun" class="login-shell__icon" />
-          <h1 class="login-shell__title">{{ heading }}</h1>
-        </div>
-        <p class="login-shell__subline">{{ subline }}</p>
-      </header>
-      <div class="login-shell__body">
-        <RouterView />
-      </div>
-    </section>
-  </main>
+  <section class="login-shell bf-glass-window" data-window-root>
+    <TitleBar>
+      <button
+        v-if="!isRegionPage"
+        type="button"
+        class="login-shell__region-btn"
+        :title="`Region: ${currentRegion}`"
+        @click="toggleRegion"
+      >
+        <span class="material-symbols-outlined login-shell__region-icon">public</span>
+        <span class="login-shell__region-label">{{ currentRegion }}</span>
+      </button>
+      <button type="button" class="login-shell__action-btn" @click="handleOpenSettings">
+        <span class="material-symbols-outlined">settings</span>
+      </button>
+      <button type="button" class="login-shell__action-btn" @click="handleOpenAbout">
+        <span class="material-symbols-outlined">info</span>
+      </button>
+    </TitleBar>
+    <div class="login-shell__body">
+      <RouterView />
+    </div>
+  </section>
 </template>
 
 <style scoped>
-/*
- * P12.2 D1 refactor: page-level chrome (background gradient + glass
- * surface) moved to project-wide utility classes
- * (`bf-mica-bg`, `bf-glass-panel`) declared in `src/styles/utilities.css`.
- * Only LoginPage-specific layout (size/spacing) stays here so adding
- * a second top-level page (P12.2 AccountList) reuses the same
- * primitives instead of copy-pasting the rgba/blur soup.
- */
 .login-shell {
-  box-sizing: border-box;
-  min-height: 100vh;
-  display: grid;
-  place-items: center;
-  padding: 2rem;
-}
-
-.login-shell__panel {
-  width: 100%;
-  max-width: 560px;
+  display: flex;
+  flex-direction: column;
   overflow: hidden;
 }
 
-.login-shell__header {
-  padding: 2rem 2rem 1rem;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.4);
-  text-align: center;
-}
-
-.login-shell__brand {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.5rem;
-}
-
-.login-shell__icon {
-  height: 36px;
-  width: auto;
-  flex-shrink: 0;
-}
-
-.login-shell__title {
-  margin: 0;
-  font-size: 1.5rem;
-  font-weight: 800;
-  letter-spacing: -0.01em;
-  color: var(--bf-on-surface);
-}
-
-.login-shell__subline {
-  margin: 0.5rem 0 0;
-  font-size: 0.875rem;
-  color: var(--bf-on-surface-variant);
-}
-
 .login-shell__body {
-  padding: 2rem;
-  min-height: 240px;
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 1.5rem;
+}
+
+.login-shell__action-btn {
+  appearance: none;
+  background: transparent;
+  border: none;
+  width: 28px;
+  height: 28px;
+  display: grid;
+  place-items: center;
+  border-radius: 6px;
+  cursor: pointer;
+  color: var(--bf-on-surface-variant, #54443a);
+  transition: background 150ms ease;
+  padding: 0;
+}
+.login-shell__action-btn .material-symbols-outlined {
+  font-size: 18px;
+}
+.login-shell__action-btn:hover {
+  background: rgba(0, 0, 0, 0.06);
+}
+
+.login-shell__region-btn {
+  appearance: none;
+  background: color-mix(in srgb, var(--bf-primary-container, #ff8201) 15%, transparent);
+  border: 1px solid color-mix(in srgb, var(--bf-primary-container, #ff8201) 30%, transparent);
+  height: 26px;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0 0.5rem 0 0.25rem;
+  border-radius: 6px;
+  cursor: pointer;
+  color: var(--bf-primary, #954a00);
+  font: inherit;
+  font-size: 11px;
+  font-weight: 700;
+  transition: background 150ms ease;
+}
+.login-shell__region-icon {
+  font-size: 14px;
+}
+.login-shell__region-btn:hover {
+  background: color-mix(in srgb, var(--bf-primary-container, #ff8201) 25%, transparent);
 }
 </style>

--- a/src/pages/LoginRegionSelection.vue
+++ b/src/pages/LoginRegionSelection.vue
@@ -11,36 +11,36 @@
  * 2. On click, persists the choice to Config.xml under the legacy
  *    `loginRegion` key (so old WPF installs reading the same file see
  *    the value preserved verbatim).
- * 3. Navigates to the next step in the login funnel — the regular
- *    id-pass form. Future P12.1 D-steps may swap the destination
- *    based on the previously-used login method (the WPF
- *    `MainWindow.Initialize()` logic).
+ * 3. Navigates to the next step in the login funnel based on the
+ *    saved `loginMethod` — regular id-pass form (`0`) or QR form
+ *    (`1`, TW only). HK always routes to id-pass because the HK
+ *    portal does not expose the QR endpoint.
  *
- * # WPF deviation (intentional)
+ * # Auto-redirect (WPF `loginMethodInit` parity)
  *
- * WPF only popped this window on `LoadDataError` (catch path);
- * normal boots silently used the cached `App.LoginRegion`. We elevate
- * it to a real route here because:
+ * WPF only popped `LoginRegionSelection.xaml` on `LoadDataError`;
+ * normal boots silently used the cached `App.LoginRegion` and
+ * `App.LoginMethod` to jump straight to the correct form
+ * (`MainWindow.xaml.cs::loginMethodInit` L1027-1114).
  *
- * - The mockup design (`mockups/LoginRegionSelection.html`) expects
- *   it to be a deliberate first-time-setup screen.
- * - SPA navigation feels more natural with route-driven UI than with
- *   imperative `ShowDialog()` calls.
- *
- * The "skip picker if already chosen" logic is a P12.1 D10 concern
- * (router `beforeEach` guard); D2 keeps the picker reachable so the
- * first-launch + manual region-switch flows both work.
+ * The SPA mirrors this by watching `config.loaded`: once the
+ * Config.xml snapshot is available, if a `loginRegion` is already
+ * saved **and** the route has no `?pick` query, the picker replaces
+ * itself with the target form via `router.replace`. The `?pick`
+ * escape hatch lets login-form back buttons return the user to the
+ * picker without triggering the redirect again.
  */
 
-import { computed } from 'vue'
+import { computed, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { useRouter } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import { useConfigStore } from '../stores/config'
 import type { LoginRegion } from '../types/bindings'
 
 defineOptions({ name: 'LoginRegionSelection' })
 
 const { t } = useI18n()
+const route = useRoute()
 const router = useRouter()
 const config = useConfigStore()
 
@@ -76,20 +76,38 @@ const heading = computed(() => t('BeanfunRegionSelected'))
 const subline = computed(() => t('loginRegion.subline'))
 const tip = computed(() => t('loginRegion.tip'))
 
-async function selectRegion(region: LoginRegion): Promise<void> {
-  /*
-   * Match the WPF `loginRegion` key verbatim so an existing user
-   * picking up the new build sees their region choice survive.
-   */
-  await config.set('loginRegion', region)
+/**
+ * Resolve the login form path for a given region, honouring the
+ * saved `loginMethod` preference. QR (`loginMethod === '1'`) is
+ * TW-only; HK always falls back to id-pass.
+ */
+function resolveLoginPath(region: LoginRegion): string {
+  const method = config.get('loginMethod')
+  if (method === '1' && region === 'TW') return '/login/qr'
+  return '/login/id-pass'
+}
 
-  /*
-   * Forward to the regular id-pass form by default. The "remember
-   * last login method" branch (WPF `loginMethodInit`) lands in the
-   * D10 router guard once `/login/qr` and `/login/gamepass` exist as
-   * destinations.
-   */
-  await router.push('/login/id-pass')
+/*
+ * Auto-redirect: once config is loaded, if a region is already
+ * saved and the user didn't explicitly ask for the picker
+ * (`?pick=1`), jump straight to the correct login form.
+ */
+watch(
+  () => config.loaded,
+  (loaded) => {
+    if (!loaded) return
+    if (route.query.pick) return
+    const saved = config.get('loginRegion')
+    if (saved === 'TW' || saved === 'HK') {
+      void router.replace(resolveLoginPath(saved as LoginRegion))
+    }
+  },
+  { immediate: true },
+)
+
+async function selectRegion(region: LoginRegion): Promise<void> {
+  await config.set('loginRegion', region)
+  await router.push(resolveLoginPath(region))
 }
 </script>
 

--- a/src/pages/ManageAccount.vue
+++ b/src/pages/ManageAccount.vue
@@ -105,6 +105,7 @@ import AddAccount from '../windows/AddAccount.vue'
 import ChangeAccount from '../windows/ChangeAccount.vue'
 import { useAccountStore } from '../stores/account'
 import type { Account } from '../types/bindings'
+import TitleBar from '../components/TitleBar.vue'
 
 defineOptions({ name: 'ManageAccount' })
 
@@ -498,208 +499,213 @@ function handleBack(): void {
 </script>
 
 <template>
-  <main class="manage bf-mica-bg">
-    <div class="manage__container">
-      <!-- Header -->
-      <header class="manage__header">
-        <div class="manage__header-icon" aria-hidden="true">
-          <el-icon :size="24"><UserFilled /></el-icon>
-        </div>
-        <div class="manage__header-text">
-          <h1 class="manage__title bf-text-gradient">{{ t('ManageAccount') }}</h1>
-          <p class="manage__subline">{{ t('manageAccount.subtitle') }}</p>
-        </div>
-      </header>
-
-      <!-- Toolbar: search + import / export / add -->
-      <section class="manage__toolbar bf-glass-panel">
-        <div class="manage__toolbar-search">
-          <el-input
-            v-model="query"
-            :placeholder="t('manageAccount.searchPlaceholder')"
-            :disabled="loadState === 'loading'"
-            clearable
-            data-test="manage-account-search"
-          >
-            <template #prefix>
-              <el-icon><Search /></el-icon>
-            </template>
-          </el-input>
-        </div>
-        <div class="manage__toolbar-actions">
-          <el-button
-            class="bf-btn-secondary manage__action-btn"
-            :disabled="importing"
-            data-test="manage-account-import"
-            @click="handleImport"
-          >
-            <el-icon><Upload /></el-icon>
-            <span>{{ t('manageAccount.import') }}</span>
-          </el-button>
-          <el-button
-            class="bf-btn-secondary manage__action-btn"
-            :disabled="exporting || account.accounts.length === 0"
-            data-test="manage-account-export"
-            @click="handleExport"
-          >
-            <el-icon><Download /></el-icon>
-            <span>{{ t('manageAccount.export') }}</span>
-          </el-button>
-          <el-button
-            class="bf-btn-secondary manage__action-btn"
-            data-test="manage-account-backup"
-            @click="openBackup"
-          >
-            <el-icon><Lock /></el-icon>
-            <span>{{ t('DataBackup') }}</span>
-          </el-button>
-          <button
-            type="button"
-            class="bf-btn-gradient manage__action-btn"
-            data-test="manage-account-add"
-            @click="openAdd"
-          >
-            <el-icon><Plus /></el-icon>
-            <span>{{ t('Add') }}</span>
-          </button>
-        </div>
-      </section>
-
-      <!-- Stats: single card (Q7) -->
-      <section class="manage__stats">
-        <div class="manage__stat-card bf-glass-card bf-ghost-border">
-          <el-icon class="manage__stat-icon" :size="20"><UserFilled /></el-icon>
-          <div class="manage__stat-text">
-            <span class="manage__stat-label">
-              {{ t('manageAccount.totalAccounts') }}
-            </span>
-            <span class="manage__stat-value" data-test="manage-account-total">
-              {{ totalAccounts }}
-            </span>
+  <main class="manage bf-glass-window" data-window-root>
+    <TitleBar />
+    <div class="manage__scroll">
+      <div class="manage__container">
+        <!-- Header -->
+        <header class="manage__header">
+          <div class="manage__header-icon" aria-hidden="true">
+            <el-icon :size="24"><UserFilled /></el-icon>
           </div>
-        </div>
-      </section>
+          <div class="manage__header-text">
+            <h1 class="manage__title bf-text-gradient">{{ t('ManageAccount') }}</h1>
+            <p class="manage__subline">{{ t('manageAccount.subtitle') }}</p>
+          </div>
+        </header>
 
-      <!-- Table -->
-      <section class="manage__list bf-glass-panel">
-        <div class="manage__list-header">
-          <div class="manage__col-handle" />
-          <div class="manage__col-account">{{ t('manageAccount.colAccount') }}</div>
-          <div class="manage__col-remark">{{ t('manageAccount.colRemark') }}</div>
-          <div class="manage__col-region">{{ t('manageAccount.colRegion') }}</div>
-          <div class="manage__col-last">{{ t('manageAccount.colLastLogin') }}</div>
-          <div class="manage__col-actions">{{ t('manageAccount.colActions') }}</div>
-        </div>
-
-        <div class="manage__list-body bf-custom-scrollbar">
-          <p
-            v-if="loadState === 'loading'"
-            class="manage__list-state"
-            data-test="manage-account-loading"
-          >
-            {{ t('accountList.loading') }}
-          </p>
-
-          <div
-            v-else-if="loadState === 'error'"
-            class="manage__list-state manage__list-state--error"
-            data-test="manage-account-error"
-          >
-            <p>{{ loadError ?? t('accountList.loadFailed') }}</p>
+        <!-- Toolbar: search + import / export / add -->
+        <section class="manage__toolbar bf-glass-panel">
+          <div class="manage__toolbar-search">
+            <el-input
+              v-model="query"
+              :placeholder="t('manageAccount.searchPlaceholder')"
+              :disabled="loadState === 'loading'"
+              clearable
+              data-test="manage-account-search"
+            >
+              <template #prefix>
+                <el-icon><Search /></el-icon>
+              </template>
+            </el-input>
+          </div>
+          <div class="manage__toolbar-actions">
             <el-button
-              type="primary"
-              plain
-              size="small"
-              data-test="manage-account-retry"
-              @click="loadList"
+              class="bf-btn-secondary manage__action-btn"
+              :disabled="importing"
+              data-test="manage-account-import"
+              @click="handleImport"
             >
-              {{ t('accountList.retry') }}
+              <el-icon><Upload /></el-icon>
+              <span>{{ t('manageAccount.import') }}</span>
             </el-button>
-          </div>
-
-          <p
-            v-else-if="loadState === 'empty'"
-            class="manage__list-state"
-            data-test="manage-account-empty"
-          >
-            {{ t('manageAccount.empty') }}
-          </p>
-
-          <p
-            v-else-if="searchedAccounts.length === 0"
-            class="manage__list-state"
-            data-test="manage-account-no-search-result"
-          >
-            {{ t('manageAccount.noSearchResult') }}
-          </p>
-
-          <div
-            v-for="(row, index) in searchedAccounts"
-            v-else
-            :key="`${row.region}|${row.account_id}`"
-            class="manage__row"
-            :class="{ 'manage__row--last': index === searchedAccounts.length - 1 }"
-            :data-test="`manage-account-row-${row.region}-${row.account_id}`"
-          >
-            <span
-              class="manage__drag-handle"
-              :title="t('manageAccount.dragDisabledTip')"
-              data-test="manage-account-drag-handle"
+            <el-button
+              class="bf-btn-secondary manage__action-btn"
+              :disabled="exporting || account.accounts.length === 0"
+              data-test="manage-account-export"
+              @click="handleExport"
             >
-              <el-icon><Rank /></el-icon>
-            </span>
-            <div class="manage__cell-account">
-              <div class="manage__avatar" aria-hidden="true">{{ avatarGlyph(row) }}</div>
-              <span class="manage__account-id">{{ row.account_id }}</span>
-            </div>
-            <div class="manage__cell-remark">
-              <span v-if="row.account_name.trim().length > 0">{{ row.account_name }}</span>
-              <span v-else class="manage__remark-empty">
-                {{ t('manageAccount.remarkEmpty') }}
+              <el-icon><Download /></el-icon>
+              <span>{{ t('manageAccount.export') }}</span>
+            </el-button>
+            <el-button
+              class="bf-btn-secondary manage__action-btn"
+              data-test="manage-account-backup"
+              @click="openBackup"
+            >
+              <el-icon><Lock /></el-icon>
+              <span>{{ t('DataBackup') }}</span>
+            </el-button>
+            <button
+              type="button"
+              class="bf-btn-gradient manage__action-btn"
+              data-test="manage-account-add"
+              @click="openAdd"
+            >
+              <el-icon><Plus /></el-icon>
+              <span>{{ t('Add') }}</span>
+            </button>
+          </div>
+        </section>
+
+        <!-- Stats: single card (Q7) -->
+        <section class="manage__stats">
+          <div class="manage__stat-card bf-glass-card bf-ghost-border">
+            <el-icon class="manage__stat-icon" :size="20"><UserFilled /></el-icon>
+            <div class="manage__stat-text">
+              <span class="manage__stat-label">
+                {{ t('manageAccount.totalAccounts') }}
               </span>
-            </div>
-            <div class="manage__cell-region">
-              <span class="manage__chip" :class="{ 'manage__chip--primary': row.region === 'TW' }">
-                {{ regionLabel(row.region) }}
+              <span class="manage__stat-value" data-test="manage-account-total">
+                {{ totalAccounts }}
               </span>
-            </div>
-            <div class="manage__cell-last">
-              {{ t('manageAccount.lastLoginUnknown') }}
-            </div>
-            <div class="manage__cell-actions">
-              <button
-                type="button"
-                class="manage__icon-btn"
-                :title="t('manageAccount.editAction')"
-                :data-test="`manage-account-edit-${row.region}-${row.account_id}`"
-                @click="openEdit(row)"
-              >
-                <el-icon><EditPen /></el-icon>
-              </button>
-              <button
-                type="button"
-                class="manage__icon-btn"
-                :title="t('manageAccount.copyIdAction')"
-                :data-test="`manage-account-copy-${row.region}-${row.account_id}`"
-                @click="handleCopyId(row)"
-              >
-                <el-icon><DocumentCopy /></el-icon>
-              </button>
-              <button
-                type="button"
-                class="manage__icon-btn manage__icon-btn--danger"
-                :title="t('manageAccount.deleteAction')"
-                :data-test="`manage-account-delete-${row.region}-${row.account_id}`"
-                @click="handleDelete(row)"
-              >
-                <el-icon><Delete /></el-icon>
-              </button>
             </div>
           </div>
-        </div>
-      </section>
+        </section>
 
-      <!--
+        <!-- Table -->
+        <section class="manage__list bf-glass-panel">
+          <div class="manage__list-header">
+            <div class="manage__col-handle" />
+            <div class="manage__col-account">{{ t('manageAccount.colAccount') }}</div>
+            <div class="manage__col-remark">{{ t('manageAccount.colRemark') }}</div>
+            <div class="manage__col-region">{{ t('manageAccount.colRegion') }}</div>
+            <div class="manage__col-last">{{ t('manageAccount.colLastLogin') }}</div>
+            <div class="manage__col-actions">{{ t('manageAccount.colActions') }}</div>
+          </div>
+
+          <div class="manage__list-body bf-custom-scrollbar">
+            <p
+              v-if="loadState === 'loading'"
+              class="manage__list-state"
+              data-test="manage-account-loading"
+            >
+              {{ t('accountList.loading') }}
+            </p>
+
+            <div
+              v-else-if="loadState === 'error'"
+              class="manage__list-state manage__list-state--error"
+              data-test="manage-account-error"
+            >
+              <p>{{ loadError ?? t('accountList.loadFailed') }}</p>
+              <el-button
+                type="primary"
+                plain
+                size="small"
+                data-test="manage-account-retry"
+                @click="loadList"
+              >
+                {{ t('accountList.retry') }}
+              </el-button>
+            </div>
+
+            <p
+              v-else-if="loadState === 'empty'"
+              class="manage__list-state"
+              data-test="manage-account-empty"
+            >
+              {{ t('manageAccount.empty') }}
+            </p>
+
+            <p
+              v-else-if="searchedAccounts.length === 0"
+              class="manage__list-state"
+              data-test="manage-account-no-search-result"
+            >
+              {{ t('manageAccount.noSearchResult') }}
+            </p>
+
+            <div
+              v-for="(row, index) in searchedAccounts"
+              v-else
+              :key="`${row.region}|${row.account_id}`"
+              class="manage__row"
+              :class="{ 'manage__row--last': index === searchedAccounts.length - 1 }"
+              :data-test="`manage-account-row-${row.region}-${row.account_id}`"
+            >
+              <span
+                class="manage__drag-handle"
+                :title="t('manageAccount.dragDisabledTip')"
+                data-test="manage-account-drag-handle"
+              >
+                <el-icon><Rank /></el-icon>
+              </span>
+              <div class="manage__cell-account">
+                <div class="manage__avatar" aria-hidden="true">{{ avatarGlyph(row) }}</div>
+                <span class="manage__account-id">{{ row.account_id }}</span>
+              </div>
+              <div class="manage__cell-remark">
+                <span v-if="row.account_name.trim().length > 0">{{ row.account_name }}</span>
+                <span v-else class="manage__remark-empty">
+                  {{ t('manageAccount.remarkEmpty') }}
+                </span>
+              </div>
+              <div class="manage__cell-region">
+                <span
+                  class="manage__chip"
+                  :class="{ 'manage__chip--primary': row.region === 'TW' }"
+                >
+                  {{ regionLabel(row.region) }}
+                </span>
+              </div>
+              <div class="manage__cell-last">
+                {{ t('manageAccount.lastLoginUnknown') }}
+              </div>
+              <div class="manage__cell-actions">
+                <button
+                  type="button"
+                  class="manage__icon-btn"
+                  :title="t('manageAccount.editAction')"
+                  :data-test="`manage-account-edit-${row.region}-${row.account_id}`"
+                  @click="openEdit(row)"
+                >
+                  <el-icon><EditPen /></el-icon>
+                </button>
+                <button
+                  type="button"
+                  class="manage__icon-btn"
+                  :title="t('manageAccount.copyIdAction')"
+                  :data-test="`manage-account-copy-${row.region}-${row.account_id}`"
+                  @click="handleCopyId(row)"
+                >
+                  <el-icon><DocumentCopy /></el-icon>
+                </button>
+                <button
+                  type="button"
+                  class="manage__icon-btn manage__icon-btn--danger"
+                  :title="t('manageAccount.deleteAction')"
+                  :data-test="`manage-account-delete-${row.region}-${row.account_id}`"
+                  @click="handleDelete(row)"
+                >
+                  <el-icon><Delete /></el-icon>
+                </button>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <!--
         Footer: encryption hint (left) + Back button (right).
         Hint and back button share the same flex row so the
         layout collapses gracefully on narrow widths (the back
@@ -708,36 +714,41 @@ function handleBack(): void {
         (P12.4-followup-B-fix F6 — without this the page had no
         navigation affordance back to Settings).
       -->
-      <footer class="manage__footer">
-        <div class="manage__footer-hint">
-          <el-icon><InfoFilled /></el-icon>
-          <span>{{ t('manageAccount.footerHint') }}</span>
-        </div>
-        <el-button
-          class="bf-btn-secondary manage__back-btn"
-          data-test="manage-account-back"
-          @click="handleBack"
-        >
-          <el-icon><ArrowLeft /></el-icon>
-          <span>{{ t('Back') }}</span>
-        </el-button>
-      </footer>
+        <footer class="manage__footer">
+          <div class="manage__footer-hint">
+            <el-icon><InfoFilled /></el-icon>
+            <span>{{ t('manageAccount.footerHint') }}</span>
+          </div>
+          <el-button
+            class="bf-btn-secondary manage__back-btn"
+            data-test="manage-account-back"
+            @click="handleBack"
+          >
+            <el-icon><ArrowLeft /></el-icon>
+            <span>{{ t('Back') }}</span>
+          </el-button>
+        </footer>
 
-      <!-- Add / Edit / Recovery dialogs — mounted unconditionally for transitions. -->
-      <AddAccount v-model:visible="addVisible" />
-      <ChangeAccount v-model:visible="editVisible" :account="editTarget" />
-      <AccRecovery v-model:visible="accRecoveryVisible" @restored="handleRestored" />
+        <!-- Add / Edit / Recovery dialogs — mounted unconditionally for transitions. -->
+        <AddAccount v-model:visible="addVisible" />
+        <ChangeAccount v-model:visible="editVisible" :account="editTarget" />
+        <AccRecovery v-model:visible="accRecoveryVisible" @restored="handleRestored" />
+      </div>
     </div>
   </main>
 </template>
 
 <style scoped>
 .manage {
-  box-sizing: border-box;
-  min-height: 100vh;
-  padding: 2.5rem 1.5rem;
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.manage__scroll {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1.5rem;
 }
 
 .manage__container {

--- a/src/pages/QrForm.vue
+++ b/src/pages/QrForm.vue
@@ -258,6 +258,19 @@ const canCopyDeeplink = computed(() => {
 
 const isStarting = computed(() => auth.pendingAction === AUTH_ACTIONS.LoginQrStart)
 
+async function copyQrImage(): Promise<void> {
+  const dataUrl = bitmap.value
+  if (!dataUrl) return
+  try {
+    const res = await fetch(dataUrl)
+    const blob = await res.blob()
+    await navigator.clipboard.write([new ClipboardItem({ [blob.type]: blob })])
+    ElMessage.success(t('CopyFinished'))
+  } catch {
+    ElMessage.error(t('CopyFailed'))
+  }
+}
+
 async function copyDeeplink(): Promise<void> {
   const link = deeplink.value
   if (!link) {
@@ -318,6 +331,7 @@ function handleGameStart(): void {
         :alt="t('loginQr.title')"
         class="qr-form__bitmap"
         data-testid="qr-bitmap"
+        @contextmenu.stop.prevent="copyQrImage"
       />
       <div v-else class="qr-form__placeholder" />
     </div>
@@ -439,13 +453,17 @@ function handleGameStart(): void {
 
 .qr-form__actions {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
   gap: 0.75rem;
+}
+
+.qr-form__actions :deep(.el-button) {
+  width: 100%;
+  margin-left: 0;
 }
 
 .qr-form__back,
 .qr-form__refresh {
-  width: 100%;
   font-weight: 700;
 }
 

--- a/src/pages/QrForm.vue
+++ b/src/pages/QrForm.vue
@@ -251,6 +251,7 @@ onBeforeUnmount(() => {
 
 const bitmap = computed(() => auth.qrChallenge?.bitmap_base64 ?? null)
 const deeplink = computed(() => auth.qrChallenge?.deeplink ?? null)
+const showEnlarged = ref(false)
 const canCopyDeeplink = computed(() => {
   const link = deeplink.value
   return typeof link === 'string' && link.length > 0
@@ -265,7 +266,7 @@ async function copyQrImage(): Promise<void> {
     const res = await fetch(dataUrl)
     const blob = await res.blob()
     await navigator.clipboard.write([new ClipboardItem({ [blob.type]: blob })])
-    ElMessage.success(t('CopyFinished'))
+    ElMessage.success(t('loginQr.copyQrSuccess'))
   } catch {
     ElMessage.error(t('CopyFailed'))
   }
@@ -336,6 +337,37 @@ function handleGameStart(): void {
       <div v-else class="qr-form__placeholder" />
     </div>
 
+    <div v-if="bitmap" class="qr-form__qr-actions">
+      <button
+        type="button"
+        class="qr-form__qr-btn"
+        data-testid="qr-enlarge"
+        @click="showEnlarged = true"
+      >
+        <span class="material-symbols-outlined">zoom_in</span>
+        {{ t('loginQr.enlarge') }}
+      </button>
+      <button
+        type="button"
+        class="qr-form__qr-btn"
+        data-testid="qr-copy-image"
+        @click="copyQrImage"
+      >
+        <span class="material-symbols-outlined">content_copy</span>
+        {{ t('loginQr.copyQr') }}
+      </button>
+    </div>
+
+    <!-- Enlarged QR dialog -->
+    <div v-if="showEnlarged" class="qr-form__overlay" @click="showEnlarged = false">
+      <div class="qr-form__enlarged" @click.stop>
+        <img :src="bitmap!" :alt="t('loginQr.title')" class="qr-form__enlarged-img" />
+        <button type="button" class="qr-form__enlarged-close" @click="showEnlarged = false">
+          <span class="material-symbols-outlined">close</span>
+        </button>
+      </div>
+    </div>
+
     <p v-if="connectionLost" class="qr-form__error" data-testid="qr-connection-lost">
       {{ t('loginQr.connectionLost') }}
     </p>
@@ -383,6 +415,9 @@ function handleGameStart(): void {
   flex-direction: column;
   gap: 1rem;
   align-items: stretch;
+  box-sizing: border-box;
+  max-width: 100%;
+  overflow: hidden;
 }
 
 .qr-form__header {
@@ -470,5 +505,78 @@ function handleGameStart(): void {
 .qr-form__game-start {
   width: 100%;
   font-weight: 700;
+}
+
+.qr-form__qr-actions {
+  display: flex;
+  justify-content: center;
+  gap: 0.75rem;
+}
+
+.qr-form__qr-btn {
+  appearance: none;
+  background: rgba(255, 255, 255, 0.6);
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 8px;
+  padding: 0.375rem 0.75rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--bf-on-surface-variant, #54443a);
+  transition: background 150ms ease;
+}
+.qr-form__qr-btn .material-symbols-outlined {
+  font-size: 16px;
+}
+.qr-form__qr-btn:hover {
+  background: rgba(255, 255, 255, 0.9);
+}
+
+.qr-form__overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 10000;
+  background: rgba(0, 0, 0, 0.5);
+  display: grid;
+  place-items: center;
+}
+
+.qr-form__enlarged {
+  position: relative;
+  background: #fff;
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+}
+
+.qr-form__enlarged-img {
+  width: 360px;
+  height: 360px;
+  image-rendering: pixelated;
+  display: block;
+}
+
+.qr-form__enlarged-close {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  appearance: none;
+  background: rgba(0, 0, 0, 0.06);
+  border: none;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  color: #333;
+  transition: background 150ms ease;
+}
+.qr-form__enlarged-close:hover {
+  background: rgba(0, 0, 0, 0.12);
 }
 </style>

--- a/src/pages/QrForm.vue
+++ b/src/pages/QrForm.vue
@@ -238,7 +238,7 @@ onMounted(async () => {
   if (region !== 'TW') {
     ElMessage.info(t('loginQr.unsupportedHK'))
     disposed = true
-    await router.push('/login')
+    await router.push({ path: '/login', query: { pick: '1' } })
     return
   }
   await doStart()
@@ -299,7 +299,7 @@ async function refresh(): Promise<void> {
 async function goBack(): Promise<void> {
   disposed = true
   clearPollTimer()
-  await router.push('/login')
+  await router.push({ path: '/login', query: { pick: '1' } })
 }
 
 /**

--- a/src/pages/Settings.vue
+++ b/src/pages/Settings.vue
@@ -132,6 +132,7 @@ import { useGameStore } from '../stores/game'
 import { useUiStore, type AppLocale, type LoginMethodValue, type UpdateChannel } from '../stores/ui'
 import { TOOLS_GAME_CODES } from '../constants/tools'
 import ToolsDialogStack from '../windows/ToolsDialogStack.vue'
+import TitleBar from '../components/TitleBar.vue'
 
 defineOptions({ name: 'SettingsPage' })
 
@@ -614,229 +615,234 @@ onMounted(() => {
 </script>
 
 <template>
-  <main class="settings bf-mica-bg">
-    <div class="settings__container">
-      <!-- Header -->
-      <header class="settings__header">
-        <div class="settings__header-icon" aria-hidden="true">
-          <el-icon :size="24"><SettingIcon /></el-icon>
-        </div>
-        <div class="settings__header-text">
-          <h1 class="settings__title bf-text-gradient">{{ t('Settings') }}</h1>
-          <p class="settings__subline">{{ t('settings.subtitle') }}</p>
-        </div>
-      </header>
-
-      <!-- App section -->
-      <section class="settings__section bf-glass-panel" data-test="settings-app-section">
-        <header class="settings__section-header">
-          <el-icon><User /></el-icon>
-          <span>{{ t('AppName') }}</span>
+  <main class="settings bf-glass-window" data-window-root>
+    <TitleBar />
+    <div class="settings__scroll">
+      <div class="settings__container">
+        <!-- Header -->
+        <header class="settings__header">
+          <div class="settings__header-icon" aria-hidden="true">
+            <el-icon :size="24"><SettingIcon /></el-icon>
+          </div>
+          <div class="settings__header-text">
+            <h1 class="settings__title bf-text-gradient">{{ t('Settings') }}</h1>
+            <p class="settings__subline">{{ t('settings.subtitle') }}</p>
+          </div>
         </header>
 
-        <div class="settings__grid settings__grid--two-col">
-          <!-- Left column: Manage account + 3 selects -->
-          <div class="settings__col">
-            <div class="settings__row">
-              <el-button
-                class="bf-btn-secondary settings__inline-btn"
-                data-test="settings-manage-account"
-                @click="handleManageAccount"
-              >
-                {{ t('ManageAccount') }}
-              </el-button>
-            </div>
-
-            <div class="settings__row">
-              <label class="settings__label">{{ t('UpdateChannel') }}</label>
-              <el-select
-                :model-value="ui.updateChannel"
-                class="settings__select"
-                data-test="settings-update-channel"
-                @change="handleUpdateChannelChange"
-              >
-                <el-option
-                  v-for="opt in UPDATE_CHANNEL_OPTIONS"
-                  :key="opt.value"
-                  :value="opt.value"
-                  :label="t(opt.labelKey)"
-                />
-              </el-select>
-            </div>
-
-            <div class="settings__row">
-              <label class="settings__label">{{ t('Language') }}</label>
-              <el-select
-                :model-value="ui.language"
-                class="settings__select"
-                data-test="settings-language"
-                @change="handleLanguageChange"
-              >
-                <el-option
-                  v-for="opt in LANGUAGE_OPTIONS"
-                  :key="opt.value"
-                  :value="opt.value"
-                  :label="opt.label"
-                />
-              </el-select>
-            </div>
-
-            <div class="settings__row">
-              <label class="settings__label">{{ t('ThemeColor') }}</label>
-              <div class="settings__theme-row">
-                <el-input
-                  :model-value="ui.themeColor"
-                  class="settings__theme-input"
-                  data-test="settings-theme-input"
-                  @change="handleThemeColorChange"
-                />
-                <el-color-picker
-                  :model-value="ui.themeColor"
-                  data-test="settings-theme-picker"
-                  @change="handleThemeColorChange"
-                />
-              </div>
-            </div>
-
-            <div
-              v-if="showLoginModePanel"
-              class="settings__row"
-              data-test="settings-login-mode-row"
-            >
-              <label class="settings__label">{{ t('LoginMode') }}</label>
-              <el-select
-                :model-value="ui.loginMethod"
-                class="settings__select"
-                data-test="settings-login-mode"
-                @change="handleLoginMethodChange"
-              >
-                <el-option
-                  v-for="opt in LOGIN_METHOD_OPTIONS"
-                  :key="opt.value"
-                  :value="opt.value"
-                  :label="t(opt.labelKey)"
-                />
-              </el-select>
-            </div>
-          </div>
-
-          <!-- Right column: 4 boolean checkboxes (D4) -->
-          <div class="settings__col">
-            <div class="settings__row settings__row--checkbox">
-              <el-checkbox
-                :model-value="ui.askUpdate"
-                data-test="settings-ask-update"
-                @change="(value) => ui.setAskUpdate(Boolean(value))"
-              >
-                {{ t('AutoCheckUpdate') }}
-              </el-checkbox>
-            </div>
-
-            <div class="settings__row settings__row--checkbox">
-              <el-checkbox
-                :model-value="ui.autoStartGame"
-                data-test="settings-auto-start-game"
-                @change="(value) => ui.setAutoStartGame(Boolean(value))"
-              >
-                {{ t('RunAfterLogin') }}
-              </el-checkbox>
-            </div>
-
-            <div class="settings__row settings__row--checkbox">
-              <el-checkbox
-                :model-value="ui.minimizeToTray"
-                data-test="settings-minimize-to-tray"
-                @change="(value) => ui.setMinimizeToTray(Boolean(value))"
-              >
-                {{ t('MinimizeToTaskbar') }}
-              </el-checkbox>
-            </div>
-
-            <div class="settings__row settings__row--checkbox">
-              <el-tooltip placement="right" :content="t('settings.disableHardwareAccelerationTip')">
-                <el-checkbox
-                  :model-value="ui.disableHwAccel"
-                  data-test="settings-disable-hw-accel"
-                  @change="(value) => handleDisableHwAccelChange(Boolean(value))"
-                >
-                  {{ t('DisableHardwareAcceleration') }}
-                </el-checkbox>
-              </el-tooltip>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <!-- Game section (D5) — only when a game is selected (WPF parity: if no game, t_GamePath is empty + the section is uninteractive). -->
-      <section
-        v-if="game.selectedGame"
-        class="settings__section bf-glass-panel"
-        data-test="settings-game-section"
-      >
-        <header class="settings__section-header">
-          <el-icon><Operation /></el-icon>
-          <span>{{ t('Game') }}</span>
-        </header>
-
-        <div class="settings__grid">
-          <div class="settings__row">
-            <label class="settings__label">{{ t('GamePath') }}</label>
-            <el-input
-              :model-value="gamePath"
-              readonly
-              :placeholder="t('settings.gamePathPlaceholder')"
-              class="settings__game-path-input"
-              data-test="settings-game-path"
-              @click="pickGamePath"
-            >
-              <template #suffix>
-                <el-icon class="settings__game-path-icon"><FolderOpened /></el-icon>
-              </template>
-            </el-input>
-          </div>
+        <!-- App section -->
+        <section class="settings__section bf-glass-panel" data-test="settings-app-section">
+          <header class="settings__section-header">
+            <el-icon><User /></el-icon>
+            <span>{{ t('AppName') }}</span>
+          </header>
 
           <div class="settings__grid settings__grid--two-col">
+            <!-- Left column: Manage account + 3 selects -->
+            <div class="settings__col">
+              <div class="settings__row">
+                <el-button
+                  class="bf-btn-secondary settings__inline-btn"
+                  data-test="settings-manage-account"
+                  @click="handleManageAccount"
+                >
+                  {{ t('ManageAccount') }}
+                </el-button>
+              </div>
+
+              <div class="settings__row">
+                <label class="settings__label">{{ t('UpdateChannel') }}</label>
+                <el-select
+                  :model-value="ui.updateChannel"
+                  class="settings__select"
+                  data-test="settings-update-channel"
+                  @change="handleUpdateChannelChange"
+                >
+                  <el-option
+                    v-for="opt in UPDATE_CHANNEL_OPTIONS"
+                    :key="opt.value"
+                    :value="opt.value"
+                    :label="t(opt.labelKey)"
+                  />
+                </el-select>
+              </div>
+
+              <div class="settings__row">
+                <label class="settings__label">{{ t('Language') }}</label>
+                <el-select
+                  :model-value="ui.language"
+                  class="settings__select"
+                  data-test="settings-language"
+                  @change="handleLanguageChange"
+                >
+                  <el-option
+                    v-for="opt in LANGUAGE_OPTIONS"
+                    :key="opt.value"
+                    :value="opt.value"
+                    :label="opt.label"
+                  />
+                </el-select>
+              </div>
+
+              <div class="settings__row">
+                <label class="settings__label">{{ t('ThemeColor') }}</label>
+                <div class="settings__theme-row">
+                  <el-input
+                    :model-value="ui.themeColor"
+                    class="settings__theme-input"
+                    data-test="settings-theme-input"
+                    @change="handleThemeColorChange"
+                  />
+                  <el-color-picker
+                    :model-value="ui.themeColor"
+                    data-test="settings-theme-picker"
+                    @change="handleThemeColorChange"
+                  />
+                </div>
+              </div>
+
+              <div
+                v-if="showLoginModePanel"
+                class="settings__row"
+                data-test="settings-login-mode-row"
+              >
+                <label class="settings__label">{{ t('LoginMode') }}</label>
+                <el-select
+                  :model-value="ui.loginMethod"
+                  class="settings__select"
+                  data-test="settings-login-mode"
+                  @change="handleLoginMethodChange"
+                >
+                  <el-option
+                    v-for="opt in LOGIN_METHOD_OPTIONS"
+                    :key="opt.value"
+                    :value="opt.value"
+                    :label="t(opt.labelKey)"
+                  />
+                </el-select>
+              </div>
+            </div>
+
+            <!-- Right column: 4 boolean checkboxes (D4) -->
             <div class="settings__col">
               <div class="settings__row settings__row--checkbox">
-                <el-tooltip placement="right" :content="t('settings.tradLoginTip')">
-                  <el-checkbox
-                    :model-value="ui.tradLogin"
-                    data-test="settings-trad-login"
-                    @change="(value) => ui.setTradLogin(Boolean(value))"
-                  >
-                    {{ t('TraditionalLoginMode') }}
-                  </el-checkbox>
-                </el-tooltip>
+                <el-checkbox
+                  :model-value="ui.askUpdate"
+                  data-test="settings-ask-update"
+                  @change="(value) => ui.setAskUpdate(Boolean(value))"
+                >
+                  {{ t('AutoCheckUpdate') }}
+                </el-checkbox>
               </div>
 
               <div class="settings__row settings__row--checkbox">
-                <el-tooltip placement="right" :content="t('settings.killPatcherTip')">
+                <el-checkbox
+                  :model-value="ui.autoStartGame"
+                  data-test="settings-auto-start-game"
+                  @change="(value) => ui.setAutoStartGame(Boolean(value))"
+                >
+                  {{ t('RunAfterLogin') }}
+                </el-checkbox>
+              </div>
+
+              <div class="settings__row settings__row--checkbox">
+                <el-checkbox
+                  :model-value="ui.minimizeToTray"
+                  data-test="settings-minimize-to-tray"
+                  @change="(value) => ui.setMinimizeToTray(Boolean(value))"
+                >
+                  {{ t('MinimizeToTaskbar') }}
+                </el-checkbox>
+              </div>
+
+              <div class="settings__row settings__row--checkbox">
+                <el-tooltip
+                  placement="right"
+                  :content="t('settings.disableHardwareAccelerationTip')"
+                >
                   <el-checkbox
-                    :model-value="ui.autoKillPatcher"
-                    data-test="settings-auto-kill-patcher"
-                    @change="(value) => ui.setAutoKillPatcher(Boolean(value))"
+                    :model-value="ui.disableHwAccel"
+                    data-test="settings-disable-hw-accel"
+                    @change="(value) => handleDisableHwAccelChange(Boolean(value))"
                   >
-                    {{ t('KillPatcher') }}
+                    {{ t('DisableHardwareAcceleration') }}
                   </el-checkbox>
                 </el-tooltip>
               </div>
             </div>
+          </div>
+        </section>
 
-            <div class="settings__col">
-              <div class="settings__row settings__row--checkbox">
-                <el-tooltip placement="right" :content="t('settings.skipPlayWindowTip')">
-                  <el-checkbox
-                    :model-value="ui.skipPlayWnd"
-                    data-test="settings-skip-play-wnd"
-                    @change="(value) => ui.setSkipPlayWnd(Boolean(value))"
-                  >
-                    {{ t('SkipPlayWindow') }}
-                  </el-checkbox>
-                </el-tooltip>
+        <!-- Game section (D5) — only when a game is selected (WPF parity: if no game, t_GamePath is empty + the section is uninteractive). -->
+        <section
+          v-if="game.selectedGame"
+          class="settings__section bf-glass-panel"
+          data-test="settings-game-section"
+        >
+          <header class="settings__section-header">
+            <el-icon><Operation /></el-icon>
+            <span>{{ t('Game') }}</span>
+          </header>
+
+          <div class="settings__grid">
+            <div class="settings__row">
+              <label class="settings__label">{{ t('GamePath') }}</label>
+              <el-input
+                :model-value="gamePath"
+                readonly
+                :placeholder="t('settings.gamePathPlaceholder')"
+                class="settings__game-path-input"
+                data-test="settings-game-path"
+                @click="pickGamePath"
+              >
+                <template #suffix>
+                  <el-icon class="settings__game-path-icon"><FolderOpened /></el-icon>
+                </template>
+              </el-input>
+            </div>
+
+            <div class="settings__grid settings__grid--two-col">
+              <div class="settings__col">
+                <div class="settings__row settings__row--checkbox">
+                  <el-tooltip placement="right" :content="t('settings.tradLoginTip')">
+                    <el-checkbox
+                      :model-value="ui.tradLogin"
+                      data-test="settings-trad-login"
+                      @change="(value) => ui.setTradLogin(Boolean(value))"
+                    >
+                      {{ t('TraditionalLoginMode') }}
+                    </el-checkbox>
+                  </el-tooltip>
+                </div>
+
+                <div class="settings__row settings__row--checkbox">
+                  <el-tooltip placement="right" :content="t('settings.killPatcherTip')">
+                    <el-checkbox
+                      :model-value="ui.autoKillPatcher"
+                      data-test="settings-auto-kill-patcher"
+                      @change="(value) => ui.setAutoKillPatcher(Boolean(value))"
+                    >
+                      {{ t('KillPatcher') }}
+                    </el-checkbox>
+                  </el-tooltip>
+                </div>
               </div>
 
-              <div v-if="showToolsButton" class="settings__row" data-test="settings-tools-row">
-                <!--
+              <div class="settings__col">
+                <div class="settings__row settings__row--checkbox">
+                  <el-tooltip placement="right" :content="t('settings.skipPlayWindowTip')">
+                    <el-checkbox
+                      :model-value="ui.skipPlayWnd"
+                      data-test="settings-skip-play-wnd"
+                      @change="(value) => ui.setSkipPlayWnd(Boolean(value))"
+                    >
+                      {{ t('SkipPlayWindow') }}
+                    </el-checkbox>
+                  </el-tooltip>
+                </div>
+
+                <div v-if="showToolsButton" class="settings__row" data-test="settings-tools-row">
+                  <!--
                   P12.5 D7: WPF parity gate — the Tools button is only
                   rendered for the three tools-bearing game codes
                   (`MainWindow.xaml.cs` L621 / L630-633 hides it for
@@ -845,65 +851,69 @@ onMounted(() => {
                   cleanly when the button is absent (mirrors WPF
                   `Visibility.Collapsed` semantics, not `Hidden`).
                 -->
-                <el-button
-                  class="bf-btn-secondary settings__inline-btn"
-                  data-test="settings-tools"
-                  @click="handleTools"
-                >
-                  {{ t('Tools') }}
-                </el-button>
+                  <el-button
+                    class="bf-btn-secondary settings__inline-btn"
+                    data-test="settings-tools"
+                    @click="handleTools"
+                  >
+                    {{ t('Tools') }}
+                  </el-button>
+                </div>
               </div>
             </div>
           </div>
-        </div>
-      </section>
+        </section>
 
-      <!-- Game section empty banner (no selected game) — informational, mirrors WPF's empty t_GamePath fallback semantically. -->
-      <section
-        v-else
-        class="settings__section bf-glass-panel settings__section--empty"
-        data-test="settings-game-section-empty"
-      >
-        <el-icon class="settings__empty-icon" :size="20"><InfoFilled /></el-icon>
-        <p class="settings__empty-text">{{ t('settings.gameSectionEmpty') }}</p>
-      </section>
-
-      <!-- Footer: Back button -->
-      <footer class="settings__footer">
-        <el-button
-          class="bf-btn-secondary settings__back-btn"
-          data-test="settings-back"
-          @click="handleBack"
+        <!-- Game section empty banner (no selected game) — informational, mirrors WPF's empty t_GamePath fallback semantically. -->
+        <section
+          v-else
+          class="settings__section bf-glass-panel settings__section--empty"
+          data-test="settings-game-section-empty"
         >
-          <el-icon><ArrowLeft /></el-icon>
-          <span>{{ t('Back') }}</span>
-        </el-button>
-      </footer>
+          <el-icon class="settings__empty-icon" :size="20"><InfoFilled /></el-icon>
+          <p class="settings__empty-text">{{ t('settings.gameSectionEmpty') }}</p>
+        </section>
 
-      <!-- P12.5 D7: Tools dialog stack — same wrapper component the
+        <!-- Footer: Back button -->
+        <footer class="settings__footer">
+          <el-button
+            class="bf-btn-secondary settings__back-btn"
+            data-test="settings-back"
+            @click="handleBack"
+          >
+            <el-icon><ArrowLeft /></el-icon>
+            <span>{{ t('Back') }}</span>
+          </el-button>
+        </footer>
+
+        <!-- P12.5 D7: Tools dialog stack — same wrapper component the
            AccountList page mounts. See `pages/AccountList.vue`'s
            ToolsDialogStack mount comment + `windows/ToolsDialogStack.vue`
            top docblock for the full design discussion. The wrapper
            mounts unconditionally so its internal dialog mounts can
            play their open transitions on first open; per-dialog
            visibility is owned inside the wrapper. -->
-      <ToolsDialogStack ref="toolsDialogRef" />
+        <ToolsDialogStack ref="toolsDialogRef" />
+      </div>
     </div>
   </main>
 </template>
 
 <style scoped>
 .settings {
-  box-sizing: border-box;
-  min-height: 100vh;
-  padding: 2.5rem 1.5rem;
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.settings__scroll {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1.5rem;
 }
 
 .settings__container {
   width: 100%;
-  max-width: 880px;
   display: flex;
   flex-direction: column;
   gap: 1rem;

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -78,7 +78,20 @@
 import type { RouteRecordRaw, Router } from 'vue-router'
 import { createRouter, createWebHashHistory } from 'vue-router'
 
+import { getCurrentWindow } from '@tauri-apps/api/window'
+import { LogicalSize } from '@tauri-apps/api/dpi'
+
 import { registerSessionExpiredHandler } from '../services/invoke'
+
+/**
+ * Resize the Tauri window to the given logical dimensions.
+ * Exported so individual pages can call it on mount when their
+ * content height differs from the route meta default (e.g.
+ * Settings page without the Game section when unauthenticated).
+ */
+export function resizeWindow(width: number, height: number): void {
+  void getCurrentWindow().setSize(new LogicalSize(width, height))
+}
 
 import LoginPage from '../pages/LoginPage.vue'
 import LoginRegionSelection from '../pages/LoginRegionSelection.vue'
@@ -144,36 +157,73 @@ const loginChildren: RouteRecordRaw[] = [
     path: '',
     name: ROUTE_NAMES.LoginRegion,
     component: LoginRegionSelection,
+    meta: {
+      titleKey: 'titleBar.regionSelection',
+      titleIcon: 'public',
+      windowWidth: 560,
+      windowHeight: 480,
+    },
   },
   {
     path: 'id-pass',
     name: ROUTE_NAMES.LoginIdPass,
     component: IdPassForm,
+    meta: { titleKey: 'titleBar.login', titleIcon: 'login', windowWidth: 560, windowHeight: 520 },
   },
   {
     path: 'qr',
     name: ROUTE_NAMES.LoginQr,
     component: QrForm,
+    meta: {
+      titleKey: 'titleBar.login',
+      titleIcon: 'qr_code_2',
+      windowWidth: 560,
+      windowHeight: 680,
+    },
   },
   {
     path: 'gamepass',
     name: ROUTE_NAMES.LoginGamepass,
     component: GamepassForm,
+    meta: {
+      titleKey: 'titleBar.login',
+      titleIcon: 'verified_user',
+      windowWidth: 560,
+      windowHeight: 460,
+    },
   },
   {
     path: 'totp',
     name: ROUTE_NAMES.LoginTotp,
     component: LoginTotp,
+    meta: {
+      titleKey: 'titleBar.totp',
+      titleIcon: 'encrypted',
+      windowWidth: 520,
+      windowHeight: 380,
+    },
   },
   {
     path: 'wait',
     name: ROUTE_NAMES.LoginWait,
     component: LoginWait,
+    meta: {
+      titleKey: 'titleBar.loginWait',
+      titleIcon: 'login',
+      windowWidth: 480,
+      windowHeight: 360,
+    },
   },
   {
     path: 'verify',
     name: ROUTE_NAMES.LoginVerify,
     component: VerifyPage,
+    meta: {
+      titleKey: 'titleBar.verify',
+      titleIcon: 'shield_lock',
+      windowWidth: 560,
+      windowHeight: 480,
+    },
   },
 ]
 
@@ -198,12 +248,24 @@ export const routes: RouteRecordRaw[] = [
      * (P12.2 D-step) can land the user back on the page they
      * originally targeted.
      */
-    meta: { requiresAuth: true },
+    meta: {
+      requiresAuth: true,
+      titleKey: 'titleBar.accounts',
+      titleIcon: 'sports_esports',
+      windowWidth: 560,
+      windowHeight: 640,
+    },
   },
   {
     path: '/settings',
     name: ROUTE_NAMES.Settings,
     component: SettingsPage,
+    meta: {
+      titleKey: 'titleBar.settings',
+      titleIcon: 'settings',
+      windowWidth: 880,
+      windowHeight: 680,
+    },
     /*
      * P12.4 D6: Settings page is reachable from both the
      * post-login `AccountList` top-bar icon and (per WPF parity
@@ -222,6 +284,7 @@ export const routes: RouteRecordRaw[] = [
     path: '/about',
     name: ROUTE_NAMES.About,
     component: AboutPage,
+    meta: { titleKey: 'titleBar.about', titleIcon: 'info', windowWidth: 560, windowHeight: 680 },
     /*
      * P12.4 D7: same public-route rationale as `/settings` —
      * WPF allowed the About page from both pre-login and
@@ -245,7 +308,13 @@ export const routes: RouteRecordRaw[] = [
      * accounts are session-scoped UX (the page only makes sense for
      * a logged-in user managing the credentials they just used).
      */
-    meta: { requiresAuth: true },
+    meta: {
+      requiresAuth: true,
+      titleKey: 'titleBar.manageAccount',
+      titleIcon: 'manage_accounts',
+      windowWidth: 880,
+      windowHeight: 640,
+    },
   },
   {
     path: '/:pathMatch(.*)*',
@@ -291,6 +360,26 @@ declare module 'vue-router' {
      * `/login` → redirect to `/login` → ...).
      */
     requiresAuth?: boolean
+    /**
+     * i18n key for the custom title bar text. When unset, the
+     * title bar falls back to `t('AppName')`.
+     */
+    titleKey?: string
+    /**
+     * Material Symbols icon name for the custom title bar.
+     * When unset, falls back to `'coffee'`.
+     */
+    titleIcon?: string
+    /**
+     * Desired window width in logical pixels for this route.
+     * The router afterEach hook calls `appWindow.setSize()` when
+     * the value differs from the current route.
+     */
+    windowWidth?: number
+    /**
+     * Desired window height in logical pixels for this route.
+     */
+    windowHeight?: number
   }
 }
 
@@ -388,5 +477,43 @@ export function installRouterGuards(router: Router, deps: RouterGuardDeps): void
       path: '/login',
       query: { sessionExpired: '1' },
     })
+  })
+
+  /*
+   * Auto-fit window size to content. Uses a ResizeObserver on the
+   * `[data-window-root]` element so the window tracks content
+   * height changes (e.g. sections appearing/disappearing, async
+   * data loading). Width comes from route meta.
+   */
+  const appWindow = getCurrentWindow()
+  let currentWidth = 560
+  let observer: ResizeObserver | null = null
+
+  function fitWindow(): void {
+    const root = document.querySelector('[data-window-root]') as HTMLElement | null
+    if (!root) return
+    // Remove height lock to measure natural content height
+    root.style.height = 'auto'
+    const h = Math.max(300, Math.min(Math.ceil(root.scrollHeight), 900))
+    void appWindow.setSize(new LogicalSize(currentWidth, h)).then(() => {
+      // Lock height to viewport so flex scroll areas work
+      root.style.height = '100vh'
+    })
+  }
+
+  function setupObserver(): void {
+    if (observer) observer.disconnect()
+    const root = document.querySelector('[data-window-root]') as HTMLElement | null
+    if (!root) return
+    observer = new ResizeObserver(() => fitWindow())
+    observer.observe(root)
+    fitWindow()
+  }
+
+  router.afterEach((to) => {
+    const w = to.meta.windowWidth as number | undefined
+    if (w) currentWidth = w
+    // Give Vue time to mount the new route component
+    setTimeout(setupObserver, 80)
   })
 }

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -547,6 +547,27 @@ export const useAuthStore = defineStore('auth', () => {
     verifyIntent.value = null
   }
 
+  /**
+   * Patch the active `(service_code, service_region)` pair on the
+   * in-memory session so the frontend's `sameAsSession` guard in
+   * `AccountList.vue::selectActiveGame` stays in sync with the
+   * backend after a successful `commands.setActiveService` call.
+   *
+   * Without this, switching to Game A then back to the original
+   * login game skips the backend `setActiveService` (the stale
+   * frontend session still matches the original pair) while the
+   * backend session still points at Game A — the subsequent
+   * `getAccounts` returns the wrong game's account list.
+   */
+  function updateSessionService(serviceCode: string, serviceRegion: string): void {
+    if (session.value === null) return
+    session.value = {
+      ...session.value,
+      service_code: serviceCode,
+      service_region: serviceRegion,
+    }
+  }
+
   async function logout(): Promise<void> {
     return withGuard(AUTH_ACTIONS.Logout, async () => {
       await wrapCommand(commands.logout())
@@ -575,6 +596,7 @@ export const useAuthStore = defineStore('auth', () => {
     getVerifyCaptcha,
     submitVerify,
     clearSession,
+    updateSessionService,
     logout,
     setLoginIntent,
     clearLoginIntent,

--- a/src/stores/config.ts
+++ b/src/stores/config.ts
@@ -102,7 +102,10 @@ export const useConfigStore = defineStore('config', () => {
   async function set(key: string, value: string | null): Promise<void> {
     const result = await safeInvoke(commands.setConfig(key, value))
     if (!result.ok) {
-      console.warn(`[config] set "${key}" failed (file may be read-only), using in-memory value`, result.error)
+      console.warn(
+        `[config] set "${key}" failed (file may be read-only), using in-memory value`,
+        result.error,
+      )
     }
     if (value === null) {
       delete entries.value[key]

--- a/src/stores/config.ts
+++ b/src/stores/config.ts
@@ -30,7 +30,7 @@
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
 import { commands } from '../types/bindings'
-import { wrapCommand } from '../services/invoke'
+import { safeInvoke, wrapCommand } from '../services/invoke'
 
 export const useConfigStore = defineStore('config', () => {
   /**
@@ -89,11 +89,21 @@ export const useConfigStore = defineStore('config', () => {
   /**
    * Persist a key to backend Config.xml and update the local cache.
    *
+   * If the file is read-only (user locked their settings on purpose),
+   * the backend write fails silently and only the in-memory cache is
+   * updated — matching WPF's silent `catch{}` at
+   * `ConfigAppSettings.cs` L60. The current session keeps working;
+   * the on-disk file stays untouched so the locked values survive
+   * across restarts.
+   *
    * @param key — config key (matches WPF naming verbatim)
    * @param value — string to set, or `null` to delete the key
    */
   async function set(key: string, value: string | null): Promise<void> {
-    await wrapCommand(commands.setConfig(key, value))
+    const result = await safeInvoke(commands.setConfig(key, value))
+    if (!result.ok) {
+      console.warn(`[config] set "${key}" failed (file may be read-only), using in-memory value`, result.error)
+    }
     if (value === null) {
       delete entries.value[key]
     } else {

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -54,6 +54,37 @@
 }
 
 /* =========================================================================
+ * Glass window root — card IS the window (decorations: false)
+ *
+ * Composites the bf-mica-bg gradient with a white overlay so the
+ * window root is opaque (no desktop bleed-through), then applies the
+ * glass-panel border / shadow / radius. Every top-level page uses
+ * this class instead of the old bf-mica-bg + bf-glass-panel two-layer
+ * pattern when running in the custom-titlebar shell.
+ * ========================================================================= */
+
+.bf-glass-window {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.55) 0%, rgba(255, 255, 255, 0.45) 100%),
+    radial-gradient(
+      1200px 800px at 10% -10%,
+      color-mix(in srgb, var(--bf-primary-container) 30%, transparent) 0%,
+      transparent 60%
+    ),
+    radial-gradient(
+      900px 700px at 110% 110%,
+      color-mix(in srgb, var(--bf-primary) 22%, transparent) 0%,
+      transparent 55%
+    ),
+    linear-gradient(180deg, #f7f1ec 0%, #ece1d6 100%);
+  border: 1px solid var(--bf-glass-border);
+  border-radius: var(--bf-radius-panel);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.7),
+    var(--bf-shadow-panel);
+}
+
+/* =========================================================================
  * Glass panels — primary container surface
  * ========================================================================= */
 

--- a/src/types/bindings.ts
+++ b/src/types/bindings.ts
@@ -1947,6 +1947,30 @@ async openMemberCenterBrowser() : Promise<Result<null, CommandError>> {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
 }
+},
+/**
+ * Open the Beanfun **Gash recharge** page in a dedicated in-app
+ * webview window. Mirrors WPF
+ * `Pages/AccountList.xaml.cs::bfb_Gash_Click`.
+ * 
+ * Same security rationale as [`open_member_center_browser`] — the
+ * URL embeds `web_token`, so it must be built backend-side to keep
+ * the secret confined to Rust.
+ * 
+ * # Errors
+ * 
+ * - `auth.session_required` — no active session.
+ * - [`INVALID_URL_CODE`] — `build_gash_recharge_url` produced a
+ * URL outside the allowlist (defensive — should be unreachable).
+ * - `ui.window_create_failed` — see [`open_url_in_webview`].
+ */
+async openGashRechargeBrowser() : Promise<Result<null, CommandError>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("open_gash_recharge_browser") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
 }
 }
 

--- a/src/types/bindings.ts
+++ b/src/types/bindings.ts
@@ -1170,6 +1170,42 @@ async openUrl(url: string) : Promise<Result<null, CommandError>> {
 }
 },
 /**
+ * Minimize the main window, honouring the `minimize_to_tray`
+ * config setting.
+ * 
+ * Driven by the custom `TitleBar` minimize button in the
+ * frontend. Replaces the legacy `appWindow.minimize()` direct call
+ * because the post-PR-228 borderless + transparent + non-resizable
+ * window no longer reliably produces the `WindowEvent::Resized(0, 0)`
+ * signal Windows used to fire on minimize, which broke the
+ * fallback path in [`crate::tray::handle_minimize_to_tray`].
+ * 
+ * Behaviour:
+ * 
+ * - If `minimize_to_tray = true` in `Config.xml` **and** the tray
+ * icon was created successfully at boot — hide the window and
+ * reveal the tray icon (delegated to [`tray::hide_to_tray`] so
+ * the side effect stays single-sourced with the window-event
+ * fallback path).
+ * - Otherwise — fall through to a normal `window.minimize()`.
+ * 
+ * # Errors
+ * 
+ * - `system.window_not_found` — the `main` webview window is not
+ * currently registered with the app handle. Should never happen
+ * in steady state (the window is created at boot).
+ * - `system.minimize_failed` — Tauri's `window.minimize()` returned
+ * an error from the underlying OS call.
+ */
+async minimizeMainWindow() : Promise<Result<null, CommandError>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("minimize_main_window") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
  * Read a single config value by `key`, falling back to `""` when
  * the file is missing / unreadable / the key is absent.
  * 

--- a/src/windows/MapleTools.vue
+++ b/src/windows/MapleTools.vue
@@ -102,8 +102,7 @@ defineOptions({ name: 'MapleToolsDialog' })
 const PLAYER_REPORT_URL =
   'https://event.beanfun.com/customerservice/PluginReporting/PlayerReport.aspx'
 
-const VIDEO_REPORT_URL =
-  'https://beanfun-event.beanfun.com/EventAD_Mobile/EventAD?eventAdId=3453'
+const VIDEO_REPORT_URL = 'https://beanfun-event.beanfun.com/EventAD_Mobile/EventAD?eventAdId=3453'
 
 const props = withDefaults(
   defineProps<{

--- a/src/windows/MapleTools.vue
+++ b/src/windows/MapleTools.vue
@@ -9,9 +9,7 @@
  * - Vertical stack of `Button`s in a `StackPanel Margin="20"`,
  *   each with `Margin="5"`. Original WPF order:
  *   Recycling → PlayerReport → VideoReport →
- *   EquipStarForceCalculator → PerfectCoreCalculator. SPA order
- *   matches but with VideoReport removed (see "WPF deviation:
- *   VideoReport removed" below).
+ *   EquipStarForceCalculator → PerfectCoreCalculator.
  * - Window title `{DynamicResource ToolBox}` ("工具箱" / "Toolbox").
  * - **Recycling** (`btn_Recycling_Click` L51-112): YesNo confirm
  *   `MsgRecycling` → backend filesystem sweep → `MsgRecyclingDone`
@@ -33,20 +31,11 @@
  *
  * # WPF deviations (intentional)
  *
- * - **VideoReport removed (P12.4-followup-B-fix F2, Q12)**: WPF
- *   `btn_VideoReport_Click` L34-39 navigates to
- *   `event.beanfun.com/MapleStory/eventad/EventAD.aspx?EventADID=3453`,
- *   which redirects to a `tw.hicdn.beanfun.com/.../404.html` page
- *   — the upstream EventAD record was retired, the button has
- *   been dead-link for an indeterminate amount of time. WPF still
- *   ships the button (it just opens 404). User instruction during
- *   the followup-B smoke test was to drop the button rather than
- *   leave a confusing affordance; this is the only intentional
- *   deviation from strict WPF parity in MapleTools. If beanfun
- *   ever restores the EventAD page, revert this commit's
- *   MapleTools changes (the button itself is mechanical to add
- *   back; the i18n key `VideoReport` stays in the WPF locale
- *   tree even now).
+ * - **VideoReport URL updated**: WPF's original URL
+ *   `event.beanfun.com/MapleStory/eventad/EventAD.aspx?EventADID=3453`
+ *   now 404s — beanfun migrated the page to
+ *   `beanfun-event.beanfun.com/EventAD_Mobile/EventAD?eventAdId=3453`.
+ *   The SPA uses the new URL directly.
  * - **Modal vs new Window**: same rationale as the rest of
  *   `windows/*.vue` — the SPA renders dialogs in-page via
  *   `el-dialog`. The MapleTools dialog stays open while a child
@@ -96,26 +85,25 @@
 
 import { useI18n } from 'vue-i18n'
 import { ElButton, ElDialog, ElIcon, ElMessage, ElMessageBox } from 'element-plus'
-import { CircleClose, Delete, Document, Pointer, Setting } from '@element-plus/icons-vue'
+import {
+  CircleClose,
+  Delete,
+  Document,
+  Pointer,
+  Setting,
+  VideoCamera,
+} from '@element-plus/icons-vue'
 
 import { commands, type LoginRegion } from '../types/bindings'
 import { safeInvoke } from '../services/invoke'
 
 defineOptions({ name: 'MapleToolsDialog' })
 
-/**
- * PlayerReport URL ported verbatim from `MapleTools.xaml.cs` L31
- * so the Tauri build hits the exact same Beanfun event-portal
- * endpoint WPF does. Kept as a module-level const (not prop /
- * config) because it is part of the WPF surface — every Beanfun
- * build (TW / HK) historically navigates to this same URL.
- *
- * `VIDEO_REPORT_URL` was removed in P12.4-followup-B-fix F2 (see
- * the file docblock "WPF deviations" section for the audit
- * trail).
- */
 const PLAYER_REPORT_URL =
   'https://event.beanfun.com/customerservice/PluginReporting/PlayerReport.aspx'
+
+const VIDEO_REPORT_URL =
+  'https://beanfun-event.beanfun.com/EventAD_Mobile/EventAD?eventAdId=3453'
 
 const props = withDefaults(
   defineProps<{
@@ -156,15 +144,9 @@ const emit = defineEmits<{
   (event: 'update:visible', next: boolean): void
   /**
    * Ask the parent to open the in-app browser at `url`. Used for
-   * PlayerReport — the URL lands on `event.beanfun.com`, which
-   * sits inside the backend `web_browser::is_allowed_host` suffix
-   * policy (`*.beanfun.com`) since P12.4-followup-B-fix F1, so
-   * `useInAppBrowser` opens the URL in a fresh `WebviewWindow`
-   * with the BeanfunClient session cookies pre-seeded — full WPF
-   * `new WebBrowser(uri).Show()` parity. The system-browser
-   * fallback inside `useInAppBrowser` only fires for URLs outside
-   * `*.beanfun.com`, which is no longer reachable from this
-   * component after the F2 VideoReport removal.
+   * PlayerReport and VideoReport — both URLs land on
+   * `*.beanfun.com`, which sits inside the backend
+   * `web_browser::is_allowed_host` suffix policy.
    */
   (event: 'open-web-browser', url: string): void
   /** Ask the parent to open the EquipCalculator dialog (P12.5 D5). */
@@ -270,6 +252,10 @@ async function handlePlayerReport(): Promise<void> {
   emit('open-web-browser', PLAYER_REPORT_URL)
 }
 
+function handleVideoReport(): void {
+  emit('open-web-browser', VIDEO_REPORT_URL)
+}
+
 function handleEquipCalculator(): void {
   emit('open-equip-calculator')
 }
@@ -340,6 +326,14 @@ function handleVisibleChange(value: boolean): void {
       >
         <el-icon><Document /></el-icon>
         <span>{{ t('PlayerReport') }}</span>
+      </el-button>
+      <el-button
+        class="maple-tools__button bf-btn-secondary"
+        data-test="maple-tools-video-report"
+        @click="handleVideoReport"
+      >
+        <el-icon><VideoCamera /></el-icon>
+        <span>{{ t('VideoReport') }}</span>
       </el-button>
       <el-button
         class="maple-tools__button bf-btn-secondary"

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,44 @@
+/**
+ * Global test setup — mocks for Tauri APIs that are unavailable
+ * in the jsdom test environment.
+ */
+
+import { vi } from 'vitest'
+import { config } from '@vue/test-utils'
+import { defineComponent, h } from 'vue'
+
+/* Mock @tauri-apps/api/window used by TitleBar.vue */
+vi.mock('@tauri-apps/api/window', () => ({
+  getCurrentWindow: () => ({
+    minimize: vi.fn(),
+    close: vi.fn(),
+    startDragging: vi.fn(),
+    setSize: vi.fn(),
+  }),
+}))
+
+vi.mock('@tauri-apps/api/dpi', () => ({
+  LogicalSize: class LogicalSize {
+    width: number
+    height: number
+    constructor(w: number, h: number) {
+      this.width = w
+      this.height = h
+    }
+  },
+}))
+
+/*
+ * Globally stub TitleBar so page-level tests that mock
+ * element-plus / vue-router don't break on TitleBar's imports.
+ */
+config.global.stubs = {
+  ...config.global.stubs,
+  TitleBar: defineComponent({
+    name: 'TitleBarStub',
+    setup:
+      (_, { slots }) =>
+      () =>
+        h('div', { class: 'bf-titlebar' }, slots.default?.()),
+  }),
+}

--- a/tests/unit/i18n/index.spec.ts
+++ b/tests/unit/i18n/index.spec.ts
@@ -129,9 +129,9 @@ describe('locale assets', () => {
 
   it('merges WPF flat keys with frontend-only nested keys', () => {
     expect(i18nMessages['zh-TW']).toHaveProperty('AppName', '繽放')
-    expect(i18nMessages['zh-TW'].loginShell).toHaveProperty('heading')
+    expect(i18nMessages['zh-TW'].titleBar).toHaveProperty('minimize')
     expect(i18nMessages['en-US']).toHaveProperty('AppName')
-    expect(i18nMessages['en-US'].loginShell).toHaveProperty('heading')
+    expect(i18nMessages['en-US'].titleBar).toHaveProperty('minimize')
   })
 })
 
@@ -139,13 +139,13 @@ describe('createAppI18n', () => {
   it('boots with zh-TW as the default locale and zh-TW messages applied', () => {
     const i18n = createAppI18n()
     expect(i18n.global.locale.value).toBe('zh-TW')
-    expect(i18n.global.t('loginShell.heading')).toBe(i18nMessages['zh-TW'].loginShell.heading)
+    expect(i18n.global.t('titleBar.minimize')).toBe(i18nMessages['zh-TW'].titleBar.minimize)
   })
 
   it('renders zh-CN messages when locale switches', () => {
     const i18n = createAppI18n()
     setLocale(i18n, 'zh-CN')
-    expect(i18n.global.t('loginShell.heading')).toBe(i18nMessages['zh-CN'].loginShell.heading)
+    expect(i18n.global.t('titleBar.minimize')).toBe(i18nMessages['zh-CN'].titleBar.minimize)
   })
 
   it('substitutes positional placeholders ({0}) in WPF-style messages', () => {
@@ -163,9 +163,9 @@ describe('createAppI18n', () => {
 
   it('setLocale switches the rendered language end-to-end', () => {
     const i18n = createAppI18n()
-    expect(i18n.global.t('loginShell.heading')).toBe(i18nMessages['zh-TW'].loginShell.heading)
+    expect(i18n.global.t('titleBar.minimize')).toBe(i18nMessages['zh-TW'].titleBar.minimize)
     setLocale(i18n, 'en-US')
-    expect(i18n.global.t('loginShell.heading')).toBe(i18nMessages['en-US'].loginShell.heading)
+    expect(i18n.global.t('titleBar.minimize')).toBe(i18nMessages['en-US'].titleBar.minimize)
   })
 
   it('zh-CN falls back to zh-TW (NOT en-US) for keys missing in zh-Hans.xaml (WPF parity)', () => {

--- a/tests/unit/i18n/key-usage.spec.ts
+++ b/tests/unit/i18n/key-usage.spec.ts
@@ -217,6 +217,13 @@ const DYNAMIC_KEY_CONSUMERS: readonly DynamicConsumer[] = [
     reason: 'Region tile hint key is read dynamically from TILES[i].hintKey.',
     usedBy: 'src/pages/LoginRegionSelection.vue::TILES',
   },
+  {
+    kind: 'prefix',
+    prefix: 'titleBar.',
+    reason:
+      'Resolved at runtime from route.meta.titleKey in TitleBar.vue (e.g. route meta sets titleKey to "titleBar.regionSelection").',
+    usedBy: 'src/components/TitleBar.vue::titleText computed',
+  },
 ]
 
 function isCoveredByDynamicConsumer(path: string): boolean {

--- a/tests/unit/pages/AccountList.spec.ts
+++ b/tests/unit/pages/AccountList.spec.ts
@@ -194,8 +194,9 @@ vi.mock('@element-plus/icons-vue', () => {
     Plus: stub('PlusStub'),
     Refresh: stub('RefreshStub'),
     Service: stub('ServiceStub'),
-    Setting: stub('SettingStub'),
+    Iphone: stub('IphoneStub'),
     SwitchButton: stub('SwitchButtonStub'),
+    Wallet: stub('WalletStub'),
     User: stub('UserStub'),
     VideoPlay: stub('VideoPlayStub'),
     /*
@@ -222,7 +223,9 @@ vi.mock('@element-plus/icons-vue', () => {
  * element, animation timing) is intentionally out of scope for
  * unit tests — those would belong in an E2E suite.
  */
-let capturedOnEnd: ((event: { oldIndex?: number; newIndex?: number }) => void) | null = null
+let capturedOnEnd:
+  | ((event: { oldIndex?: number; newIndex?: number; item: HTMLElement; from: HTMLElement }) => void)
+  | null = null
 
 vi.mock('sortablejs', () => ({
   default: {
@@ -1596,7 +1599,7 @@ describe('AccountList page', () => {
      * The page's @end handler receives `{ oldIndex, newIndex }`
      * and splices the Pinia array in place before persisting.
      */
-    vi.mocked(commands.getAccounts).mockReturnValueOnce(ok(POPULATED_LIST))
+    vi.mocked(commands.getAccounts).mockReturnValueOnce(ok(structuredClone(POPULATED_LIST)))
 
     const ctx = buildHarness()
     useAuthStore().session = FAKE_SESSION
@@ -1619,7 +1622,14 @@ describe('AccountList page', () => {
      * producing [sid-2, sid-3, sid-1].
      */
     expect(capturedOnEnd).not.toBeNull()
-    capturedOnEnd!({ oldIndex: 0, newIndex: 2 })
+    const fakeFrom = document.createElement('ul')
+    for (let i = 0; i < 3; i++) fakeFrom.appendChild(document.createElement('li'))
+    capturedOnEnd!({
+      oldIndex: 0,
+      newIndex: 2,
+      item: fakeFrom.children[0] as HTMLElement,
+      from: fakeFrom,
+    })
     await flushPromises()
 
     /*
@@ -1657,7 +1667,7 @@ describe('AccountList page', () => {
      * (bypassing `configStore.set` → `wrapCommand` → toast) so
      * the user sees nothing.
      */
-    vi.mocked(commands.getAccounts).mockReturnValueOnce(ok(POPULATED_LIST))
+    vi.mocked(commands.getAccounts).mockReturnValueOnce(ok(structuredClone(POPULATED_LIST)))
     vi.mocked(commands.setConfig).mockReturnValueOnce(
       err({ code: 'config.write_failed', message: 'disk full', details: null }),
     )
@@ -1672,7 +1682,14 @@ describe('AccountList page', () => {
      * index 0. The handler splices the array to [sid-2, sid-1, sid-3].
      */
     expect(capturedOnEnd).not.toBeNull()
-    capturedOnEnd!({ oldIndex: 1, newIndex: 0 })
+    const fakeFrom = document.createElement('ul')
+    for (let i = 0; i < 3; i++) fakeFrom.appendChild(document.createElement('li'))
+    capturedOnEnd!({
+      oldIndex: 1,
+      newIndex: 0,
+      item: fakeFrom.children[1] as HTMLElement,
+      from: fakeFrom,
+    })
     await flushPromises()
 
     /* The IPC fired (we asked the backend to persist). */
@@ -1684,6 +1701,7 @@ describe('AccountList page', () => {
      * persist failure — the WPF behaviour is identical, the user
      * keeps the drag result and the next refresh reconciles).
      */
+    const account = useAccountStore()
     expect(account.serviceAccounts.map((a) => a.sid)).toEqual(['sid-2', 'sid-1', 'sid-3'])
     /*
      * Cache was NOT mutated since the IPC failed — mirrors the

--- a/tests/unit/pages/AccountList.spec.ts
+++ b/tests/unit/pages/AccountList.spec.ts
@@ -224,7 +224,12 @@ vi.mock('@element-plus/icons-vue', () => {
  * unit tests — those would belong in an E2E suite.
  */
 let capturedOnEnd:
-  | ((event: { oldIndex?: number; newIndex?: number; item: HTMLElement; from: HTMLElement }) => void)
+  | ((event: {
+      oldIndex?: number
+      newIndex?: number
+      item: HTMLElement
+      from: HTMLElement
+    }) => void)
   | null = null
 
 vi.mock('sortablejs', () => ({

--- a/tests/unit/pages/AccountList.spec.ts
+++ b/tests/unit/pages/AccountList.spec.ts
@@ -1603,7 +1603,7 @@ describe('AccountList page', () => {
 
     const ctx = buildHarness()
     useAuthStore().session = FAKE_SESSION
-    const wrapper = await ctx.mountIt()
+    await ctx.mountIt()
     await flushPromises()
 
     const account = useAccountStore()
@@ -1674,7 +1674,7 @@ describe('AccountList page', () => {
 
     const ctx = buildHarness()
     useAuthStore().session = FAKE_SESSION
-    const wrapper = await ctx.mountIt()
+    await ctx.mountIt()
     await flushPromises()
 
     /*

--- a/tests/unit/pages/AccountList.spec.ts
+++ b/tests/unit/pages/AccountList.spec.ts
@@ -213,44 +213,24 @@ vi.mock('@element-plus/icons-vue', () => {
 })
 
 /**
- * D7: stub `vuedraggable` to a thin reactive wrapper that:
- *
- * 1. Renders the `#item` slot once per `:list` element (in
- *    bound order), exposing the same `{ element, index }` slot
- *    shape vuedraggable@4 ships, so the existing row template
- *    inside AccountList renders unchanged.
- * 2. Forwards extra attrs (e.g. `data-test`, `class`) onto the
- *    rendered tag so the `[data-test="account-list-rows"]`
- *    selector in pre-D7 tests keeps resolving.
- * 3. Lets tests fire `@end` directly via
- *    `wrapper.findComponent(DraggableStub).vm.$emit('end')` after
- *    mutating `:list` (mutating Pinia state has the same effect
- *    as Sortable.js' real splice — both flow through Vue
- *    reactivity to the bound prop).
+ * D7: mock `sortablejs`. The page uses `Sortable.create()` directly
+ * on a native `<ul>` ref. We capture the `onEnd` callback passed to
+ * `Sortable.create` so tests can invoke it with a synthetic
+ * `{ oldIndex, newIndex }` event to exercise the drag-end handler.
  *
  * Real Sortable.js DOM behaviour (mouse-down on handle, ghost
  * element, animation timing) is intentionally out of scope for
  * unit tests — those would belong in an E2E suite.
  */
-vi.mock('vuedraggable', () => ({
-  default: defineComponent({
-    name: 'DraggableStub',
-    props: {
-      list: { type: Array, default: () => [] },
-      itemKey: { type: [String, Function], default: '' },
-    },
-    emits: ['end', 'change'],
-    setup(props, { slots, attrs }) {
-      return () =>
-        h(
-          'ul',
-          { ...attrs, class: ['draggable-stub', attrs.class] },
-          (props.list as Array<Record<string, unknown>>).map((element, index) =>
-            slots.item ? slots.item({ element, index }) : null,
-          ),
-        )
-    },
-  }),
+let capturedOnEnd: ((event: { oldIndex?: number; newIndex?: number }) => void) | null = null
+
+vi.mock('sortablejs', () => ({
+  default: {
+    create: vi.fn((_el: HTMLElement, options: { onEnd?: typeof capturedOnEnd }) => {
+      capturedOnEnd = options?.onEnd ?? null
+      return { destroy: vi.fn() }
+    }),
+  },
 }))
 
 vi.mock('../../../src/types/bindings', () => ({
@@ -1562,10 +1542,9 @@ describe('AccountList page', () => {
    * Sortable.js DOM mechanics (mouse-down on handle, ghost element,
    * animation) are intentionally out of scope here — they belong in
    * an E2E suite. The unit boundary is the page's @end handler:
-   * after Vuedraggable has already mutated the bound `:list` in
-   * place (we simulate that by writing to `account.serviceAccounts`
-   * directly — same Pinia reactivity flow), the @end handler runs
-   * its (a) canonical store-action funnel and (b) silent persist.
+   * the @end handler receives `{ oldIndex, newIndex }` from the
+   * event, splices the Pinia array in place, then runs its
+   * (a) canonical store-action funnel and (b) silent persist.
    */
 
   it('D7: applies the saved per-game order to the server-sorted list on load', async () => {
@@ -1614,10 +1593,8 @@ describe('AccountList page', () => {
      * (L477-487): once the user releases the drag, the new sid CSV
      * gets persisted under `AccountOrder_<service_code>_<service_region>`.
      *
-     * The page's @end handler reads the (already-mutated) sids from
-     * `account.serviceAccounts.map(a => a.sid)`, so we simulate
-     * Sortable.js' splice by writing to that array directly and
-     * then firing the @end emit on the DraggableStub.
+     * The page's @end handler receives `{ oldIndex, newIndex }`
+     * and splices the Pinia array in place before persisting.
      */
     vi.mocked(commands.getAccounts).mockReturnValueOnce(ok(POPULATED_LIST))
 
@@ -1637,16 +1614,12 @@ describe('AccountList page', () => {
     const setOrderSpy = vi.spyOn(account, 'setServiceAccountOrder')
 
     /*
-     * Sortable.js' real onEnd flow first splices the bound array
-     * in place, then fires the event. Reproduce that order so the
-     * page's @end handler reads the post-drag order from the
-     * store, not the pre-drag order.
+     * Simulate dragging item at index 0 (SERVICE_ACCOUNT / sid-1)
+     * to index 2. The handler splices the Pinia array in place,
+     * producing [sid-2, sid-3, sid-1].
      */
-    account.serviceAccounts = [SECOND_SA, BANNED_SA, SERVICE_ACCOUNT]
-
-    const draggable = wrapper.findComponent({ name: 'DraggableStub' })
-    expect(draggable.exists()).toBe(true)
-    draggable.vm.$emit('end')
+    expect(capturedOnEnd).not.toBeNull()
+    capturedOnEnd!({ oldIndex: 0, newIndex: 2 })
     await flushPromises()
 
     /*
@@ -1694,11 +1667,12 @@ describe('AccountList page', () => {
     const wrapper = await ctx.mountIt()
     await flushPromises()
 
-    const account = useAccountStore()
-    account.serviceAccounts = [SECOND_SA, SERVICE_ACCOUNT, BANNED_SA]
-
-    const draggable = wrapper.findComponent({ name: 'DraggableStub' })
-    draggable.vm.$emit('end')
+    /*
+     * Simulate dragging item at index 1 (SECOND_SA / sid-2) to
+     * index 0. The handler splices the array to [sid-2, sid-1, sid-3].
+     */
+    expect(capturedOnEnd).not.toBeNull()
+    capturedOnEnd!({ oldIndex: 1, newIndex: 0 })
     await flushPromises()
 
     /* The IPC fired (we asked the backend to persist). */

--- a/tests/unit/pages/LoginPage.spec.ts
+++ b/tests/unit/pages/LoginPage.spec.ts
@@ -1,23 +1,21 @@
 /**
  * P12.1 D1 — login shell render guard.
  *
- * Three concerns this spec locks down:
+ * Two concerns this spec locks down:
  *
- * 1. The shell renders the localized brand heading + subline (proves
- *    `loginShell.*` keys flow through and the template binds to them).
- * 2. The shell exposes a `<RouterView />` slot — D2-D8 will rely on
+ * 1. The shell exposes a `<RouterView />` slot — D2-D8 will rely on
  *    this to mount their respective forms.
- * 3. Locale switches re-render the brand text live (proves the shell
- *    isn't accidentally caching the initial translation).
+ * 2. The shell renders a TitleBar component for window chrome.
  */
 
 import { describe, expect, it } from 'vitest'
-import { defineComponent, h, nextTick } from 'vue'
+import { defineComponent, h } from 'vue'
 import { mount } from '@vue/test-utils'
 import { createMemoryHistory, createRouter } from 'vue-router'
+import { createPinia } from 'pinia'
 
 import LoginPage from '../../../src/pages/LoginPage.vue'
-import { createAppI18n, i18nMessages, setLocale } from '../../../src/i18n'
+import { createAppI18n } from '../../../src/i18n'
 
 const ChildStub = defineComponent({
   name: 'ChildStub',
@@ -37,6 +35,7 @@ function mountLoginPage(initialPath = '/login/_test') {
   })
 
   const i18n = createAppI18n()
+  const pinia = createPinia()
 
   return {
     router,
@@ -45,7 +44,7 @@ function mountLoginPage(initialPath = '/login/_test') {
       await router.push(initialPath)
       await router.isReady()
       const wrapper = mount(LoginPage, {
-        global: { plugins: [router, i18n] },
+        global: { plugins: [router, i18n, pinia] },
       })
       return wrapper
     },
@@ -53,16 +52,11 @@ function mountLoginPage(initialPath = '/login/_test') {
 }
 
 describe('LoginPage shell', () => {
-  it('renders the localized brand heading + subline', async () => {
+  it('renders the TitleBar component', async () => {
     const ctx = mountLoginPage()
     const wrapper = await ctx.mount()
 
-    expect(wrapper.find('.login-shell__title').text()).toBe(
-      i18nMessages['zh-TW'].loginShell.heading,
-    )
-    expect(wrapper.find('.login-shell__subline').text()).toBe(
-      i18nMessages['zh-TW'].loginShell.subline,
-    )
+    expect(wrapper.find('.bf-titlebar').exists()).toBe(true)
   })
 
   it('exposes a <RouterView /> slot for child routes', async () => {
@@ -71,24 +65,5 @@ describe('LoginPage shell', () => {
 
     expect(wrapper.find('[data-testid="child"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="child"]').text()).toBe('child route content')
-  })
-
-  it('re-renders brand text after a runtime locale switch', async () => {
-    const ctx = mountLoginPage()
-    const wrapper = await ctx.mount()
-
-    expect(wrapper.find('.login-shell__title').text()).toBe(
-      i18nMessages['zh-TW'].loginShell.heading,
-    )
-
-    setLocale(ctx.i18n, 'en-US')
-    await nextTick()
-
-    expect(wrapper.find('.login-shell__title').text()).toBe(
-      i18nMessages['en-US'].loginShell.heading,
-    )
-    expect(wrapper.find('.login-shell__subline').text()).toBe(
-      i18nMessages['en-US'].loginShell.subline,
-    )
   })
 })

--- a/tests/unit/pages/LoginRegionSelection.spec.ts
+++ b/tests/unit/pages/LoginRegionSelection.spec.ts
@@ -130,7 +130,9 @@ describe('LoginRegionSelection', () => {
     expect(wrapper.find('.region-picker__subline').text()).toBe(
       i18nMessages['zh-TW'].loginRegion.subline,
     )
-    expect(wrapper.find('.region-picker__tip').text()).toBe(i18nMessages['zh-TW'].loginRegion.tip)
+    expect(wrapper.find('.region-picker__tip').text()).toContain(
+      i18nMessages['zh-TW'].loginRegion.tip,
+    )
   })
 
   it('persists "TW" to loginRegion when the Taiwan tile is clicked', async () => {

--- a/tests/unit/stores/account.spec.ts
+++ b/tests/unit/stores/account.spec.ts
@@ -297,7 +297,7 @@ describe('useAccountStore — service accounts', () => {
  * Exercises the two ordering actions added in P12.2 D7:
  *
  * - {@link useAccountStore.setServiceAccountOrder} — explicit
- *   sid-list reorder; the page calls this after a vuedraggable
+ *   sid-list reorder; the page calls this after a SortableJS
  *   `@end` event.
  * - {@link useAccountStore.applyServiceAccountOrderFromSavedCsv} —
  *   convenience wrapper that parses the CSV WPF persists under

--- a/tests/unit/stores/config.spec.ts
+++ b/tests/unit/stores/config.spec.ts
@@ -95,7 +95,7 @@ describe('useConfigStore', () => {
     expect('ToBeDeleted' in store.entries).toBe(false)
   })
 
-  it('set leaves the cache untouched when the backend errors', async () => {
+  it('set updates the in-memory cache even when the backend write fails (read-only file)', async () => {
     mockGetAllConfig.mockReturnValueOnce(ok({ Locale: 'zh-TW' }))
     mockSetConfig.mockReturnValueOnce(
       err({ code: 'config.io_error', message: 'disk full', details: null }),
@@ -104,8 +104,8 @@ describe('useConfigStore', () => {
     const store = useConfigStore()
     await store.loadAll()
 
-    await expect(store.set('Locale', 'en-US')).rejects.toThrow()
-    expect(store.get('Locale')).toBe('zh-TW')
+    await store.set('Locale', 'en-US')
+    expect(store.get('Locale')).toBe('en-US')
   })
 
   it('loadAll surfaces backend errors via wrapCommand', async () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
+    setupFiles: ['tests/setup.ts'],
     include: ['tests/unit/**/*.spec.ts'],
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
## Summary

This branch bundles the glass-panel UI refresh cherry-picked from [#228](https://github.com/pungin/Beanfun/pull/228) together with a follow-up fix for a minimize-to-tray regression the new window shell introduced.

### Glass-panel UI refresh (cherry-picked from #228)

- Custom `TitleBar.vue` with drag / minimize / close buttons plus dynamic page titles.
- `decorations: false` + `transparent: true` window backed by the new `bf-glass-window` utility class that reuses the existing mica gradient — visual identity preserved.
- Router `meta` carries `titleKey` / `titleIcon` / `windowWidth` / `windowHeight`; the `afterEach` hook resizes the window per route.
- Material Symbols font loaded in `index.html`; global scrollbar / MessageBox overrides in `App.vue`.
- Pages restructured with `TitleBar` + scroll wrapper: `LoginPage`, `AccountList` (page header retained per request), `Settings`, `About`, `ManageAccount`.
- QR form: enlarge-on-click dialog + "copy QR" button + hint text (original `size="large"` button styling retained).
- i18n: added `titleBar.*` / `loginQr.{enlarge,copyQr,copyQrSuccess}`; removed unused `loginShell.*`; `warnHtmlMessage: false` in i18n init.
- `mockups/` added to `.gitignore`.

### Follow-up fix — minimize honours `minimize_to_tray`

The borderless + transparent + non-resizable window no longer reliably emits Windows' `WM_SIZE(SIZE_MINIMIZED, 0, 0)` that `tray::handle_minimize_to_tray` was listening for, so the TitleBar minimize button always dropped to the taskbar even when the user had ticked "Minimize to notification center".

Fix: switch the TitleBar minimize path to a new `minimize_main_window` Tauri command that reads the config and either hides-and-shows-tray or falls through to a plain `window.minimize()`. The `Resized(0, 0)` listener is kept as a defensive fallback for any OS-initiated minimize.

- `tray.rs` — extract `hide_to_tray` (generic over `Runtime`); expose `is_minimize_to_tray_enabled`; add `TrayState` newtype for command-layer access to the tray ID via managed state.
- `lib.rs` — `.manage(TrayState(arc))` so the setup / window-event closures and the new command share one `Arc<Mutex<Option<TrayIconId>>>`.
- `commands/system.rs` — new `minimize_main_window<R: Runtime>` with `system.window_not_found` / `system.minimize_failed` error codes.
- `commands/mod.rs` — register in `collect_commands!` (with `::<tauri::Wry>` turbofish per the `login_gamepass_start` precedent) and in `REQUIRED_COMMANDS`.
- `bindings.ts` — regenerated via `cargo run --example export_bindings`.
- `TitleBar.vue` — call `commands.minimizeMainWindow()`; fallback to `appWindow.minimize()` on command error so the button never becomes a silent no-op.

## Test plan

### Automated

- [x] `cargo test --lib` — 730 passed
- [x] `npx vitest run` — 585 passed across 40 files

### Manual (requires `npm run tauri dev`)

**Glass-panel shell**

- [x] Open login page — custom titlebar renders with app icon, drag works, minimize + close buttons work, region switcher + settings/about buttons in titlebar slot work.
- [x] Navigate Login → AccountList → Settings → About → ManageAccount — window resizes per route, titlebar title updates.
- [x] `Esc` / click-outside on any MessageBox (e.g. confirm / alert) — glass styling applied.
- [x] Login region selection unaffected.
- [x] Account reordering (SortableJS) on AccountList unaffected.
- [x] Drag title bar to move window; double-clicking titlebar does nothing (expected — not implemented).

**QR form**

- [x] QR button enlarge opens dialog; hint text "右鍵可以複製" visible.
- [x] Right-click QR image copies it (unchanged behaviour).
- [x] "Copy QR" button copies and shows success message.
- [x] Existing buttons (login / region / refresh) remain `size="large"`.

**Minimize-to-tray**

- [x] Settings → **uncheck** "Minimize to notification center" → TitleBar minimize → window goes to Windows taskbar.
- [x] Settings → **check** "Minimize to notification center" → TitleBar minimize → window hides, tray icon appears.
- [x] Left-click tray icon → window restored, tray icon hidden.

## Credits

Glass-panel shell commits carry `Co-Authored-By: William Leung <61426712+lshw54@users.noreply.github.com>` (original PR #228 author). The follow-up minimize-to-tray fix is authored locally.
