### PR TITLE
fix(login): restore ?pick escape hatch and fix `返回一般登入` landing page

### DIFF
--- a/src/pages/GamepassForm.vue
+++ b/src/pages/GamepassForm.vue
@@ -312,7 +312,12 @@ async function refresh(): Promise<void> {
 
 async function goBack(): Promise<void> {
   disposed = true
-  await router.push({ path: '/login', query: { pick: '1' } })
+  // "返回一般登入" — go back to the regular id-pass form within the
+  // same saved region, NOT to the region picker. Pushing
+  // `/login?pick=1` would force the user to re-pick TW/HK, which the
+  // button label does not promise. Mirrors WPF's
+  // `LoginMethod = Regular` + `loginMethodChanged()` flow.
+  await router.push('/login/id-pass')
 }
 </script>
 

--- a/src/pages/LoginRegionSelection.vue
+++ b/src/pages/LoginRegionSelection.vue
@@ -31,7 +31,7 @@
  * picker without triggering the redirect again.
  */
 
-import { computed, onMounted, watch } from 'vue'
+import { computed, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 import { useConfigStore } from '../stores/config'
@@ -43,16 +43,6 @@ const { t } = useI18n()
 const route = useRoute()
 const router = useRouter()
 const config = useConfigStore()
-
-/**
- * Skip the region picker if a region is already saved — go
- * straight to the login form. First-launch users see the picker.
- */
-onMounted(() => {
-  if (config.get('loginRegion')) {
-    void router.replace('/login/id-pass')
-  }
-})
 
 /**
  * Tile descriptors. Kept declarative so the template stays a flat

--- a/src/pages/QrForm.vue
+++ b/src/pages/QrForm.vue
@@ -17,9 +17,13 @@
  *   QR challenge, overwriting any prior `pending_qr` slot (see
  *   `commands/auth.rs::login_qr_start` side-effect docs).
  * - **Back button**: `qr_form.xaml.cs::btn_back_Click` flips
- *   `App.LoginMethod = Regular` and re-runs `loginMethodChanged()`.
- *   We push `/login`; the parent `LoginPage` re-renders
- *   `LoginRegionSelection` at the root child route.
+ *   `App.LoginMethod = Regular` and re-runs `loginMethodChanged()`,
+ *   which lands the user on the regular id-pass form (the QR mode is
+ *   peer to id-pass within the same region, not above region picking).
+ *   We mirror that with `router.push('/login/id-pass')` — staying in
+ *   the saved region, just switching the login mode. We do NOT push
+ *   `/login?pick=1`; the button is "返回一般登入" (back to regular
+ *   login), not "重選區域" (re-pick region).
  *
  * # Polling strategy (Q2 + Q10)
  *
@@ -300,7 +304,7 @@ async function refresh(): Promise<void> {
 async function goBack(): Promise<void> {
   disposed = true
   clearPollTimer()
-  await router.push({ path: '/login', query: { pick: '1' } })
+  await router.push('/login/id-pass')
 }
 
 /**

--- a/tests/unit/pages/GamepassForm.spec.ts
+++ b/tests/unit/pages/GamepassForm.spec.ts
@@ -17,7 +17,9 @@
  *    `connection-lost` banner shows and the steps stay at `0`.
  * 5. Refresh re-issues both commands and clears the banner on
  *    success.
- * 6. Back button navigates to `/login` without further calls.
+ * 6. Back button ("返回一般登入") navigates to `/login/id-pass` (NOT
+ *    `/login?pick=1` — the button switches login mode within the same
+ *    region, it does not re-pick region) without further backend calls.
  * 7. Locale switch re-renders the localized copy.
  *
  * CP4 event-wiring assertions (new):
@@ -231,6 +233,14 @@ function mountForm(opts: { region?: string } = {}) {
     routes: [
       { path: '/login', name: 'login', component: LoginStub },
       { path: '/login/gamepass', name: 'login-gamepass', component: GamepassForm },
+      {
+        path: '/login/id-pass',
+        name: 'login-id-pass',
+        component: defineComponent({
+          name: 'IdPassStub',
+          render: () => h('div', { 'data-testid': 'id-pass-stub' }),
+        }),
+      },
       { path: '/accounts', name: 'accounts', component: AccountsStub },
     ],
   })
@@ -368,7 +378,13 @@ describe('GamepassForm', () => {
     expect(wrapper.find('[data-testid="gamepass-steps"]').attributes('data-active')).toBe('2')
   })
 
-  it('Back button navigates to /login without further backend calls', async () => {
+  it('Back button ("返回一般登入") navigates to /login/id-pass without further backend calls', async () => {
+    /*
+     * Regression for the bug where goBack pushed `/login?pick=1`,
+     * which dumped the user back at the region picker even though
+     * the button label promised "back to regular (id-pass) login".
+     * The correct behaviour is mode-switch within the saved region.
+     */
     const ctx = mountForm()
     const wrapper = await ctx.mountIt()
     await flushPromises()
@@ -379,7 +395,7 @@ describe('GamepassForm', () => {
     await wrapper.find('[data-testid="gamepass-back"]').trigger('click')
     await flushPromises()
 
-    expect(ctx.router.currentRoute.value.path).toBe('/login')
+    expect(ctx.router.currentRoute.value.path).toBe('/login/id-pass')
     expect(mockLoginGamepassStart.mock.calls.length).toBe(startCallsAfterMount)
     expect(mockOpenGamepassWindow.mock.calls.length).toBe(openCallsAfterMount)
   })

--- a/tests/unit/pages/LoginRegionSelection.spec.ts
+++ b/tests/unit/pages/LoginRegionSelection.spec.ts
@@ -23,6 +23,7 @@ import { defineComponent, h, nextTick } from 'vue'
 import type { I18n } from 'vue-i18n'
 
 import type { CommandError, Result } from '../../../src/types/bindings'
+import { useConfigStore } from '../../../src/stores/config'
 
 vi.mock('element-plus', () => ({
   ElIcon: defineComponent({
@@ -51,6 +52,7 @@ import LoginRegionSelection from '../../../src/pages/LoginRegionSelection.vue'
 import { createAppI18n, i18nMessages, setLocale } from '../../../src/i18n'
 
 const mockSetConfig = vi.mocked(commands.setConfig)
+const mockGetAllConfig = vi.mocked(commands.getAllConfig)
 
 const ok = <T>(data: T): Promise<Result<T, CommandError>> => Promise.resolve({ status: 'ok', data })
 
@@ -60,7 +62,7 @@ const ok = <T>(data: T): Promise<Result<T, CommandError>> => Promise.resolve({ s
  * `router.push` resolves cleanly. Mirrors the test layout we'll reuse
  * in D3-D8 to verify each form's nav target.
  */
-function mountPicker(): {
+function mountPicker(opts: { initialPath?: string } = {}): {
   router: Router
   i18n: I18n
   mountIt: () => Promise<ReturnType<typeof mount>>
@@ -81,6 +83,14 @@ function mountPicker(): {
           render: () => h('div', { 'data-testid': 'id-pass-stub' }),
         }),
       },
+      {
+        path: '/login/qr',
+        name: 'login-qr',
+        component: defineComponent({
+          name: 'QrStub',
+          render: () => h('div', { 'data-testid': 'qr-stub' }),
+        }),
+      },
     ],
   })
 
@@ -90,7 +100,7 @@ function mountPicker(): {
     router,
     i18n,
     async mountIt() {
-      await router.push('/login/region')
+      await router.push(opts.initialPath ?? '/login/region')
       await router.isReady()
       return mount(LoginRegionSelection, {
         global: { plugins: [router, i18n] },
@@ -104,6 +114,8 @@ describe('LoginRegionSelection', () => {
     setActivePinia(createPinia())
     mockSetConfig.mockReset()
     mockSetConfig.mockReturnValue(ok(null))
+    mockGetAllConfig.mockReset()
+    mockGetAllConfig.mockReturnValue(ok({}))
   })
 
   it('renders both region tiles with their localized labels', async () => {
@@ -170,6 +182,84 @@ describe('LoginRegionSelection', () => {
 
     expect(ctx.router.currentRoute.value.path).toBe('/login/id-pass')
     expect(ctx.router.currentRoute.value.name).toBe('login-id-pass')
+  })
+
+  /*
+   * Auto-redirect (WPF `loginMethodInit` parity, commit `24a07af`).
+   *
+   * Once `Config.xml` is loaded, a saved `loginRegion` should skip
+   * the picker and jump straight to the matching login form. The
+   * `?pick=1` query is the documented escape hatch — login-form back
+   * buttons append it so the user can return to the picker.
+   *
+   * This block locks down the bug fixed in
+   * `fix(login-region): remove duplicate onMounted redirect`: a stray
+   * `onMounted` block was racing the watcher with weaker logic
+   * (no `?pick` check, no `loginMethod` awareness), making the
+   * picker unreachable after first launch.
+   */
+  describe('auto-redirect when Config.xml has saved preferences', () => {
+    it('jumps to /login/id-pass when loginRegion=TW is saved (default loginMethod)', async () => {
+      mockGetAllConfig.mockReturnValue(ok({ loginRegion: 'TW' }))
+      const ctx = mountPicker()
+      const config = useConfigStore()
+      await config.loadAll()
+      const wrapper = await ctx.mountIt()
+      await flushPromises()
+
+      expect(ctx.router.currentRoute.value.path).toBe('/login/id-pass')
+      wrapper.unmount()
+    })
+
+    it('jumps to /login/qr when loginRegion=TW + loginMethod=1 are saved', async () => {
+      mockGetAllConfig.mockReturnValue(ok({ loginRegion: 'TW', loginMethod: '1' }))
+      const ctx = mountPicker()
+      const config = useConfigStore()
+      await config.loadAll()
+      const wrapper = await ctx.mountIt()
+      await flushPromises()
+
+      expect(ctx.router.currentRoute.value.path).toBe('/login/qr')
+      wrapper.unmount()
+    })
+
+    it('falls back to /login/id-pass for HK even when loginMethod=1 (HK has no QR endpoint)', async () => {
+      mockGetAllConfig.mockReturnValue(ok({ loginRegion: 'HK', loginMethod: '1' }))
+      const ctx = mountPicker()
+      const config = useConfigStore()
+      await config.loadAll()
+      const wrapper = await ctx.mountIt()
+      await flushPromises()
+
+      expect(ctx.router.currentRoute.value.path).toBe('/login/id-pass')
+      wrapper.unmount()
+    })
+
+    it('stays on the picker when ?pick=1 is in the route, even with a saved region', async () => {
+      mockGetAllConfig.mockReturnValue(ok({ loginRegion: 'TW' }))
+      const ctx = mountPicker({ initialPath: '/login/region?pick=1' })
+      const config = useConfigStore()
+      await config.loadAll()
+      const wrapper = await ctx.mountIt()
+      await flushPromises()
+
+      expect(ctx.router.currentRoute.value.path).toBe('/login/region')
+      expect(wrapper.findAll('.region-tile')).toHaveLength(2)
+      wrapper.unmount()
+    })
+
+    it('stays on the picker on first launch when no region is saved', async () => {
+      mockGetAllConfig.mockReturnValue(ok({}))
+      const ctx = mountPicker()
+      const config = useConfigStore()
+      await config.loadAll()
+      const wrapper = await ctx.mountIt()
+      await flushPromises()
+
+      expect(ctx.router.currentRoute.value.path).toBe('/login/region')
+      expect(wrapper.findAll('.region-tile')).toHaveLength(2)
+      wrapper.unmount()
+    })
   })
 
   it('re-renders heading + tile labels after a runtime locale switch', async () => {

--- a/tests/unit/pages/QrForm.spec.ts
+++ b/tests/unit/pages/QrForm.spec.ts
@@ -17,7 +17,9 @@
  * 7. `loginQrCheck` error result stops polling + shows inline
  *    "connection lost" banner (Q11 = B — no toast, inline fallback).
  * 8. Refresh button re-mints the QR.
- * 9. Back button navigates to `/login` and halts the polling loop.
+ * 9. Back button ("返回一般登入") navigates to `/login/id-pass` (NOT
+ *    `/login?pick=1` — the button switches login mode within the same
+ *    region, it does not re-pick region) and halts the polling loop.
  * 10. Copy deeplink success path uses `navigator.clipboard.writeText`
  *     + success toast.
  * 11. Copy deeplink button is disabled when the server returns no
@@ -179,6 +181,14 @@ function mountForm(opts: { region?: string } = {}) {
     routes: [
       { path: '/login', name: 'login', component: LoginStub },
       { path: '/login/qr', name: 'login-qr', component: QrForm },
+      {
+        path: '/login/id-pass',
+        name: 'login-id-pass',
+        component: defineComponent({
+          name: 'IdPassStub',
+          render: () => h('div', { 'data-testid': 'id-pass-stub' }),
+        }),
+      },
       {
         path: '/accounts',
         name: 'accounts',
@@ -409,7 +419,13 @@ describe('QrForm', () => {
     )
   })
 
-  it('Back button navigates to /login and halts polling', async () => {
+  it('Back button ("返回一般登入") navigates to /login/id-pass and halts polling', async () => {
+    /*
+     * Regression for the bug where goBack pushed `/login?pick=1`,
+     * which dumped the user back at the region picker even though
+     * the button label promised "back to regular (id-pass) login".
+     * The correct behaviour is mode-switch within the saved region.
+     */
     mockLoginQrStart.mockReturnValueOnce(ok(CHALLENGE))
     mockLoginQrCheck.mockResolvedValue({ status: 'ok', data: STATUS_PENDING })
 
@@ -420,7 +436,7 @@ describe('QrForm', () => {
     await wrapper.find('[data-testid="qr-back"]').trigger('click')
     await flushPromises()
 
-    expect(ctx.router.currentRoute.value.path).toBe('/login')
+    expect(ctx.router.currentRoute.value.path).toBe('/login/id-pass')
 
     const callsAfterBack = mockLoginQrCheck.mock.calls.length
     await advancePoll(3)


### PR DESCRIPTION
## Summary

修兩個會把使用者送到錯誤頁面的 navigation bug。兩個 bug 都是 commit `24a07af` 加 `?pick=1` escape hatch 時引入的副作用。

### Bug 1: 區域選擇頁的 `?pick=1` escape hatch 失效

`LoginRegionSelection.vue` 同時有兩個 auto-redirect 機制互相打架：

1. **`onMounted`（舊邏輯）**：mount 時看 `loginRegion` 有就馬上 `router.replace('/login/id-pass')`。**沒檢查 `?pick`**、**沒看 `loginMethod`**（永遠跳 id-pass）。
2. **`watch(() => config.loaded, ..., { immediate: true })`**（commit `24a07af` 加的）：同樣的 redirect 意圖，但會檢查 `?pick=1`、會根據 `loginMethod` 決定要跳 `/login/id-pass` 還是 `/login/qr`。

`onMounted` 比 watcher 早一步同步執行，所以從登入表單按 back 帶 `?pick=1` 想回到區域選擇頁時，**還沒看到頁面就被 onMounted 踢走** → 設好 region 之後永遠到不了區域選擇頁；QR 模式的 user 還會被 onMounted 默默改回 id-pass。

看起來是 PR #230 cherry-pick `24a07af` 時，新的 watcher 加進來但舊的 `onMounted` 沒清乾淨。

### Bug 2: QR / Gamepass 表單的「返回一般登入」按鈕跳到錯地方

`QrForm.vue:goBack` 跟 `GamepassForm.vue:goBack` 都 push `/login?pick=1`，把使用者送到區域選擇頁。但 button 上的 i18n key `BackRegularLogin` →「返回一般登入」/「Back to Regular Login」，**「一般登入」明確指 id-pass form**，不是區域選擇。

WPF 的對應行為（`qr_form.xaml.cs::btn_back_Click`）是 `App.LoginMethod = Regular` + `loginMethodChanged()`，意思是「在同一個 region 內把模式切回 id-pass」，而不是「重選 region」。

24a07af 加 `?pick=1` 的時候順手把 QR / Gamepass 的 goBack 也改成用這個機制，但語意上 `?pick=1` 是「我要重選 region」，跟「返回一般登入」(=mode switch) 不同。

## Changes

### Bug 1
- 砍掉 `LoginRegionSelection.vue` 的 `onMounted` block 跟連帶的 `onMounted` import（watcher 已是 strict superset）
- 加 5 個 regression test 覆蓋 redirect 決策的所有分支：
  - 存 TW + 預設 `loginMethod` → 跳 `/login/id-pass`
  - 存 TW + `loginMethod=1` → 跳 `/login/qr`
  - 存 HK + `loginMethod=1` → 仍跳 `/login/id-pass`（HK 無 QR）
  - 有 saved region + `?pick=1` → 留在 picker
  - 無 saved region → 留在 picker

### Bug 2
- `QrForm.vue:goBack` + `GamepassForm.vue:goBack` 改成 `router.push('/login/id-pass')`
- `QrForm.vue` 的 docblock 對應更新（原 docblock 自己描述 WPF 行為跟 SPA implementation 已經對不上）
- `GamepassForm.vue:goBack` 加 inline comment 說明為什麼不用 `?pick=1`
- **保留** `onMounted` 內 region != TW 的 fallback 仍然是 `?pick=1`（那是 region 校驗失敗，本來就該回 picker）
- 兩個 spec 加 `/login/id-pass` route stub、改 expect、補 regression 註解

## Test plan

- [x] `npx vitest run tests/unit/pages/{LoginRegionSelection,QrForm,GamepassForm}.spec.ts` — 37 / 37 pass
- [x] `npx vue-tsc --noEmit` — clean
- [x] Lint — clean
- [x] 手測：設好 region 進入 id-pass → 按 back → 應該看到區域選擇頁
- [x] 手測：設 QR 模式 → 重啟 → 應該直接進 QR 而不是 id-pass
- [x] 手測：QR 表單點「返回一般登入」→ 應該到 id-pass form（同 region），不是區域選擇頁
- [x] 手測：Gamepass 表單點「返回一般登入」→ 應該到 id-pass form（同 region），不是區域選擇頁
