### PR TITLE
fix(ci): build NSIS installer alongside standalone exe

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -30,7 +30,7 @@ env:
 
 jobs:
   build:
-    name: 'Build Beanfun.exe & Create Release'
+    name: 'Build Beanfun.exe + NSIS Installer & Create Release'
     runs-on: windows-latest
     permissions:
       contents: write
@@ -125,8 +125,14 @@ jobs:
           $pkg = $pkg -replace '"version"\s*:\s*"[\d.]+"', "`"version`": `"$semVer`""
           [System.IO.File]::WriteAllText("package.json", $pkg)
 
-      - name: Build Tauri application (standalone exe)
-        run: npm run tauri build -- --no-bundle
+      - name: Build Tauri application (standalone exe + NSIS installer)
+        # `--bundles nsis` builds the standalone exe at
+        # src-tauri/target/release/beanfun.exe (consumed by the rename step
+        # below) and additionally packs an NSIS installer at
+        # src-tauri/target/release/bundle/nsis/Beanfun_<ver>_x64-setup.exe
+        # using the offlineInstaller WebView2 mode configured in
+        # src-tauri/tauri.conf.json.
+        run: npm run tauri build -- --bundles nsis
 
       - name: Rename exe to Beanfun.exe
         shell: cmd
@@ -191,7 +197,11 @@ jobs:
             ---
 
             ### Download
-            **[Beanfun.exe](${{ github.server_url }}/${{ github.repository }}/releases/download/${{ steps.prep_version.outputs.tag_name }}/Beanfun.exe)**
+
+            | Type | File | When to use |
+            |------|------|-------------|
+            | Portable | **[Beanfun.exe](${{ github.server_url }}/${{ github.repository }}/releases/download/${{ steps.prep_version.outputs.tag_name }}/Beanfun.exe)** | Drop-in replacement; requires WebView2 already installed (Win11 / most Win10) |
+            | Installer | **[Beanfun_${{ steps.prep_version.outputs.semantic_version }}_x64-setup.exe](${{ github.server_url }}/${{ github.repository }}/releases/download/${{ steps.prep_version.outputs.tag_name }}/Beanfun_${{ steps.prep_version.outputs.semantic_version }}_x64-setup.exe)** | Bundles WebView2 runtime offline; for stripped-down Windows 10 (no Edge) or first-time install |
 
             ### What's New
             ${{ steps.prep_release.outputs.commits_text }}
@@ -199,8 +209,14 @@ jobs:
             Total commits: ${{ steps.prep_release.outputs.commit_count }}
 
             ### Installation
-            1. Download **Beanfun.exe** above.
+
+            **Portable (Beanfun.exe)**
+            1. Download `Beanfun.exe`.
             2. Replace your old file and run.
+
+            **Installer (Beanfun_${{ steps.prep_version.outputs.semantic_version }}_x64-setup.exe)**
+            1. Download the setup installer.
+            2. Run it; WebView2 runtime is bundled and will be installed automatically if missing.
 
             ${{ github.event.inputs.release_type == 'prerelease' && '> **NOTE:** This is a pre-release version. Use at your own risk.' || '' }}
 
@@ -214,7 +230,9 @@ jobs:
             | Source Commit | [View](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}) |
 
             </details>
-          files: src-tauri/target/release/Beanfun.exe
+          files: |
+            src-tauri/target/release/Beanfun.exe
+            src-tauri/target/release/bundle/nsis/*-setup.exe
           draft: false
           prerelease: ${{ github.event.inputs.release_type == 'prerelease' }}
 


### PR DESCRIPTION
## Summary

5.9.3 release 缺了 NSIS installer，雖然 `src-tauri/tauri.conf.json` 早就設定 `"targets": ["nsis"]` + `offlineInstaller`，但 workflow 用 `tauri build -- --no-bundle` 把整個 bundling 階段跳掉，所以 NSIS 從來沒被產出。論壇對外宣傳已寫「同時提供免安裝版 exe 和 NSIS 安裝版 適用於精簡版 Windows」，需要補回來。

- Build step：`-- --no-bundle` → `-- --bundles nsis`，每次 release 同時產出 standalone exe 與 NSIS installer
- Upload `files`：同時包 `Beanfun.exe` 與 `bundle/nsis/*-setup.exe`
- Release notes：Download / Installation 區塊分成 Portable / Installer 兩種選擇並標註適用情境
- 不動 version bump 流程、不動其他 step

## Test plan

- [ ] Merge 後 revert `0c447fc` 把版本回退到 5.9.2
- [ ] 砍掉現存的 `v5.9.3.2604202330` release + tag
- [ ] 手動觸發 `Build and Release` workflow（branch=`code`, release_type=`prerelease`, version_increment=`patch`）
- [ ] 確認新 release 的 Assets 同時包含 `Beanfun.exe` 與 `Beanfun_5.9.3_x64-setup.exe`
- [ ] 確認 release notes 的 Download 表格兩個下載連結都能正確下載
- [ ] 在乾淨 / 精簡版 Win10 環境試跑 NSIS installer，確認 WebView2 offline 安裝成功
