### PR TITLE
fix(ci): scope version-bump regex to [package] section, inline wv2-windows-core

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -107,7 +107,14 @@ jobs:
           $semVer = "${{ steps.prep_version.outputs.semantic_version }}"
 
           $cargo = Get-Content src-tauri/Cargo.toml -Raw -Encoding UTF8
-          $cargo = $cargo -replace '(?m)^version\s*=\s*"[\d.]+"', "version = `"$semVer`""
+          # Only replace the `version = "..."` line inside the [package] section.
+          # The previous `(?m)^version\s*=\s*"[\d.]+"` pattern also matched the
+          # top-level `version` key of explicit-table dependencies such as
+          # `[target.'cfg(windows)'.dependencies.wv2-windows-core]`, which broke
+          # the build by rewriting them to the package version. The non-greedy
+          # `(?:(?!\r?\n\[).)*?` group stops at the next section header, so the
+          # match is safely scoped to [package] regardless of CRLF/LF endings.
+          $cargo = $cargo -replace '(?sm)(\[package\](?:(?!\r?\n\[).)*?^version\s*=\s*")[\d.]+(")', "`${1}$semVer`${2}"
           [System.IO.File]::WriteAllText("src-tauri/Cargo.toml", $cargo)
 
           $tauri = Get-Content src-tauri/tauri.conf.json -Raw -Encoding UTF8

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -141,9 +141,10 @@ wmi = "0.14"
 webview2-com-sys = "0.38"
 webview2-com = "0.38"
 # Same windows-core version as webview2-com-sys for PCWSTR / Interface types.
-[target.'cfg(windows)'.dependencies.wv2-windows-core]
-package = "windows-core"
-version = "0.61"
+# Inline form (instead of `[target.'cfg(windows)'.dependencies.wv2-windows-core]`)
+# avoids a standalone `version = "..."` line that the release workflow's
+# version-bump regex previously misidentified as the package version.
+wv2-windows-core = { package = "windows-core", version = "0.61" }
 
 [dev-dependencies]
 wiremock = "0.6"


### PR DESCRIPTION
## Summary

Fixes the broken release workflow that has been failing since #230 was merged. See run [#20 / job 72225904016](https://github.com/pungin/Beanfun/actions/runs/24695082681/job/72225904016).

### Root cause

`.github/workflows/build-and-release.yml` bumps the package version with this regex:

```pwsh
$cargo = $cargo -replace '(?m)^version\s*=\s*"[\d.]+"', "version = `"$semVer`""
```

`(?m)^version` matches **every** line starting with `version`, including the standalone `version = "0.61"` line inside the `[target.'cfg(windows)'.dependencies.wv2-windows-core]` section that was added in #230. The workflow rewrote that line to the new package version (e.g. `5.9.3`), so cargo then tried to resolve `windows-core = "^5.9.3"`, which does not exist on crates.io (latest is `0.62.x`):

```text
error: failed to select a version for the requirement `windows-core = "^5.9.3"`
candidate versions found which didn't match: 0.62.2, 0.62.1, 0.62.0, ...
```

### Changes

1. **`fix(ci)` — scope version-bump regex to `[package]` section only.** New pattern anchors on `[package]` and stops at the next section header via a `(?!\r?\n\[)` negative lookahead (CRLF/LF safe). Locally verified against the actual `Cargo.toml`: `[package]` version replaced as expected, `wv2-windows-core` version untouched.
2. **`refactor(deps)` — inline `wv2-windows-core` declaration.** Defensive change so future contributors don't have to rely on the regex being perfectly scoped. Semantically identical, `Cargo.lock` unchanged.

The two changes are independent — either one alone fixes the build — but together they remove both the bug and the foot-gun.

### Out of scope

The `Node.js 20 actions are deprecated` warning shown on the same run is **not** addressed here. Dependabot has previously opened #219 / #220 / #221 for these bumps and they were closed by maintainers; want to discuss separately before reopening.

## Test plan

- [ ] Trigger `Build and Release` workflow (workflow_dispatch) on this branch and confirm the build step succeeds.
- [ ] Verify the bumped `Cargo.toml` only changes the `[package]` `version` line (workflow log "Update version in Cargo.toml..." step).
