### PR TITLE
fix: ServiceAccountInfo selectable + Win10 shadow + window auto-fit (#234 #235 #236)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,11 @@ jobs:
   rust:
     name: 'Rust: fmt / Clippy / Test'
     runs-on: windows-latest
+    # Cap the job at 25 min so a hung test (e.g. wiremock + tokio
+    # paused-time interaction on Windows) fails loudly within the
+    # next CI cycle instead of silently consuming the GitHub default
+    # 6-hour budget. Healthy runs land in 4-8 min on a warm cache.
+    timeout-minutes: 25
     defaults:
       run:
         working-directory: src-tauri

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -368,6 +368,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-test",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -5039,6 +5040,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -330,7 +330,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "beanfun"
-version = "5.9.2"
+version = "5.9.3"
 dependencies = [
  "aes",
  "anyhow",
@@ -346,6 +346,7 @@ dependencies = [
  "md-5",
  "nrbf",
  "open",
+ "os_info",
  "percent-encoding",
  "pretty_assertions",
  "quick-xml 0.37.5",
@@ -2565,6 +2566,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2670,6 +2683,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-core-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2691,6 +2725,38 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
 ]
 
 [[package]]
@@ -2751,8 +2817,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
  "bitflags 2.11.1",
+ "block2",
  "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
  "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-core-text",
+ "objc2-foundation",
+ "objc2-quartz-core",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+dependencies = [
+ "objc2",
  "objc2-foundation",
 ]
 
@@ -2802,6 +2887,21 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "os_info"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4022a17595a00d6a369236fdae483f0de7f0a339960a53118b818238e132224"
+dependencies = [
+ "android_system_properties",
+ "log",
+ "nix",
+ "objc2",
+ "objc2-foundation",
+ "objc2-ui-kit",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -363,6 +363,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-dialog",
  "tauri-plugin-opener",
+ "tauri-plugin-window-state",
  "tauri-specta",
  "tempfile",
  "thiserror 2.0.18",
@@ -4704,6 +4705,21 @@ dependencies = [
  "url",
  "windows 0.61.3",
  "zbus",
+]
+
+[[package]]
+name = "tauri-plugin-window-state"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73736611e14142408d15353e21e3cca2f12a3cfb523ad0ce85999b6d2ef1a704"
+dependencies = [
+ "bitflags 2.11.1",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -145,6 +145,15 @@ webview2-com = "0.38"
 # avoids a standalone `version = "..."` line that the release workflow's
 # version-bump regex previously misidentified as the package version.
 wv2-windows-core = { package = "windows-core", version = "0.61" }
+# Windows build number detection — used by `lib.rs::run` to disable the
+# window shadow on Windows 10 only. Works around upstream tauri-apps/tauri
+# #11654 / #13176 where the undecorated shadow inset calculation is wrong
+# on Win10 and paints a 1px artefact border after DWM redraws. Win11
+# (build >= 22000) keeps the default shadow because the upstream fix
+# (tao #1052) renders correctly there and the shadow gives the rounded
+# glass panel its depth. `default-features = false` opts out of the optional
+# `serde` feature; we only need `os_info::get()` for the version check.
+os_info = { version = "3", default-features = false }
 
 [dev-dependencies]
 wiremock = "0.6"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -37,6 +37,13 @@ tauri-plugin-opener = "2"
 # on Linux); no extra config needed beyond declaring the plugin in `lib.rs`
 # and granting `dialog:default` in `capabilities/default.json`.
 tauri-plugin-dialog = "2"
+# Persists the main window's *position* across launches so users that
+# drag the launcher to e.g. a secondary monitor get it back in the
+# same spot next time. We deliberately enable `StateFlags::POSITION`
+# only — `tauri.conf.json` ships `resizable: false` and the router's
+# `fitWindow` (`router/index.ts`) drives per-route height/width, so
+# persisting SIZE / MAXIMIZED would fight those handlers.
+tauri-plugin-window-state = "2"
 
 # Cross-platform URL / file opener (ShellExecuteW on Windows,
 # LSOpenCFURLRef on macOS, xdg-open on Linux). Already pulled in as

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -82,6 +82,11 @@ reqwest_cookie_store = "0.8"
 
 # Async runtime
 tokio = { version = "1", features = ["rt", "sync", "time", "fs", "macros"] }
+# CancellationToken for the session keep-alive ping loop
+# (see `commands::auth::run_ping_loop` + `commands::state::AuthContext::ping_cancel`).
+# Already pulled in transitively by `tauri`; making the dependency explicit so
+# the feature set doesn't silently regress if an intermediate crate drops it.
+tokio-util = { version = "0.7", features = ["rt"] }
 
 # Crypto
 des = "0.8"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -10,6 +10,7 @@
     "core:window:allow-start-dragging",
     "core:window:allow-set-size",
     "opener:default",
-    "dialog:default"
+    "dialog:default",
+    "window-state:default"
   ]
 }

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -83,12 +83,15 @@
 //!
 //! [`AppState::pending_totp`]: super::state::AppState::pending_totp
 
+use std::time::Duration;
+
 use serde::Serialize;
 use specta::Type;
 use tauri::{
     webview::PageLoadEvent, AppHandle, Emitter, Manager, State, WebviewUrl, WebviewWindow,
     WebviewWindowBuilder, WindowEvent,
 };
+use tokio_util::sync::CancellationToken;
 use url::Url;
 
 use crate::commands::{
@@ -110,8 +113,124 @@ use crate::services::beanfun::{
         get_verify_page_info as get_verify_page_info_service,
         submit_verify as submit_verify_service, VerifyOutcome,
     },
-    LoginError,
+    LoginError, Session,
 };
+
+// ═══════════════════════════════════════════════════════════════════════
+// Session keep-alive (WPF pingWorker parity)
+// ═══════════════════════════════════════════════════════════════════════
+
+/// Interval between consecutive [`BeanfunClient::ping`] calls inside
+/// [`run_ping_loop`].
+///
+/// 60 s matches WPF `MainWindow.pingWorker_DoWork` (`WaitSecs = 60`,
+/// `MainWindow.xaml.cs` L2327). The Beanfun portal drops idle sessions
+/// after a few minutes server-side; pinging every minute has proved
+/// sufficient (WPF users reported sessions surviving for days).
+const PING_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Install a freshly-minted `(client, session)` pair onto
+/// [`AppState::auth`] and spawn the session keep-alive ping loop.
+///
+/// Centralises the four-site login-finalisation pattern:
+///
+/// 1. Derive the [`SessionInfo`] DTO **before** moving `session` so we
+///    can still return it to the caller.
+/// 2. Wrap `client` + `session` in an [`AuthContext`] — each call
+///    mints a fresh [`CancellationToken`] via
+///    [`AuthContext::new`].
+/// 3. Install the context on [`AppState::auth`]. Holds the write lock
+///    for the shortest possible window (no `.await` points between
+///    the acquire and the release besides the `replace` itself).
+/// 4. Spawn [`run_ping_loop`] with a clone of `client` + a clone of
+///    the context's `ping_cancel` token. The clones share the same
+///    cookie jar and cancellation signal as the installed context,
+///    so `logout` -> `cancel()` stops the loop promptly.
+///
+/// # Why clone `client` for the spawned task?
+///
+/// [`BeanfunClient`] is cheap to clone (all inner fields are
+/// `Arc<_>`), and cloning keeps ownership semantics simple: the
+/// spawned task outlives any single `AppState::auth` read guard.
+async fn install_session_and_start_ping(
+    state: &AppState,
+    client: BeanfunClient,
+    session: Session,
+) -> SessionInfo {
+    let info = SessionInfo::from(&session);
+    let ctx = AuthContext::new(client, session);
+    let ping_client = ctx.client.clone();
+    let ping_cancel = ctx.ping_cancel.clone();
+
+    // Atomic replace: if a prior `AuthContext` was still installed
+    // (e.g. the user re-logged in without first calling `logout`,
+    // or a `session_required` flow recovered mid-session), cancel
+    // its keep-alive loop so we don't leak an orphaned background
+    // task holding a stale cookie jar.
+    let prev = state.auth.write().await.replace(ctx);
+    if let Some(prev_ctx) = prev {
+        prev_ctx.ping_cancel.cancel();
+    }
+
+    spawn_ping_loop(ping_client, ping_cancel);
+    info
+}
+
+/// Spawn [`run_ping_loop`] as a detached Tokio task.
+///
+/// Split out of [`install_session_and_start_ping`] so unit tests can
+/// drive [`run_ping_loop`] directly without a live Tokio reactor
+/// observing a spawned future.
+fn spawn_ping_loop(client: BeanfunClient, cancel: CancellationToken) {
+    tokio::spawn(run_ping_loop(client, cancel));
+}
+
+/// Periodically hit [`BeanfunClient::ping`] until `cancel` fires.
+///
+/// Ports WPF `MainWindow.pingWorker_DoWork`
+/// (`MainWindow.xaml.cs` L2322-2368). The WPF loop is:
+///
+/// 1. Ping.
+/// 2. Sleep `WaitSecs` (60 s), checking cancellation each second.
+/// 3. Goto 1.
+///
+/// Our Tokio rewrite uses [`tokio::select!`] on the cancel token so
+/// shutdown fires immediately instead of waiting up to 1 s for the
+/// next inner tick. Cancellation is also checked *during* the ping
+/// itself so a mid-flight request doesn't delay shutdown by up to
+/// the client timeout (tens of seconds).
+///
+/// # Error handling
+///
+/// Ping failures are swallowed at `tracing::debug!` level to match
+/// WPF `BeanfunClient.Ping()`'s `catch { }` (bfClient.cs L193-212).
+/// A transient network hiccup or a 5xx from the Beanfun portal must
+/// not kill the keep-alive loop — the next tick 60 s later is the
+/// retry. If the session is genuinely dead the user will find out
+/// on their next meaningful action (Get OTP, launch game), just
+/// like WPF.
+async fn run_ping_loop(client: BeanfunClient, cancel: CancellationToken) {
+    loop {
+        tokio::select! {
+            biased;
+            _ = cancel.cancelled() => return,
+            res = client.ping() => {
+                if let Err(err) = res {
+                    tracing::debug!(
+                        error = ?err,
+                        "session keep-alive ping failed; will retry next tick"
+                    );
+                }
+            }
+        }
+
+        tokio::select! {
+            biased;
+            _ = cancel.cancelled() => return,
+            _ = tokio::time::sleep(PING_INTERVAL) => {}
+        }
+    }
+}
 
 /// Error code surfaced to the frontend when [`login_totp`] runs and
 /// there is no pending TOTP challenge on [`AppState::pending_totp`].
@@ -252,8 +371,7 @@ pub async fn login_regular(
 
     match outcome {
         Ok(session) => {
-            let info = SessionInfo::from(&session);
-            *state.auth.write().await = Some(AuthContext::new(client, session));
+            let info = install_session_and_start_ping(&state, client, session).await;
             Ok(info)
         }
         Err(LoginError::TotpRequired(challenge)) => {
@@ -322,8 +440,7 @@ pub async fn login_totp(
     .await?;
 
     *state.pending_totp.write().await = None;
-    let info = SessionInfo::from(&session);
-    *state.auth.write().await = Some(AuthContext::new(client, session));
+    let info = install_session_and_start_ping(&state, client, session).await;
     Ok(info)
 }
 
@@ -526,8 +643,7 @@ pub async fn login_qr_check(state: State<'_, AppState>) -> Result<QrStatus, Comm
         QrPollOutcome::Approved => {
             let session = finalize_qr_login(&client, &init).await?;
             *state.pending_qr.write().await = None;
-            let info = SessionInfo::from(&session);
-            *state.auth.write().await = Some(AuthContext::new(client, session));
+            let info = install_session_and_start_ping(&state, client, session).await;
             Ok(QrStatus::Approved { session: info })
         }
     }
@@ -963,8 +1079,7 @@ async fn handle_gamepass_page_load<R: tauri::Runtime>(
         return;
     }
 
-    let info = SessionInfo::from(&session);
-    *state.auth.write().await = Some(AuthContext::new(client, session));
+    let info = install_session_and_start_ping(&state, client, session).await;
 
     tracing::info!(
         step = "GamepassCompletion.Success",
@@ -1705,6 +1820,15 @@ pub async fn logout(state: State<'_, AppState>) -> Result<(), CommandError> {
     let prev_auth = state.auth.write().await.take();
 
     if let Some(ctx) = prev_auth {
+        // Cancel the session keep-alive ping loop *first* so the
+        // background task doesn't race with `logout_service` and
+        // POST a keep-alive ping against a server the server-side
+        // logout just invalidated. `cancel()` is idempotent and
+        // non-blocking; the spawned task observes the signal on
+        // the next `tokio::select!` wake-up inside
+        // [`run_ping_loop`].
+        ctx.ping_cancel.cancel();
+
         if let Err(err) = logout_service(&ctx.client).await {
             tracing::warn!(
                 error = ?err,
@@ -1724,6 +1848,257 @@ mod tests {
 
     fn empty_state() -> AppState {
         AppState::new(PathBuf::from(r"C:\tmp"))
+    }
+
+    // ── Session keep-alive (run_ping_loop) ────────────────────────
+
+    use crate::services::beanfun::Endpoints;
+    use std::time::Duration as StdDuration;
+    use url::Url;
+    use wiremock::matchers::{method as wm_method, path as wm_path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn fake_session() -> Session {
+        Session::new(
+            LoginRegion::TW,
+            "skey-test",
+            "web-token-test",
+            "acc-test",
+            LoginRegion::TW.default_service_code(),
+            LoginRegion::TW.default_service_region(),
+        )
+    }
+
+    /// Build a [`BeanfunClient`] whose `portal_base` points at
+    /// `server`. Shared between the cancellation and error-handling
+    /// tests for [`run_ping_loop`].
+    fn ping_client_against(server: &MockServer) -> BeanfunClient {
+        let base = Url::parse(&format!("{}/", server.uri())).expect("mock URL parses");
+        let endpoints = Endpoints {
+            login_base: base.clone(),
+            portal_base: base.clone(),
+            newlogin_base: base,
+        };
+        let mut cfg = ClientConfig::for_region(LoginRegion::TW);
+        cfg.endpoints = endpoints;
+        BeanfunClient::new(cfg).expect("client builds")
+    }
+
+    async fn mount_echo_token_200(server: &MockServer) {
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/beanfun_block/generic_handlers/echo_token.ashx"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("ok"))
+            .mount(server)
+            .await;
+    }
+
+    /// Cancelling the token *before* the first ping fires must
+    /// terminate [`run_ping_loop`] without issuing any HTTP
+    /// request. This pins the shutdown semantics that `logout`
+    /// relies on: `ctx.ping_cancel.cancel()` takes effect
+    /// immediately, not "after the next tick".
+    #[tokio::test]
+    async fn run_ping_loop_exits_promptly_when_cancelled_before_first_tick() {
+        let server = MockServer::start().await;
+        mount_echo_token_200(&server).await;
+        let client = ping_client_against(&server);
+
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+
+        tokio::time::timeout(StdDuration::from_secs(5), run_ping_loop(client, cancel))
+            .await
+            .expect("loop must return promptly on pre-cancelled token");
+
+        let requests = server.received_requests().await.expect("log enabled");
+        assert!(
+            requests.is_empty(),
+            "no ping should fire if token is cancelled before loop entry; got {} request(s)",
+            requests.len(),
+        );
+    }
+
+    /// After one successful ping, cancelling the token mid-sleep
+    /// must cause the loop to exit on the next `select!` wake
+    /// without waiting the full [`PING_INTERVAL`]. This is the
+    /// hot path — a user that logs out 1 s after login should
+    /// not leave a 59 s zombie task running.
+    #[tokio::test]
+    async fn run_ping_loop_exits_during_sleep_after_first_ping() {
+        let server = MockServer::start().await;
+        mount_echo_token_200(&server).await;
+        let client = ping_client_against(&server);
+
+        let cancel = CancellationToken::new();
+        let cancel_for_loop = cancel.clone();
+        let handle = tokio::spawn(async move { run_ping_loop(client, cancel_for_loop).await });
+
+        // Wait until the first ping has been observed by the mock,
+        // then cancel. We poll instead of `sleep` so the test stays
+        // deterministic across slow CI machines.
+        let deadline = tokio::time::Instant::now() + StdDuration::from_secs(5);
+        loop {
+            let count = server
+                .received_requests()
+                .await
+                .map(|r| r.len())
+                .unwrap_or(0);
+            if count >= 1 {
+                break;
+            }
+            if tokio::time::Instant::now() >= deadline {
+                panic!("first ping never arrived within 5s");
+            }
+            tokio::time::sleep(StdDuration::from_millis(10)).await;
+        }
+
+        cancel.cancel();
+
+        tokio::time::timeout(StdDuration::from_secs(5), handle)
+            .await
+            .expect("loop must exit promptly after cancel")
+            .expect("spawned task must not panic");
+    }
+
+    /// A 5xx response from `echo_token.ashx` must NOT kill the
+    /// loop — WPF's `catch { }` swallows errors and the next tick
+    /// retries. We pin this by waiting for *two* requests to land
+    /// against a server that always returns 500.
+    #[tokio::test(start_paused = true)]
+    async fn run_ping_loop_keeps_running_after_ping_failure() {
+        let server = MockServer::start().await;
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/beanfun_block/generic_handlers/echo_token.ashx"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+        let client = ping_client_against(&server);
+
+        let cancel = CancellationToken::new();
+        let cancel_for_loop = cancel.clone();
+        let handle = tokio::spawn(async move { run_ping_loop(client, cancel_for_loop).await });
+
+        // Wait for the *first* real ping to land. With `start_paused
+        // = true` the runtime clock doesn't advance until we call
+        // `advance`, so the first ping — which fires immediately —
+        // is the one we wait for here.
+        while server
+            .received_requests()
+            .await
+            .map(|r| r.len())
+            .unwrap_or(0)
+            < 1
+        {
+            tokio::task::yield_now().await;
+        }
+
+        // Fast-forward past the 60s sleep so the second tick fires
+        // without actually sleeping in wall-clock time.
+        tokio::time::advance(PING_INTERVAL + StdDuration::from_millis(50)).await;
+
+        while server
+            .received_requests()
+            .await
+            .map(|r| r.len())
+            .unwrap_or(0)
+            < 2
+        {
+            tokio::task::yield_now().await;
+        }
+
+        cancel.cancel();
+        tokio::time::timeout(StdDuration::from_secs(5), handle)
+            .await
+            .expect("loop exits after cancel even while failing")
+            .expect("spawned task must not panic");
+    }
+
+    /// End-to-end wiring for the login-path helper:
+    /// `install_session_and_start_ping` must populate `AppState::auth`
+    /// *and* spawn a ping loop that actually fires. If wiring is
+    /// broken we'd observe the auth context installed but no
+    /// request ever hitting the mock server.
+    #[tokio::test]
+    async fn install_session_and_start_ping_populates_auth_and_fires_ping() {
+        let server = MockServer::start().await;
+        mount_echo_token_200(&server).await;
+        let client = ping_client_against(&server);
+
+        let state = empty_state();
+        // Minimal placeholder session — fields aren't inspected by
+        // the keep-alive loop, only `client` is.
+        let session = fake_session();
+
+        let _info = install_session_and_start_ping(&state, client, session).await;
+
+        assert!(
+            state.auth.read().await.is_some(),
+            "auth context must be installed",
+        );
+
+        // Wait for first ping to fire so we know the spawn actually
+        // landed a live task.
+        let deadline = tokio::time::Instant::now() + StdDuration::from_secs(5);
+        loop {
+            let count = server
+                .received_requests()
+                .await
+                .map(|r| r.len())
+                .unwrap_or(0);
+            if count >= 1 {
+                break;
+            }
+            if tokio::time::Instant::now() >= deadline {
+                panic!("ping loop never fired the first request within 5s");
+            }
+            tokio::time::sleep(StdDuration::from_millis(10)).await;
+        }
+
+        // Clean up so the spawned task doesn't keep looping in the
+        // background after this test returns.
+        let taken = state.auth.write().await.take();
+        if let Some(ctx) = taken {
+            ctx.ping_cancel.cancel();
+        }
+    }
+
+    /// Installing a second session must cancel the first session's
+    /// ping loop. Without this the old task would hold the old
+    /// cookie jar alive and keep calling the mock forever.
+    #[tokio::test]
+    async fn install_session_and_start_ping_cancels_previous_loop() {
+        let server = MockServer::start().await;
+        mount_echo_token_200(&server).await;
+
+        let state = empty_state();
+
+        let first_client = ping_client_against(&server);
+        install_session_and_start_ping(&state, first_client, fake_session()).await;
+        let first_token = state
+            .auth
+            .read()
+            .await
+            .as_ref()
+            .expect("first install populates auth")
+            .ping_cancel
+            .clone();
+        assert!(
+            !first_token.is_cancelled(),
+            "fresh install must leave token uncancelled",
+        );
+
+        let second_client = ping_client_against(&server);
+        install_session_and_start_ping(&state, second_client, fake_session()).await;
+        assert!(
+            first_token.is_cancelled(),
+            "replacing an auth context must cancel the prior ping loop",
+        );
+
+        // Clean up the second loop.
+        let taken = state.auth.write().await.take();
+        if let Some(ctx) = taken {
+            ctx.ping_cancel.cancel();
+        }
     }
 
     // ── split_otp_digits ──────────────────────────────────────────

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -210,6 +210,24 @@ fn spawn_ping_loop(client: BeanfunClient, cancel: CancellationToken) {
 /// on their next meaningful action (Get OTP, launch game), just
 /// like WPF.
 async fn run_ping_loop(client: BeanfunClient, cancel: CancellationToken) {
+    run_ping_loop_with_interval(client, cancel, PING_INTERVAL).await;
+}
+
+/// Inner implementation of [`run_ping_loop`] with the sleep interval
+/// pulled out as a parameter.
+///
+/// The production loop always passes [`PING_INTERVAL`] (60 s, matching
+/// WPF). Splitting the interval out keeps the unit tests fast and
+/// hermetic — they can drive the loop with a 50 ms cadence and assert
+/// real wall-clock behaviour without depending on `start_paused = true`,
+/// which interacts poorly with `wiremock`'s hyper server (the paused
+/// runtime time freezes hyper's internal time wheel and the HTTP
+/// request never resolves on Windows CI).
+async fn run_ping_loop_with_interval(
+    client: BeanfunClient,
+    cancel: CancellationToken,
+    interval: Duration,
+) {
     loop {
         tokio::select! {
             biased;
@@ -227,7 +245,7 @@ async fn run_ping_loop(client: BeanfunClient, cancel: CancellationToken) {
         tokio::select! {
             biased;
             _ = cancel.cancelled() => return,
-            _ = tokio::time::sleep(PING_INTERVAL) => {}
+            _ = tokio::time::sleep(interval) => {}
         }
     }
 }
@@ -1963,8 +1981,17 @@ mod tests {
     /// A 5xx response from `echo_token.ashx` must NOT kill the
     /// loop — WPF's `catch { }` swallows errors and the next tick
     /// retries. We pin this by waiting for *two* requests to land
-    /// against a server that always returns 500.
-    #[tokio::test(start_paused = true)]
+    /// against a server that always returns 500, using a 50 ms
+    /// interval so the test stays sub-second.
+    ///
+    /// We deliberately avoid `start_paused = true` here: the paused
+    /// runtime time freezes hyper's internal time wheel, and on
+    /// Windows CI the wiremock-served request never resolves
+    /// (observed: the rust test job hung past the 6 h GitHub
+    /// timeout). The interval-injection seam in
+    /// [`run_ping_loop_with_interval`] lets us keep real time + a
+    /// short cadence instead.
+    #[tokio::test]
     async fn run_ping_loop_keeps_running_after_ping_failure() {
         let server = MockServer::start().await;
         Mock::given(wm_method("GET"))
@@ -1976,34 +2003,29 @@ mod tests {
 
         let cancel = CancellationToken::new();
         let cancel_for_loop = cancel.clone();
-        let handle = tokio::spawn(async move { run_ping_loop(client, cancel_for_loop).await });
+        let handle = tokio::spawn(async move {
+            run_ping_loop_with_interval(client, cancel_for_loop, StdDuration::from_millis(50)).await
+        });
 
-        // Wait for the *first* real ping to land. With `start_paused
-        // = true` the runtime clock doesn't advance until we call
-        // `advance`, so the first ping — which fires immediately —
-        // is the one we wait for here.
-        while server
-            .received_requests()
-            .await
-            .map(|r| r.len())
-            .unwrap_or(0)
-            < 1
-        {
-            tokio::task::yield_now().await;
-        }
-
-        // Fast-forward past the 60s sleep so the second tick fires
-        // without actually sleeping in wall-clock time.
-        tokio::time::advance(PING_INTERVAL + StdDuration::from_millis(50)).await;
-
-        while server
-            .received_requests()
-            .await
-            .map(|r| r.len())
-            .unwrap_or(0)
-            < 2
-        {
-            tokio::task::yield_now().await;
+        // Poll for two requests to land — at 50 ms cadence the second
+        // ping should arrive within ~100 ms even on slow CI; the 10 s
+        // ceiling is a generous backstop, not the expected duration.
+        let deadline = tokio::time::Instant::now() + StdDuration::from_secs(10);
+        loop {
+            let count = server
+                .received_requests()
+                .await
+                .map(|r| r.len())
+                .unwrap_or(0);
+            if count >= 2 {
+                break;
+            }
+            if tokio::time::Instant::now() >= deadline {
+                panic!(
+                    "second ping never arrived within 10s (got {count}); 5xx must not stop the loop"
+                );
+            }
+            tokio::time::sleep(StdDuration::from_millis(10)).await;
         }
 
         cancel.cancel();

--- a/src-tauri/src/commands/state.rs
+++ b/src-tauri/src/commands/state.rs
@@ -68,6 +68,7 @@
 use std::path::PathBuf;
 
 use tokio::sync::RwLock;
+use tokio_util::sync::CancellationToken;
 
 use crate::services::beanfun::{
     client::BeanfunClient,
@@ -103,6 +104,29 @@ pub struct AuthContext {
     /// fields are redacted by the `Debug` impl — see
     /// [`Session`]'s module docs for the sensitivity policy.
     pub session: Session,
+
+    /// Cancellation handle for the session keep-alive ping loop
+    /// ([`run_ping_loop`][crate::commands::auth::run_ping_loop]),
+    /// ported from the WPF `pingWorker` background worker
+    /// (`MainWindow.xaml.cs` L2322-2368). Logout / session-clear
+    /// paths call [`.cancel()`][CancellationToken::cancel] on this
+    /// token so the spawned task exits promptly instead of living on
+    /// past the `AuthContext` it belongs to.
+    ///
+    /// Each [`AuthContext::new`] call mints a **fresh** token
+    /// ([`CancellationToken::new`]), so logging in twice spawns two
+    /// independent loops whose lifecycles are individually bounded —
+    /// a previous login's ping task is always cancelled as part of
+    /// that login's `clear_all_auth_state` before the new loop is
+    /// spawned (see `commands::auth`).
+    ///
+    /// Cloning an `AuthContext` clones the token, but
+    /// [`CancellationToken`] is internally `Arc`-backed: every clone
+    /// observes the same cancel signal. That is *exactly* the
+    /// semantics we want for the `require_auth` escape-hatch
+    /// (callers take an owned snapshot, drop the `RwLock` guard,
+    /// and the snapshot still points at the live token).
+    pub ping_cancel: CancellationToken,
 }
 
 impl AuthContext {
@@ -110,9 +134,16 @@ impl AuthContext {
     /// single swap-able unit.
     ///
     /// Callers (login commands) should immediately `write()` the
-    /// result into [`AppState::auth`] so downstream commands see it.
+    /// result into [`AppState::auth`] so downstream commands see it,
+    /// then spawn the session keep-alive ping loop using
+    /// [`ping_cancel`][Self::ping_cancel] as the shutdown signal
+    /// (see `commands::auth::spawn_ping_loop`).
     pub fn new(client: BeanfunClient, session: Session) -> Self {
-        Self { client, session }
+        Self {
+            client,
+            session,
+            ping_cancel: CancellationToken::new(),
+        }
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -393,9 +393,7 @@ pub fn run() {
             if is_windows_10() {
                 if let Some(window) = app.get_webview_window("main") {
                     if let Err(err) = window.set_shadow(false) {
-                        tracing::warn!(
-                            "set_shadow(false) on Windows 10 main window failed: {err}"
-                        );
+                        tracing::warn!("set_shadow(false) on Windows 10 main window failed: {err}");
                     }
                 }
             }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -370,6 +370,22 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
+        // Remember-window-position: restores the user's last screen
+        // position on launch (e.g. after dragging Beanfun onto a
+        // secondary monitor). `StateFlags::POSITION` intentionally
+        // *excludes* SIZE / MAXIMIZED / DECORATIONS — `tauri.conf.json`
+        // ships `resizable: false` and the router's per-route
+        // `fitWindow` (`src/router/index.ts`) is the canonical owner
+        // of the window's width/height. Persisting size here would
+        // race those handlers and the user would see the window snap
+        // to the saved size before snapping again to the route-driven
+        // size on the first navigation. The state file lives under
+        // the standard `appConfigDir` (Windows: `%APPDATA%\tw.beanfun.app\`).
+        .plugin(
+            tauri_plugin_window_state::Builder::new()
+                .with_state_flags(tauri_plugin_window_state::StateFlags::POSITION)
+                .build(),
+        )
         .manage(app_state)
         // Tauri-managed handle to the tray ID so commands (e.g.
         // `system::minimize_main_window`) can drive the tray without

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -120,6 +120,36 @@ fn resolve_storage_root() -> Result<PathBuf, CommandError> {
     Ok(std::env::temp_dir().join("Beanfun"))
 }
 
+/// Detects whether the host is running Windows 10 (build number < 22000).
+///
+/// Used by [`run`] as a gate for the `set_shadow(false)` workaround for
+/// upstream tauri-apps/tauri#11654 / #13176 — the bug only manifests on
+/// Windows 10 because the undecorated-shadow inset calculation in `tao`
+/// paints a 1px artefact border after DWM redraws. Windows 11 (build
+/// number >= 22000) renders the same shadow correctly since tao #1052
+/// landed, and the shadow there is desirable (it's what gives the rounded
+/// glass panel its depth), so we keep the default behaviour for it.
+///
+/// Returns `false` on any non-Windows host (defensive — the caller is
+/// already behind `#[cfg(target_os = "windows")]`, this mirrors that
+/// contract) and on any Windows host whose `os_info` reports a non-
+/// semantic version (`Unknown` / `Rolling` / `Custom`). "Report uncertain
+/// version → leave shadow alone" is the safer default: keeping the
+/// default shadow on an unknown host is a visual downside at worst,
+/// whereas wrongly disabling it on a Win11 host would cause a visible
+/// regression there.
+#[cfg(target_os = "windows")]
+fn is_windows_10() -> bool {
+    let info = os_info::get();
+    if info.os_type() != os_info::Type::Windows {
+        return false;
+    }
+    match info.version() {
+        os_info::Version::Semantic(_, _, build) => *build < 22000,
+        _ => false,
+    }
+}
+
 /// Regenerate `src/types/bindings.ts` from the live
 /// `tauri-specta` builder.
 ///
@@ -351,6 +381,25 @@ pub fn run() {
             if let Some(tray_id) = tray::build_tray(app) {
                 *tray_state_for_setup.lock().unwrap() = Some(tray_id);
             }
+
+            // Issue #235 workaround — on Windows 10 the undecorated-window
+            // shadow inset calculation paints a 1px coloured border on DWM
+            // redraws (upstream tauri-apps/tauri#11654 / #13176). Disabling
+            // the shadow removes the artefact. Windows 11 (build >= 22000)
+            // keeps the default shadow because the tao #1052 fix renders
+            // correctly there and the shadow gives the rounded glass panel
+            // its depth. No-op on non-Windows targets.
+            #[cfg(target_os = "windows")]
+            if is_windows_10() {
+                if let Some(window) = app.get_webview_window("main") {
+                    if let Err(err) = window.set_shadow(false) {
+                        tracing::warn!(
+                            "set_shadow(false) on Windows 10 main window failed: {err}"
+                        );
+                    }
+                }
+            }
+
             Ok(())
         })
         .on_window_event(move |window, event| {

--- a/src-tauri/src/services/beanfun/client.rs
+++ b/src-tauri/src/services/beanfun/client.rs
@@ -343,6 +343,70 @@ impl BeanfunClient {
             .map_err(|e| LoginError::InvalidUrl(format!("newlogin URL `{path}`: {e}")))
     }
 
+    /// Hit the Beanfun portal's session keep-alive endpoint so the
+    /// server's inactivity timer is reset.
+    ///
+    /// Ports the WPF `BeanfunClient.Ping()` method (`bfClient.cs`
+    /// L193-212). The original implementation is:
+    ///
+    /// ```text
+    /// public void Ping()
+    /// {
+    ///     try
+    ///     {
+    ///         string url = "https://" + (TW ? "tw" : "bfweb.hk") +
+    ///             ".beanfun.com/beanfun_block/generic_handlers/echo_token.ashx?webtoken=1";
+    ///         this.DownloadData(url);
+    ///     }
+    ///     catch { }
+    /// }
+    /// ```
+    ///
+    /// WPF drove this from `MainWindow.pingWorker_DoWork`
+    /// (`MainWindow.xaml.cs` L2322-2368) on a 60-second loop so that
+    /// the Beanfun backend's session-inactivity timeout never fired
+    /// — without it, an idle session is reaped server-side after a
+    /// few minutes and the next user action (Get OTP, launch game)
+    /// fails with a stale-cookie error. See PR #237 for the bug
+    /// report.
+    ///
+    /// # Semantics
+    ///
+    /// - Follows redirects and uses the normal cookie jar so the
+    ///   server sees the same `bfWebToken` that the business-logic
+    ///   calls do.
+    /// - **Ignores the response body** (same as WPF): the request is
+    ///   only useful for its side effect of resetting the server's
+    ///   inactivity timer. We don't even call `bounded_text` because
+    ///   buffering the body wastes bytes on the hot path.
+    /// - Non-2xx responses surface as
+    ///   [`LoginError::Http`][crate::services::beanfun::error::LoginError::Http]
+    ///   via `error_for_status()` so the caller can log; the
+    ///   [`run_ping_loop`][crate::commands::auth::run_ping_loop]
+    ///   wrapper swallows them at `tracing::debug!` level to mirror
+    ///   WPF's `catch { }`.
+    ///
+    /// # Region routing
+    ///
+    /// Derived from the client's configured [`LoginRegion`]:
+    ///
+    /// | Region | Endpoint                                                              |
+    /// |--------|-----------------------------------------------------------------------|
+    /// | TW     | `https://tw.beanfun.com/beanfun_block/generic_handlers/echo_token.ashx?webtoken=1` |
+    /// | HK     | `https://bfweb.hk.beanfun.com/beanfun_block/generic_handlers/echo_token.ashx?webtoken=1` |
+    ///
+    /// Both live on `portal_base`, so we reuse [`portal_url`] rather
+    /// than hardcoding the host — keeps wiremock tests straightforward
+    /// via [`Endpoints::custom`].
+    ///
+    /// [`portal_url`]: Self::portal_url
+    pub async fn ping(&self) -> Result<(), LoginError> {
+        let mut url = self.portal_url("beanfun_block/generic_handlers/echo_token.ashx")?;
+        url.query_pairs_mut().append_pair("webtoken", "1");
+        self.http.get(url).send().await?.error_for_status()?;
+        Ok(())
+    }
+
     /// Read `resp`'s body as UTF-8, capping the accumulated bytes at
     /// [`ClientConfig::max_body_size`].
     ///

--- a/src-tauri/tests/ping.rs
+++ b/src-tauri/tests/ping.rs
@@ -1,0 +1,242 @@
+//! Integration tests for the session keep-alive ping endpoint
+//! (`BeanfunClient::ping`), ported from the WPF `pingWorker`
+//! keep-alive loop (`MainWindow.xaml.cs` L2322-2368 calling
+//! `BeanfunClient.Ping()` at `bfClient.cs` L193-212).
+//!
+//! The Beanfun portal expires idle sessions server-side; WPF
+//! sidesteps this by pinging `echo_token.ashx?webtoken=1` every 60 s
+//! so the backend keeps the session warm. These tests pin the
+//! wire-shape contract (method, path, query, region-host routing)
+//! that [`crate::commands::auth::run_ping_loop`] depends on.
+//!
+//! | WPF parity detail                                        | Covered by                                       |
+//! |----------------------------------------------------------|--------------------------------------------------|
+//! | GET verb + `echo_token.ashx` path                        | `ping_issues_get_against_echo_token_path`        |
+//! | `webtoken=1` query string (matches WPF URL)              | `ping_attaches_webtoken_one_query_param`         |
+//! | 2xx response → `Ok(())`                                  | `ping_returns_ok_on_success_body_is_ignored`     |
+//! | 5xx response → `LoginError::Http`                        | `ping_surfaces_http_error_on_5xx`                |
+//! | TW routes through `portal_base`                          | `ping_tw_routes_through_portal_base`             |
+//! | HK routes through `portal_base` (its own HK host)        | `ping_hk_routes_through_portal_base`             |
+
+use beanfun_lib::services::beanfun::{
+    BeanfunClient, ClientConfig, Endpoints, LoginError, LoginRegion,
+};
+use url::Url;
+use wiremock::matchers::{method, path, query_param};
+use wiremock::{Mock, MockServer, Request, ResponseTemplate};
+
+// -----------------------------------------------------------------------------
+// Test fixtures
+// -----------------------------------------------------------------------------
+
+/// Build a [`BeanfunClient`] whose `portal_base` points at `server`
+/// so `/beanfun_block/generic_handlers/echo_token.ashx` requests
+/// land on the mock. `login_base` / `newlogin_base` are aliased to
+/// the same mock so an accidental mis-routing surfaces as an
+/// assertion failure on `server.received_requests` (whatever path
+/// was hit would still be visible in the log) rather than a
+/// connection refused from the real host.
+fn single_server_client(server: &MockServer, region: LoginRegion) -> BeanfunClient {
+    let base = Url::parse(&format!("{}/", server.uri())).expect("mock URL parses");
+    let endpoints = Endpoints {
+        login_base: base.clone(),
+        portal_base: base.clone(),
+        newlogin_base: base,
+    };
+    let mut cfg = ClientConfig::for_region(region);
+    cfg.endpoints = endpoints;
+    BeanfunClient::new(cfg).expect("client builds")
+}
+
+/// Three distinct mock servers so we can prove *which* base
+/// `ping` routed through. If ping ever drifts onto `login_base` or
+/// `newlogin_base` it would fail the tight `received_requests`
+/// count assertion below.
+fn split_server_client(
+    portal_server: &MockServer,
+    login_server: &MockServer,
+    newlogin_server: &MockServer,
+    region: LoginRegion,
+) -> BeanfunClient {
+    let url = |s: &MockServer| Url::parse(&format!("{}/", s.uri())).expect("mock URL parses");
+    let endpoints = Endpoints {
+        login_base: url(login_server),
+        portal_base: url(portal_server),
+        newlogin_base: url(newlogin_server),
+    };
+    let mut cfg = ClientConfig::for_region(region);
+    cfg.endpoints = endpoints;
+    BeanfunClient::new(cfg).expect("client builds")
+}
+
+const ECHO_TOKEN_PATH: &str = "/beanfun_block/generic_handlers/echo_token.ashx";
+
+async fn mount_echo_token(server: &MockServer, status: u16) {
+    Mock::given(method("GET"))
+        .and(path(ECHO_TOKEN_PATH))
+        .respond_with(ResponseTemplate::new(status).set_body_string("echo-ok"))
+        .mount(server)
+        .await;
+}
+
+// -----------------------------------------------------------------------------
+// Wire-shape contract
+// -----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn ping_issues_get_against_echo_token_path() {
+    let server = MockServer::start().await;
+    mount_echo_token(&server, 200).await;
+
+    let client = single_server_client(&server, LoginRegion::TW);
+    client.ping().await.expect("ping succeeds against 200 mock");
+
+    let requests = server.received_requests().await.expect("log is enabled");
+    assert_eq!(
+        requests.len(),
+        1,
+        "ping should issue exactly one request per call",
+    );
+    let req: &Request = &requests[0];
+    assert_eq!(req.method.as_str(), "GET");
+    assert_eq!(
+        req.url.path(),
+        ECHO_TOKEN_PATH,
+        "path must match WPF `bfClient.Ping()` URL verbatim",
+    );
+}
+
+#[tokio::test]
+async fn ping_attaches_webtoken_one_query_param() {
+    let server = MockServer::start().await;
+    // `query_param` matcher will only succeed if the inbound URL
+    // carries `webtoken=1` — pin the same query string WPF uses.
+    Mock::given(method("GET"))
+        .and(path(ECHO_TOKEN_PATH))
+        .and(query_param("webtoken", "1"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = single_server_client(&server, LoginRegion::TW);
+    client.ping().await.expect("ping succeeds");
+    // MockServer's Drop assertion (via `.expect(1)`) verifies the
+    // `webtoken=1` matcher was hit exactly once.
+}
+
+// -----------------------------------------------------------------------------
+// Result mapping
+// -----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn ping_returns_ok_on_success_body_is_ignored() {
+    // WPF `BeanfunClient.Ping()` reads the body purely for the
+    // `Console.WriteLine` debug trace; the *result* is always
+    // best-effort. Our Rust port must not parse / bounds-check the
+    // body either — a large response body must NOT surface as a
+    // `LoginError::BodyTooLarge` because we're not calling
+    // `bounded_text` on the ping path.
+    let huge_body = "x".repeat(16 * 1024 * 1024);
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(ECHO_TOKEN_PATH))
+        .respond_with(ResponseTemplate::new(200).set_body_string(huge_body))
+        .mount(&server)
+        .await;
+
+    let client = single_server_client(&server, LoginRegion::TW);
+    client
+        .ping()
+        .await
+        .expect("ping returns Ok even when body is huge");
+}
+
+#[tokio::test]
+async fn ping_surfaces_http_error_on_5xx() {
+    let server = MockServer::start().await;
+    mount_echo_token(&server, 500).await;
+
+    let client = single_server_client(&server, LoginRegion::TW);
+    let err = client
+        .ping()
+        .await
+        .expect_err("500 response must surface as LoginError::Http");
+
+    assert!(
+        matches!(err, LoginError::Http(_)),
+        "5xx should map to LoginError::Http, got {err:?}",
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Region routing
+// -----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn ping_tw_routes_through_portal_base() {
+    let portal = MockServer::start().await;
+    let login = MockServer::start().await;
+    let newlogin = MockServer::start().await;
+    mount_echo_token(&portal, 200).await;
+    mount_echo_token(&login, 200).await;
+    mount_echo_token(&newlogin, 200).await;
+
+    let client = split_server_client(&portal, &login, &newlogin, LoginRegion::TW);
+    client.ping().await.expect("ping succeeds");
+
+    assert_eq!(
+        portal.received_requests().await.expect("log enabled").len(),
+        1,
+        "TW ping must hit portal_base",
+    );
+    assert!(
+        login
+            .received_requests()
+            .await
+            .expect("log enabled")
+            .is_empty(),
+        "TW ping must not hit login_base",
+    );
+    assert!(
+        newlogin
+            .received_requests()
+            .await
+            .expect("log enabled")
+            .is_empty(),
+        "TW ping must not hit newlogin_base",
+    );
+}
+
+#[tokio::test]
+async fn ping_hk_routes_through_portal_base() {
+    // WPF `bfClient.Ping()` uses `bfweb.hk.beanfun.com` for the HK
+    // region. `portal_base` is exactly that host in
+    // `Endpoints::hk`, so the HK ping path is simply "portal_base
+    // with an HK URL" — same code path, different configured host.
+    let portal = MockServer::start().await;
+    let login = MockServer::start().await;
+    let newlogin = MockServer::start().await;
+    mount_echo_token(&portal, 200).await;
+    mount_echo_token(&login, 200).await;
+    mount_echo_token(&newlogin, 200).await;
+
+    let client = split_server_client(&portal, &login, &newlogin, LoginRegion::HK);
+    client.ping().await.expect("ping succeeds");
+
+    assert_eq!(
+        portal.received_requests().await.expect("log enabled").len(),
+        1,
+        "HK ping must hit portal_base (mapped to HK host at runtime)",
+    );
+    assert!(login
+        .received_requests()
+        .await
+        .expect("log enabled")
+        .is_empty(),);
+    assert!(newlogin
+        .received_requests()
+        .await
+        .expect("log enabled")
+        .is_empty(),);
+}

--- a/src/pages/About.vue
+++ b/src/pages/About.vue
@@ -258,7 +258,7 @@ onMounted(() => {
   <main class="about bf-glass-window" data-window-root>
     <TitleBar />
     <div class="about__scroll">
-      <div class="about__container">
+      <div class="about__container" data-window-content>
         <!-- Header: app icon + name + author -->
         <header class="about__header bf-glass-panel">
           <img

--- a/src/pages/AccountList.vue
+++ b/src/pages/AccountList.vue
@@ -2506,14 +2506,17 @@ onBeforeUnmount(() => {
 
 .account-list__title {
   margin: 0;
-  font-size: 1.625rem;
+  /* rule in this section is nudged +~0.0625rem so the page reads  */
+  /* more comfortably on high-DPI displays without overshooting    */
+  /* the rest of the chrome's proportions.                           */
+  font-size: 1.75rem;
   font-weight: 800;
   letter-spacing: -0.01em;
 }
 
 .account-list__subline {
   margin: 0.25rem 0 0;
-  font-size: 0.8125rem;
+  font-size: 0.875rem;
   color: var(--bf-on-surface-variant);
 }
 
@@ -2584,13 +2587,13 @@ onBeforeUnmount(() => {
 }
 
 .account-list__game-name {
-  font-size: 1rem;
+  font-size: 1.0625rem;
   font-weight: 700;
   line-height: 1.2;
 }
 
 .account-list__game-status {
-  font-size: 0.75rem;
+  font-size: 0.8125rem;
   color: var(--bf-on-surface-variant);
   display: inline-flex;
   align-items: center;
@@ -2656,7 +2659,7 @@ onBeforeUnmount(() => {
 }
 
 .account-list__balance-label {
-  font-size: 0.625rem;
+  font-size: 0.6875rem;
   text-transform: uppercase;
   letter-spacing: 0.06em;
   color: var(--bf-on-surface-variant);
@@ -2664,7 +2667,7 @@ onBeforeUnmount(() => {
 }
 
 .account-list__balance-value {
-  font-size: 0.9375rem;
+  font-size: 1rem;
   font-weight: 700;
   color: var(--bf-on-surface);
 }
@@ -2711,7 +2714,7 @@ onBeforeUnmount(() => {
   gap: 0.25rem;
   padding: 0.5rem;
   cursor: pointer;
-  font-size: 0.6875rem;
+  font-size: 0.75rem;
   color: var(--bf-on-surface-variant);
   transition: color var(--bf-motion-fast);
 }
@@ -2740,13 +2743,13 @@ onBeforeUnmount(() => {
 
 .account-list__list-title {
   margin: 0;
-  font-size: 0.875rem;
+  font-size: 0.9375rem;
   font-weight: 700;
   color: var(--bf-on-surface);
 }
 
 .account-list__list-count {
-  font-size: 0.75rem;
+  font-size: 0.8125rem;
   font-weight: 600;
   color: var(--bf-on-surface-variant);
   background: var(--bf-surface-container);
@@ -2780,7 +2783,7 @@ onBeforeUnmount(() => {
   margin: auto;
   padding: 1.5rem 1rem;
   text-align: center;
-  font-size: 0.8125rem;
+  font-size: 0.875rem;
   color: var(--bf-on-surface-variant);
 }
 
@@ -2832,7 +2835,7 @@ onBeforeUnmount(() => {
 
 .account-list__row-grip {
   color: var(--bf-outline-variant);
-  font-size: 0.875rem;
+  font-size: 0.9375rem;
   user-select: none;
   cursor: grab;
   letter-spacing: -0.15em;
@@ -2870,7 +2873,7 @@ onBeforeUnmount(() => {
   background: var(--bf-surface-variant);
   color: var(--bf-on-surface);
   font-weight: 700;
-  font-size: 0.8125rem;
+  font-size: 0.875rem;
   display: grid;
   place-items: center;
   flex-shrink: 0;
@@ -2889,7 +2892,7 @@ onBeforeUnmount(() => {
 
 .account-list__row-name {
   margin: 0;
-  font-size: 0.875rem;
+  font-size: 0.9375rem;
   font-weight: 600;
   color: var(--bf-on-surface);
   white-space: nowrap;
@@ -2909,7 +2912,7 @@ onBeforeUnmount(() => {
 
 .account-list__row-sub {
   margin: 0.0625rem 0 0;
-  font-size: 0.6875rem;
+  font-size: 0.75rem;
   color: var(--bf-on-surface-variant);
   white-space: nowrap;
   overflow: hidden;
@@ -2956,7 +2959,7 @@ onBeforeUnmount(() => {
   align-items: center;
   justify-content: center;
   gap: 0.375rem;
-  font-size: 0.8125rem;
+  font-size: 0.875rem;
   font-weight: 600;
   color: var(--bf-primary);
   background: transparent;
@@ -2981,7 +2984,7 @@ onBeforeUnmount(() => {
 .account-list__limit-notice {
   margin: 0 0 0.5rem;
   padding: 0.375rem 0.75rem;
-  font-size: 0.75rem;
+  font-size: 0.8125rem;
   color: var(--el-color-warning, #e6a23c);
   text-align: center;
 }
@@ -3003,7 +3006,7 @@ onBeforeUnmount(() => {
 
 .account-list__otp-title {
   margin: 0;
-  font-size: 0.875rem;
+  font-size: 0.9375rem;
   font-weight: 700;
   color: var(--bf-on-surface);
 }
@@ -3027,7 +3030,7 @@ onBeforeUnmount(() => {
   border: 0;
   border-bottom: 2px solid var(--bf-outline-variant);
   font-family: 'JetBrains Mono', 'Consolas', ui-monospace, monospace;
-  font-size: 1.125rem;
+  font-size: 1.25rem;
   letter-spacing: 0.2em;
   text-align: center;
   padding: 0.5rem 2rem 0.5rem 0.5rem;
@@ -3066,7 +3069,7 @@ onBeforeUnmount(() => {
 .account-list__otp-get {
   min-width: 100px;
   padding: 0 1rem;
-  font-size: 0.875rem;
+  font-size: 0.9375rem;
   font-weight: 700;
   display: inline-flex;
   align-items: center;

--- a/src/pages/AccountList.vue
+++ b/src/pages/AccountList.vue
@@ -1882,7 +1882,7 @@ onBeforeUnmount(destroySortable)
       </button>
     </TitleBar>
     <div class="account-list__scroll">
-      <div class="account-list__container">
+      <div class="account-list__container" data-window-content>
         <header class="account-list__header">
           <div class="account-list__header-text">
             <h1 class="account-list__title bf-text-gradient">{{ t('accountList.title') }}</h1>

--- a/src/pages/AccountList.vue
+++ b/src/pages/AccountList.vue
@@ -1857,6 +1857,93 @@ watch(rowsRef, (el) => {
 })
 
 onBeforeUnmount(destroySortable)
+
+/* --------------- Enter hotkey (WPF / Beanfun B6 parity) --------------- */
+
+/**
+ * Mirrors the legacy Beanfun (B6) client: once a service account row is
+ * highlighted, pressing `Enter` kicks off the same Get-OTP flow as
+ * clicking the button.
+ *
+ * # Why a `window`-level listener (vs a row-level `@keydown`)
+ *
+ * Clicking a row in our layout sets `account.selectedSid` but does not
+ * move DOM focus onto the `<li>` (rows are intentionally not tab stops
+ * — adding `tabindex` would change tab order and leak focus rings onto
+ * the whole list). Without focus on the row, a row-scoped `@keydown`
+ * never fires. A window-level listener sees the Enter keystroke
+ * regardless of which non-form element currently holds focus, which is
+ * the same behaviour WPF `lstViewAccount.KeyDown` had on Key.Enter.
+ *
+ * # Guards
+ *
+ * 1. `event.key === 'Enter'` — only Enter, and not on synthetic repeats
+ *    (holding Enter shouldn't spam-fire the OTP IPC), and not mid-IME
+ *    composition (CJK users would otherwise trigger an OTP every time
+ *    they commit a candidate).
+ * 2. Focus inside a form control (`input` / `textarea` / `[contenteditable]`)
+ *    → let the control handle its own Enter (e.g. submitting a dialog
+ *    form). Our `readonly` OTP `<input>` passes this filter so Enter
+ *    while it happens to hold focus after a "Copy OTP" click still
+ *    routes through.
+ * 3. Focus on a `<button>` — the browser will already fire a `click`
+ *    for Enter on a focused button, and our handler would double-fire
+ *    (once as keydown → `handleGetOtp`, once as the button's own click
+ *    handler). Skip so the button-scoped behaviour wins.
+ * 4. Any Element Plus overlay (`.el-overlay` — covers `ElDialog` +
+ *    `ElMessageBox`, both of which render outside our page subtree via
+ *    `append-to-body`) has an element focused inside → the modal owns
+ *    Enter (confirm button, form submit, etc). Without this guard the
+ *    "Change Alias" dialog's OK-on-Enter would also fire GetOtp on the
+ *    page behind it.
+ * 5. `gettingOtp.value === true` — an OTP fetch is already in flight;
+ *    `handleGetOtp` would no-op anyway, but short-circuiting here
+ *    skips the (harmless) `e.preventDefault()` so assistive tech
+ *    isn't told we swallowed the key when we actually didn't.
+ * 6. `!account.selectedSid` — nothing to fetch for. Staying silent
+ *    (no toast) matches B6: pressing Enter before picking an account
+ *    simply did nothing. We intentionally don't route through
+ *    `handleGetOtp` in this case because its built-in "no selection"
+ *    toast was written for a button click — a keyboard press that
+ *    accidentally lands on an empty list shouldn't spam the user
+ *    with a warning.
+ */
+function handleGlobalEnter(event: KeyboardEvent): void {
+  if (event.key !== 'Enter') return
+  if (event.isComposing || event.repeat) return
+
+  /*
+   * `event.target` can be the `Window` itself when the key is
+   * dispatched without a focused element (typical on first paint
+   * before the user has clicked anything). `closest` only exists on
+   * `Element`, so narrow first — a non-Element target means "focus
+   * is nowhere", which is exactly the case we want to forward.
+   */
+  const target = event.target
+  if (target instanceof HTMLElement) {
+    const tag = target.tagName
+    if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return
+    if (target.isContentEditable) return
+    if (tag === 'BUTTON' || target.closest('button')) return
+  }
+
+  const active = document.activeElement as HTMLElement | null
+  if (active?.closest('.el-overlay')) return
+
+  if (gettingOtp.value) return
+  if (!account.selectedSid) return
+
+  event.preventDefault()
+  void handleGetOtp()
+}
+
+onMounted(() => {
+  window.addEventListener('keydown', handleGlobalEnter)
+})
+
+onBeforeUnmount(() => {
+  window.removeEventListener('keydown', handleGlobalEnter)
+})
 </script>
 
 <template>

--- a/src/pages/AccountList.vue
+++ b/src/pages/AccountList.vue
@@ -2362,13 +2362,40 @@ onBeforeUnmount(destroySortable)
   background: rgba(0, 0, 0, 0.06);
 }
 
+/*
+ * Follow-up to #236: the page used to let the *outer* `__scroll`
+ * container overflow when the combined height of the game bar +
+ * quick actions + account list + OTP section exceeded the window.
+ * With many service accounts on a small-to-medium display that
+ * pushed the OTP section off-screen, forcing the user to scroll
+ * the wheel before they could hit "Get OTP" — diverging from the
+ * legacy Beanfun (B6) single-page layout.
+ *
+ * The fix turns the scroll container into a non-scrolling flex
+ * column and flips the *inner* account list (`__list` →
+ * `__list-body` below) into the only scroller. Everything else
+ * (header, game bar, quick actions, OTP footer) retains its
+ * natural height so the OTP row is always anchored at the bottom
+ * of the window, and only the list itself scrolls when the account
+ * count outgrows the available space.
+ *
+ * `min-height: 0` on every intermediate flex level is required by
+ * the flexbox spec so that `flex: 1` children can actually shrink
+ * below their content height (without it the inner scrollbar never
+ * appears and the list clips).
+ */
 .account-list__scroll {
   flex: 1;
-  overflow-y: auto;
+  min-height: 0;
+  overflow: hidden;
   padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
 }
 
 .account-list__container {
+  flex: 1;
+  min-height: 0;
   width: 100%;
   display: flex;
   flex-direction: column;
@@ -2609,6 +2636,8 @@ onBeforeUnmount(destroySortable)
 /* --------------- list section --------------- */
 
 .account-list__list {
+  flex: 1;
+  min-height: 0;
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -2640,13 +2669,24 @@ onBeforeUnmount(destroySortable)
 
 .account-list__list-body {
   flex: 1;
+  /*
+   * Follow-up to #236: dropped the previous `max-height: 300px`
+   * cap so this container scrolls whatever vertical space the
+   * surrounding flex chain has left (see `__scroll` / `__container`
+   * / `__list` docblock above). The old fixed cap combined with
+   * the outer `__scroll` overflow meant that once the account list
+   * hit 300 px, any further height (OTP footer etc.) was pushed
+   * below the window fold and the user had to scroll to reach
+   * "Get OTP". With `flex: 1 + min-height: 0` in the parent chain
+   * the list is always the one that scrolls and the OTP footer
+   * stays pinned at the bottom regardless of account count.
+   */
+  min-height: 80px;
   overflow-y: auto;
-  max-height: 300px;
   padding: 0.5rem;
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
-  min-height: 80px;
 }
 
 .account-list__list-state {

--- a/src/pages/AccountList.vue
+++ b/src/pages/AccountList.vue
@@ -2770,8 +2770,20 @@ onBeforeUnmount(() => {
    * "Get OTP". With `flex: 1 + min-height: 0` in the parent chain
    * the list is always the one that scrolls and the OTP footer
    * stays pinned at the bottom regardless of account count.
+   *
+   * `min-height: 9rem` guarantees at least two rows are always
+   * fully visible before the internal scrollbar kicks in. Budget:
+   *   row      = 0.625rem × 2 padding + ~28px content ≈ 52px
+   *   2 rows   = 104px
+   *   gap      = 0.25rem between rows = 4px
+   *   padding  = 0.5rem × 2 on __list-body = 16px
+   *   total    ≈ 124px, rounded up to 144px (9rem) for buffer.
+   * Downside: with a single account the list has a small empty
+   * area below the row. Accepted trade-off — the user reported
+   * that a partially-clipped second row (the prior 80px floor)
+   * was worse than a slightly loose single-row view.
    */
-  min-height: 80px;
+  min-height: 9rem;
   overflow-y: auto;
   padding: 0.5rem;
   display: flex;

--- a/src/pages/AccountList.vue
+++ b/src/pages/AccountList.vue
@@ -792,6 +792,39 @@ function handleGameSelected(serviceCode: string, serviceRegion: string): void {
  *    item when no `loginGame` matches.
  */
 async function setupGameOnMount(): Promise<void> {
+  /*
+   * Fast path — "navigate back from Settings / About" UX fix.
+   *
+   * `AccountList` is a regular routed component, so visiting
+   * `/settings` or `/about` unmounts it and visiting back
+   * remounts it. Without this skip, every return would re-run
+   * the full bootstrap (`game.loadGames` + `selectActiveGame` +
+   * `loadList`) and the user would see the spinner + an empty
+   * list flash before the data refilled. Users with custom
+   * drag-and-drop sort orders read that flash as "my order was
+   * reset" because the persistent CSV (`AccountOrder_<code>_<region>`)
+   * is only re-applied AFTER the HTTP response lands.
+   *
+   * Skipping is safe because every code path that *should*
+   * cause a re-fetch already clears `serviceAccounts` first:
+   *
+   * - logout / session expired → `clearAccountSession` resets
+   *   the store (router guard + `registerSessionExpiredHandler`).
+   * - change game → `setActiveService` clears the store before
+   *   the new fetch.
+   * - first cold mount after login → store is empty by
+   *   construction, so the predicate is false and the full
+   *   bootstrap runs.
+   *
+   * `loadState` would otherwise sit at its initial `'loading'`
+   * sentinel forever (no `loadList` to flip it to `'ready'`),
+   * so we flip it inline before returning.
+   */
+  if (account.serviceAccounts.length > 0 && auth.session !== null) {
+    loadState.value = 'ready'
+    return
+  }
+
   await game.loadGames()
 
   if (game.loadState === 'error') {

--- a/src/pages/LoginPage.vue
+++ b/src/pages/LoginPage.vue
@@ -73,7 +73,20 @@ function handleOpenAbout(): void {
       </button>
     </TitleBar>
     <div class="login-shell__body">
-      <RouterView :key="currentRegion" />
+      <!--
+        Issue #236 (i18n follow-up): `data-window-content` lets the
+        router's ResizeObserver track the rendered child form's
+        natural height. `[data-window-root]` above is locked to
+        `100vh` so observing it alone never fires on a language
+        switch; the wrapper below grows/shrinks with the child form's
+        own content and is what actually changes when the i18n store
+        swaps strings. Keeping the wrapper as a pure flow container
+        (no flex sizing of its own) means the child form's existing
+        layout is unchanged.
+      -->
+      <div class="login-shell__content" data-window-content>
+        <RouterView :key="currentRegion" />
+      </div>
     </div>
   </section>
 </template>

--- a/src/pages/ManageAccount.vue
+++ b/src/pages/ManageAccount.vue
@@ -520,7 +520,7 @@ function handleBack(): void {
   <main class="manage bf-glass-window" data-window-root>
     <TitleBar />
     <div class="manage__scroll">
-      <div class="manage__container">
+      <div class="manage__container" data-window-content>
         <!-- Header -->
         <header class="manage__header">
           <div class="manage__header-icon" aria-hidden="true">

--- a/src/pages/Settings.vue
+++ b/src/pages/Settings.vue
@@ -602,7 +602,7 @@ onMounted(() => {
   <main class="settings bf-glass-window" data-window-root>
     <TitleBar />
     <div class="settings__scroll">
-      <div class="settings__container">
+      <div class="settings__container" data-window-content>
         <!-- Header -->
         <header class="settings__header">
           <div class="settings__header-icon" aria-hidden="true">

--- a/src/pages/Settings.vue
+++ b/src/pages/Settings.vue
@@ -742,6 +742,7 @@ onMounted(() => {
               <div class="settings__row settings__row--checkbox">
                 <el-tooltip
                   placement="right"
+                  popper-class="settings__tip-popper"
                   :content="t('settings.disableHardwareAccelerationTip')"
                 >
                   <el-checkbox
@@ -788,7 +789,11 @@ onMounted(() => {
             <div class="settings__grid settings__grid--two-col">
               <div class="settings__col">
                 <div class="settings__row settings__row--checkbox">
-                  <el-tooltip placement="right" :content="t('settings.tradLoginTip')">
+                  <el-tooltip
+                    placement="right"
+                    popper-class="settings__tip-popper"
+                    :content="t('settings.tradLoginTip')"
+                  >
                     <el-checkbox
                       :model-value="ui.tradLogin"
                       data-test="settings-trad-login"
@@ -800,7 +805,11 @@ onMounted(() => {
                 </div>
 
                 <div class="settings__row settings__row--checkbox">
-                  <el-tooltip placement="right" :content="t('settings.killPatcherTip')">
+                  <el-tooltip
+                    placement="right"
+                    popper-class="settings__tip-popper"
+                    :content="t('settings.killPatcherTip')"
+                  >
                     <el-checkbox
                       :model-value="ui.autoKillPatcher"
                       data-test="settings-auto-kill-patcher"
@@ -814,7 +823,11 @@ onMounted(() => {
 
               <div class="settings__col">
                 <div class="settings__row settings__row--checkbox">
-                  <el-tooltip placement="right" :content="t('settings.skipPlayWindowTip')">
+                  <el-tooltip
+                    placement="right"
+                    popper-class="settings__tip-popper"
+                    :content="t('settings.skipPlayWindowTip')"
+                  >
                     <el-checkbox
                       :model-value="ui.skipPlayWnd"
                       data-test="settings-skip-play-wnd"
@@ -1067,5 +1080,35 @@ onMounted(() => {
   display: inline-flex;
   align-items: center;
   gap: 0.375rem;
+}
+</style>
+
+<!--
+ * Non-scoped style block for the `el-tooltip` popper. Element Plus
+ * teleports poppers to `document.body`, which sits outside this
+ * component's scoped CSS boundary, so a scoped rule (even behind
+ * `:deep(...)`) would not match. Keeping it global-but-namespaced
+ * via `.settings__tip-popper` limits the blast radius to the four
+ * tooltips in this page (`popper-class="settings__tip-popper"`).
+ *
+ * Why this exists:
+ *   - Several i18n strings embed `\n` to break long explanations
+ *     into two sentences (see `disableHardwareAccelerationTip` /
+ *     `tradLoginTip` in `src/i18n/messages.ts`). The default
+ *     `white-space: normal` in `el-popper` collapses those
+ *     newlines, and the resulting single-line string is wide
+ *     enough that placement="right" gets clipped by the Tauri
+ *     window edge (reported on PR #237: "Disabling h..." truncation).
+ *   - `max-width: 280px` lets Element Plus' flip strategy fall back
+ *     to `top`/`bottom` if the right placement still cannot fit.
+ *   - `word-break: break-word` protects English copy that has no
+ *     `\n` seam from overflowing when it sits right at the cap.
+ -->
+<style>
+.settings__tip-popper.el-popper {
+  max-width: 280px;
+  white-space: pre-line;
+  word-break: break-word;
+  line-height: 1.5;
 }
 </style>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -484,10 +484,45 @@ export function installRouterGuards(router: Router, deps: RouterGuardDeps): void
    * `[data-window-root]` element so the window tracks content
    * height changes (e.g. sections appearing/disappearing, async
    * data loading). Width comes from route meta.
+   *
+   * # Why double `requestAnimationFrame` (issue #236)
+   *
+   * Previously this code used `setTimeout(setupObserver, 80)` after
+   * every `afterEach`. Four bugs fell out of that:
+   *
+   * 1. **Timing race** — 80ms is not tied to Vue's render flush or
+   *    the browser's paint, so on a slow boot (config.xml IPC taking
+   *    longer than 80ms) the observer attached to a half-rendered
+   *    DOM and measured a shorter-than-final `scrollHeight`, leaving
+   *    the user with a window that never grew to match the real
+   *    content height.
+   * 2. **Navigation storm** — on first launch the router fires
+   *    `afterEach` twice in rapid succession: `/` → `/login/`
+   *    (region picker empty child) → `/login/id-pass` (via
+   *    `LoginRegionSelection.vue::watch(config.loaded)`). Both
+   *    `setTimeout` s fired, the earlier one measuring the picker
+   *    DOM just as it was being replaced. `scheduleOnNextPaint`
+   *    auto-cancels the previous pending callback so only the final
+   *    destination's DOM gets measured.
+   * 3. **`setSize` → layout-restore race** — the old code ran
+   *    `height='auto'` → measure → `setSize().then(() => height='100vh')`.
+   *    `setSize` is an async IPC (10-50 ms), so the DOM stayed in
+   *    "height: auto" for a frame-and-a-half while the window was
+   *    still at its old size — user-visible if the new content was
+   *    taller than the old window. The new `fitWindow` flips
+   *    `auto` → `100vh` synchronously within one frame (the browser
+   *    never paints the intermediate state) and fires the `setSize`
+   *    IPC without awaiting the layout restore.
+   * 4. **Observer loop** — the `height='auto'` flip fired the
+   *    observer, which called `fitWindow`, which flipped it again.
+   *    The same-frame flip-back in (3) coalesces the observer
+   *    notifications to a no-op (`100vh` in → `100vh` out), so no
+   *    explicit guard flag is needed.
    */
   const appWindow = getCurrentWindow()
   let currentWidth = 560
   let observer: ResizeObserver | null = null
+  let pendingFrame: number | null = null
 
   /**
    * Upper bound applied to the auto-fit height.
@@ -513,23 +548,80 @@ export function installRouterGuards(router: Router, deps: RouterGuardDeps): void
     return 900
   }
 
+  /**
+   * Measure the current `[data-window-root]`'s natural content
+   * height and resize the OS window to match. Both the
+   * `height: auto` measurement flip and the `height: 100vh` restore
+   * land inside a single synchronous block so the browser never
+   * paints the intermediate "unclipped" state — only one frame is
+   * ever rendered per fit regardless of how long the IPC takes.
+   *
+   * Safe to call concurrently: successive invocations just re-run
+   * the measurement cycle. The `pendingFrame` guard upstream keeps
+   * the rate low enough that this isn't a hot path.
+   */
   function fitWindow(): void {
     const root = document.querySelector('[data-window-root]') as HTMLElement | null
     if (!root) return
-    // Remove height lock to measure natural content height
+    // Both flips happen in the same synchronous block so the browser
+    // never paints the intermediate `height: auto` state (it's a
+    // forced-layout read followed by a write, both before the next
+    // paint). See bug (3) in the header docblock above.
     root.style.height = 'auto'
     const h = Math.max(300, Math.min(Math.ceil(root.scrollHeight), maxFitHeight()))
-    void appWindow.setSize(new LogicalSize(currentWidth, h)).then(() => {
-      // Lock height to viewport so flex scroll areas work
-      root.style.height = '100vh'
+    root.style.height = '100vh'
+    void appWindow.setSize(new LogicalSize(currentWidth, h))
+  }
+
+  /**
+   * Schedule `cb` to run after two animation frames.
+   *
+   * Two rAFs — not one — because Vue's async scheduler flushes
+   * on the microtask immediately after the first rAF, so the DOM is
+   * usually correct on the *second* rAF. Concrete symptom if we
+   * only used one: `LoginRegionSelection.vue::watch(config.loaded)`
+   * auto-redirects to `/login/id-pass` on the first post-mount
+   * tick, and a single-rAF measurement would race that redirect.
+   *
+   * Cancels any previously pending callback so an `afterEach` storm
+   * collapses to a single fit on the final settled destination.
+   */
+  function scheduleOnNextPaint(cb: () => void): void {
+    if (typeof window === 'undefined' || typeof window.requestAnimationFrame !== 'function') {
+      // jsdom / SSR path — just run immediately so specs don't need
+      // a rAF polyfill.
+      cb()
+      return
+    }
+    if (pendingFrame !== null) window.cancelAnimationFrame(pendingFrame)
+    pendingFrame = window.requestAnimationFrame(() => {
+      pendingFrame = window.requestAnimationFrame(() => {
+        pendingFrame = null
+        cb()
+      })
     })
   }
 
-  function setupObserver(): void {
+  /**
+   * Tear down the previous route's observer, attach a fresh one to
+   * the new route's `[data-window-root]`, and perform the first
+   * fit. `skipFirstObserverCallback` swallows the synthetic
+   * notification `ResizeObserver.observe()` fires immediately after
+   * attaching — the manual `fitWindow()` right below already covers
+   * that initial measurement, so we'd otherwise fit twice in a row.
+   */
+  function attachObserver(): void {
     if (observer) observer.disconnect()
     const root = document.querySelector('[data-window-root]') as HTMLElement | null
     if (!root) return
-    observer = new ResizeObserver(() => fitWindow())
+    let skipFirstObserverCallback = true
+    observer = new ResizeObserver(() => {
+      if (skipFirstObserverCallback) {
+        skipFirstObserverCallback = false
+        return
+      }
+      scheduleOnNextPaint(fitWindow)
+    })
     observer.observe(root)
     fitWindow()
   }
@@ -537,7 +629,6 @@ export function installRouterGuards(router: Router, deps: RouterGuardDeps): void
   router.afterEach((to) => {
     const w = to.meta.windowWidth as number | undefined
     if (w) currentWidth = w
-    // Give Vue time to mount the new route component
-    setTimeout(setupObserver, 80)
+    scheduleOnNextPaint(attachObserver)
   })
 }

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -604,25 +604,58 @@ export function installRouterGuards(router: Router, deps: RouterGuardDeps): void
 
   /**
    * Tear down the previous route's observer, attach a fresh one to
-   * the new route's `[data-window-root]`, and perform the first
-   * fit. `skipFirstObserverCallback` swallows the synthetic
-   * notification `ResizeObserver.observe()` fires immediately after
-   * attaching — the manual `fitWindow()` right below already covers
-   * that initial measurement, so we'd otherwise fit twice in a row.
+   * the new route's `[data-window-root]` *and* its
+   * `[data-window-content]` inner wrapper (if present), then perform
+   * the first fit.
+   *
+   * # Why two observation targets (issue #236 follow-up)
+   *
+   * `[data-window-root]` is always `100vh` so `ResizeObserver`
+   * callbacks never fire on changes that leave the outer frame alone
+   * — e.g. a language switch that lengthens a label inside the page,
+   * or async data arriving into the body after the initial fit.
+   * Observing the inner `[data-window-content]` wrapper (added to
+   * every top-level page template) catches these content-only height
+   * changes so the window re-fits automatically. The outer root is
+   * still observed so size changes to the window itself (F11, DPI
+   * change) continue to trigger a re-fit.
+   *
+   * # Why the `initialNotificationsIgnored` rAF gate
+   *
+   * `ResizeObserver.observe()` fires a synthetic notification for
+   * each observed target immediately after attaching, *before* the
+   * first paint. The manual `fitWindow()` at the end of this
+   * function already covers that initial measurement, so the
+   * synthetic fires would double-fit. With two targets the old
+   * "skip first callback" flag was racy (the two initials might
+   * arrive in one callback or two depending on the browser), so we
+   * instead swallow every callback until the first post-attach rAF
+   * flips the gate — guaranteed to be after all synthetic initials
+   * (they fire in the same microtask as `observe()`).
    */
   function attachObserver(): void {
     if (observer) observer.disconnect()
     const root = document.querySelector('[data-window-root]') as HTMLElement | null
     if (!root) return
-    let skipFirstObserverCallback = true
+    const content = root.querySelector('[data-window-content]') as HTMLElement | null
+    let initialNotificationsIgnored = false
     observer = new ResizeObserver(() => {
-      if (skipFirstObserverCallback) {
-        skipFirstObserverCallback = false
-        return
-      }
+      if (!initialNotificationsIgnored) return
       scheduleOnNextPaint(fitWindow)
     })
     observer.observe(root)
+    if (content) observer.observe(content)
+    if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
+      window.requestAnimationFrame(() => {
+        initialNotificationsIgnored = true
+      })
+    } else {
+      // jsdom / SSR path — the harness stubs `ResizeObserver` so
+      // the gate never matters, but flipping immediately keeps the
+      // behaviour consistent with real browsers in case a test ever
+      // exercises the observer path.
+      initialNotificationsIgnored = true
+    }
     fitWindow()
   }
 

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -489,12 +489,36 @@ export function installRouterGuards(router: Router, deps: RouterGuardDeps): void
   let currentWidth = 560
   let observer: ResizeObserver | null = null
 
+  /**
+   * Upper bound applied to the auto-fit height.
+   *
+   * Previously hard-coded to `900` which was narrower than several
+   * pages (Settings with the Game section expanded, AccountList with
+   * a populated service-account list) — the cap forced the inner
+   * `__scroll` container to paint its own scrollbar and was the root
+   * cause of issue #236 "returning from Settings still has a scroll
+   * bar". Scaling to the actual display instead fits the content
+   * naturally on any desktop without letting the window eat the
+   * taskbar (50px safety margin keeps the window draggable on
+   * Windows's default 40px taskbar).
+   *
+   * Falls back to 900 when `window.screen` is unavailable (jsdom /
+   * headless CI) so the spec harness keeps working.
+   */
+  function maxFitHeight(): number {
+    const avail = typeof window !== 'undefined' ? window.screen?.availHeight : undefined
+    if (typeof avail === 'number' && avail > 0) {
+      return Math.max(300, avail - 50)
+    }
+    return 900
+  }
+
   function fitWindow(): void {
     const root = document.querySelector('[data-window-root]') as HTMLElement | null
     if (!root) return
     // Remove height lock to measure natural content height
     root.style.height = 'auto'
-    const h = Math.max(300, Math.min(Math.ceil(root.scrollHeight), 900))
+    const h = Math.max(300, Math.min(Math.ceil(root.scrollHeight), maxFitHeight()))
     void appWindow.setSize(new LogicalSize(currentWidth, h)).then(() => {
       // Lock height to viewport so flex scroll areas work
       root.style.height = '100vh'

--- a/src/windows/ServiceAccountInfo.vue
+++ b/src/windows/ServiceAccountInfo.vue
@@ -372,6 +372,17 @@ function handleCancel(): void {
   color: var(--bf-on-surface);
   margin: 0;
   word-break: break-all;
+  /*
+   * Issue #234: use-case is copy-paste of the account / serial-number
+   * / name / authType strings the dialog surfaces. App.vue disables
+   * text selection globally (-webkit-user-select: none on body) to
+   * feel native; this dialog is the one place an explicit override
+   * matters because every row is a read-only value the user frequently
+   * copies into game support tickets.
+   */
+  -webkit-user-select: text;
+  user-select: text;
+  cursor: text;
 }
 
 .service-account-info__status--ok {

--- a/tests/unit/pages/AccountList.EnterHotkey.spec.ts
+++ b/tests/unit/pages/AccountList.EnterHotkey.spec.ts
@@ -1,0 +1,447 @@
+/**
+ * AccountList — Enter hotkey coverage (legacy Beanfun B6 / WPF parity).
+ *
+ * Locks down `handleGlobalEnter` in `src/pages/AccountList.vue`:
+ *
+ * | Scenario                                         | Expected       |
+ * |--------------------------------------------------|----------------|
+ * | Selected row + Enter                             | fires GetOtp   |
+ * | No selection + Enter                             | silent no-op   |
+ * | IME composition / key-repeat                     | ignored        |
+ * | Focus in input                                   | ignored        |
+ * | Focus inside an `.el-overlay` (ElDialog/MsgBox)  | ignored        |
+ *
+ * # Why this lives in a separate file from `AccountList.spec.ts`
+ *
+ * The SUT attaches a `window`-level `keydown` listener on mount and
+ * removes it on unmount. `AccountList.spec.ts` follows the P12 spec
+ * convention of NOT calling `wrapper.unmount()` between cases, so its
+ * mounts' listeners accumulate across the ~50 tests in that file.
+ * Dispatching `window.dispatchEvent(new KeyboardEvent(...))` inside
+ * those leaked listeners would flake our assertions (`getOtp` gets
+ * called N times instead of once, depending on how many prior mounts
+ * happened to leave a non-null `selectedSid` in their pinia). Vitest
+ * isolates each spec file in a fresh jsdom window, so hosting the
+ * Enter cases here gives the listener tests a clean slate regardless
+ * of what the sibling file does.
+ *
+ * The setup duplicates the minimal mocks from the sibling file
+ * intentionally — sharing a harness would couple the two suites and
+ * mask a common-mocks regression in one if the other was the only
+ * caller that exercised it. See DRY vs SRP trade-off discussion in
+ * the sibling file's header.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { flushPromises, mount } from '@vue/test-utils'
+import { createMemoryHistory, createRouter, type Router } from 'vue-router'
+import { defineComponent, h, type Component } from 'vue'
+
+import type {
+  AccountListResult,
+  CommandError,
+  Result,
+  ServiceAccount,
+} from '../../../src/types/bindings'
+
+vi.mock('element-plus', () => {
+  const inertStub = (name: string) =>
+    defineComponent({
+      name,
+      setup:
+        (_, { slots }) =>
+        () =>
+          h('div', slots.default?.()),
+    })
+  return {
+    ElButton: defineComponent({
+      name: 'ElButtonStub',
+      props: { type: { type: String, default: '' } },
+      emits: ['click'],
+      setup(_, { slots, emit }) {
+        return () =>
+          h(
+            'button',
+            { class: 'el-button-stub', onClick: (e: MouseEvent) => emit('click', e) },
+            slots.default?.(),
+          )
+      },
+    }),
+    ElCheckbox: defineComponent({
+      name: 'ElCheckboxStub',
+      props: { modelValue: { type: Boolean, default: false } },
+      emits: ['update:modelValue', 'change'],
+      setup(props, { slots, emit }) {
+        return () =>
+          h('label', { class: 'el-checkbox-stub' }, [
+            h('input', {
+              type: 'checkbox',
+              checked: props.modelValue,
+              onChange: (e: Event) => {
+                const next = (e.target as HTMLInputElement).checked
+                emit('update:modelValue', next)
+                emit('change', next)
+              },
+            }),
+            h('span', slots.default?.()),
+          ])
+      },
+    }),
+    ElIcon: defineComponent({
+      name: 'ElIconStub',
+      setup(_, { slots }) {
+        return () => h('span', { class: 'el-icon-stub' }, slots.default?.())
+      },
+    }),
+    ElDropdown: defineComponent({
+      name: 'ElDropdownStub',
+      setup(_, { slots, attrs }) {
+        return () =>
+          h('div', { ...attrs, class: 'el-dropdown-stub' }, [
+            slots.default?.(),
+            h('div', { class: 'el-dropdown-stub__menu' }, slots.dropdown?.()),
+          ])
+      },
+    }),
+    ElDropdownMenu: inertStub('ElDropdownMenuStub'),
+    ElDropdownItem: defineComponent({
+      name: 'ElDropdownItemStub',
+      emits: ['click'],
+      setup(_, { slots, emit, attrs }) {
+        return () =>
+          h(
+            'button',
+            {
+              ...attrs,
+              class: 'el-dropdown-item-stub',
+              onClick: (e: MouseEvent) => emit('click', e),
+            },
+            slots.default?.(),
+          )
+      },
+    }),
+    ElDialog: inertStub('ElDialogInertStub'),
+    ElForm: inertStub('ElFormInertStub'),
+    ElFormItem: inertStub('ElFormItemInertStub'),
+    ElInput: inertStub('ElInputInertStub'),
+    ElMessage: { error: vi.fn(), success: vi.fn(), warning: vi.fn(), info: vi.fn() },
+    ElMessageBox: { confirm: vi.fn() },
+  }
+})
+
+vi.mock('@element-plus/icons-vue', () => {
+  const stub = (name: string): Component => defineComponent({ name, render: () => h('svg') })
+  return {
+    DocumentCopy: stub('DocumentCopyStub'),
+    EditPen: stub('EditPenStub'),
+    InfoFilled: stub('InfoFilledStub'),
+    Key: stub('KeyStub'),
+    Message: stub('MessageStub'),
+    MoreFilled: stub('MoreFilledStub'),
+    Operation: stub('OperationStub'),
+    Plus: stub('PlusStub'),
+    Refresh: stub('RefreshStub'),
+    Service: stub('ServiceStub'),
+    Iphone: stub('IphoneStub'),
+    SwitchButton: stub('SwitchButtonStub'),
+    Wallet: stub('WalletStub'),
+    User: stub('UserStub'),
+    VideoPlay: stub('VideoPlayStub'),
+    Check: stub('CheckStub'),
+    CircleClose: stub('CircleCloseStub'),
+    CirclePlus: stub('CirclePlusStub'),
+    CopyDocument: stub('CopyDocumentStub'),
+    Document: stub('DocumentStub'),
+  }
+})
+
+vi.mock('sortablejs', () => ({
+  default: { create: vi.fn(() => ({ destroy: vi.fn() })) },
+}))
+
+vi.mock('../../../src/types/bindings', () => ({
+  commands: {
+    getAccounts: vi.fn(),
+    refresh: vi.fn(),
+    addServiceAccount: vi.fn(),
+    changeDisplayName: vi.fn(),
+    getOtp: vi.fn(),
+    getEmail: vi.fn(),
+    getRemainPoint: vi.fn(),
+    getContract: vi.fn(),
+    loadAccounts: vi.fn(),
+    saveAccount: vi.fn(),
+    removeAccount: vi.fn(),
+    importRecords: vi.fn(),
+    exportRecords: vi.fn(),
+    logout: vi.fn(),
+    autoPaste: vi.fn(),
+    setConfig: vi.fn(),
+    getAllConfig: vi.fn(),
+    listGames: vi.fn(),
+    setActiveService: vi.fn(),
+    detectGamePath: vi.fn(),
+    listGameProcesses: vi.fn(),
+    killGameProcesses: vi.fn(),
+    launchGame: vi.fn(),
+    openUrl: vi.fn(),
+    openInAppBrowser: vi.fn(),
+    openMemberCenterBrowser: vi.fn(),
+  },
+}))
+
+import { ElMessage } from 'element-plus'
+import { commands } from '../../../src/types/bindings'
+import AccountList from '../../../src/pages/AccountList.vue'
+import { useAccountStore } from '../../../src/stores/account'
+import { createAppI18n } from '../../../src/i18n'
+
+const ok = <T>(data: T): Promise<Result<T, CommandError>> => Promise.resolve({ status: 'ok', data })
+
+const SERVICE_ACCOUNT: ServiceAccount = {
+  is_enable: true,
+  visible: true,
+  is_inherited: false,
+  sid: 'sid-1',
+  ssn: '00001',
+  sname: 'Main Toon',
+  screatetime: null,
+  slastusedtime: null,
+  sauthtype: null,
+}
+
+const POPULATED_LIST: AccountListResult = {
+  accounts: [SERVICE_ACCOUNT],
+  amount_limit_notice: { kind: 'none' },
+}
+
+const InertDialogStub = defineComponent({
+  name: 'InertDialogStub',
+  props: { visible: { type: Boolean, default: false } },
+  render: () => h('div'),
+})
+
+function buildHarness(): {
+  router: Router
+  mountIt: () => Promise<ReturnType<typeof mount>>
+} {
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/accounts', name: 'accounts', component: AccountList },
+      {
+        path: '/login',
+        name: 'login-region',
+        component: defineComponent({ name: 'LoginStub', render: () => h('div') }),
+      },
+    ],
+  })
+  const i18n = createAppI18n()
+  return {
+    router,
+    async mountIt() {
+      await router.push('/accounts')
+      await router.isReady()
+      return mount(AccountList, {
+        global: {
+          plugins: [router, i18n],
+          stubs: {
+            AddServiceAccount: InertDialogStub,
+            ChangeServiceAccountDisplayName: InertDialogStub,
+            ServiceAccountInfo: InertDialogStub,
+            CopyBox: InertDialogStub,
+            GameList: InertDialogStub,
+            UnconnectedGameAddAccount: InertDialogStub,
+            UnconnectedGameChangePassword: InertDialogStub,
+            ToolsDialogStack: InertDialogStub,
+          },
+        },
+      })
+    },
+  }
+}
+
+function installClipboardMock(): { writeText: ReturnType<typeof vi.fn> } {
+  const writeText = vi.fn().mockResolvedValue(undefined)
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText },
+    configurable: true,
+    writable: true,
+  })
+  return { writeText }
+}
+
+function dispatchEnter(init: Partial<KeyboardEventInit> = {}): void {
+  window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, ...init }))
+}
+
+describe('AccountList — Enter hotkey (B6 / WPF parity)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    for (const fn of Object.values(commands) as ReturnType<typeof vi.fn>[]) fn.mockReset()
+    vi.mocked(ElMessage.error).mockReset()
+    vi.mocked(ElMessage.success).mockReset()
+    vi.mocked(ElMessage.warning).mockReset()
+    vi.mocked(ElMessage.info).mockReset()
+    /*
+     * Mount-time IPC defaults so `setupGameOnMount` + the D11 balance
+     * pre-fetch don't blow up before the case under test gets to
+     * assert anything. `getAccounts` is the one callers re-seed
+     * per-case because the happy-path fetches need a populated list.
+     */
+    vi.mocked(commands.setConfig).mockReturnValue(ok(null))
+    vi.mocked(commands.getRemainPoint).mockReturnValue(ok(0))
+    vi.mocked(commands.listGames).mockReturnValue(ok({ ini: {}, services: [] }))
+    vi.mocked(commands.setActiveService).mockReturnValue(ok(null))
+    vi.mocked(commands.detectGamePath).mockReturnValue(ok(null))
+    vi.mocked(commands.listGameProcesses).mockReturnValue(ok([]))
+    vi.mocked(commands.killGameProcesses).mockReturnValue(ok([]))
+    vi.mocked(commands.launchGame).mockReturnValue(ok(null))
+    vi.mocked(commands.openUrl).mockReturnValue(ok(null))
+    installClipboardMock()
+  })
+
+  it('selected row + Enter → fires handleGetOtp via commands.getOtp', async () => {
+    vi.mocked(commands.getAccounts).mockReturnValueOnce(ok(POPULATED_LIST))
+    vi.mocked(commands.getOtp).mockReturnValueOnce(ok('OTP-ENTER'))
+
+    const wrapper = await buildHarness().mountIt()
+    await flushPromises()
+
+    useAccountStore().selectedSid = 'sid-1'
+
+    dispatchEnter()
+    await flushPromises()
+
+    expect(commands.getOtp).toHaveBeenCalledTimes(1)
+    expect(commands.getOtp).toHaveBeenCalledWith(SERVICE_ACCOUNT)
+
+    wrapper.unmount()
+  })
+
+  it('no selection → silent no-op (MsgSelectAccount NOT fired, mirrors B6 "press Enter on empty list")', async () => {
+    /*
+     * Divergence from the Get-OTP button click, which routes through
+     * `handleGetOtp` and surfaces `MsgSelectAccount`. Enter on an
+     * empty selection is deliberately silent — keyboard presses that
+     * accidentally land on an idle page shouldn't pop a warning.
+     */
+    vi.mocked(commands.getAccounts).mockReturnValueOnce(ok(POPULATED_LIST))
+
+    const wrapper = await buildHarness().mountIt()
+    await flushPromises()
+
+    dispatchEnter()
+    await flushPromises()
+
+    expect(commands.getOtp).not.toHaveBeenCalled()
+    expect(ElMessage.warning).not.toHaveBeenCalled()
+
+    wrapper.unmount()
+  })
+
+  it('ignores IME composition and key repeat', async () => {
+    /*
+     * CJK IME users commit a candidate with Enter, which fires a
+     * keydown with `isComposing: true`. Without this guard every
+     * candidate commit inside a dialog input would kick off an OTP
+     * fetch. `repeat: true` fires when the user holds Enter — the
+     * OTP IPC should fire once per deliberate press, not per repeat.
+     */
+    vi.mocked(commands.getAccounts).mockReturnValueOnce(ok(POPULATED_LIST))
+
+    const wrapper = await buildHarness().mountIt()
+    await flushPromises()
+
+    useAccountStore().selectedSid = 'sid-1'
+
+    dispatchEnter({ isComposing: true })
+    dispatchEnter({ repeat: true })
+    await flushPromises()
+
+    expect(commands.getOtp).not.toHaveBeenCalled()
+
+    wrapper.unmount()
+  })
+
+  it('focus inside an <input> → skipped (lets the input own Enter)', async () => {
+    vi.mocked(commands.getAccounts).mockReturnValueOnce(ok(POPULATED_LIST))
+
+    const wrapper = await buildHarness().mountIt()
+    await flushPromises()
+
+    useAccountStore().selectedSid = 'sid-1'
+
+    const input = document.createElement('input')
+    document.body.appendChild(input)
+    input.focus()
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    await flushPromises()
+
+    expect(commands.getOtp).not.toHaveBeenCalled()
+
+    document.body.removeChild(input)
+    wrapper.unmount()
+  })
+
+  it('focus inside an Element Plus overlay → skipped (modal owns Enter)', async () => {
+    /*
+     * `ElDialog` / `ElMessageBox` render via `append-to-body` and
+     * wrap their content in `.el-overlay`. When a modal is open its
+     * confirm button owns Enter; routing the key to `handleGetOtp`
+     * would silently kick off OTP fetches behind the modal (e.g.
+     * the logout confirm dialog would double as a GetOtp trigger).
+     */
+    vi.mocked(commands.getAccounts).mockReturnValueOnce(ok(POPULATED_LIST))
+
+    const wrapper = await buildHarness().mountIt()
+    await flushPromises()
+
+    useAccountStore().selectedSid = 'sid-1'
+
+    const overlay = document.createElement('div')
+    overlay.className = 'el-overlay'
+    const modalBtn = document.createElement('button')
+    overlay.appendChild(modalBtn)
+    document.body.appendChild(overlay)
+    modalBtn.focus()
+
+    dispatchEnter()
+    await flushPromises()
+
+    expect(commands.getOtp).not.toHaveBeenCalled()
+
+    document.body.removeChild(overlay)
+    wrapper.unmount()
+  })
+
+  it('onBeforeUnmount removes the listener (no leak after the page closes)', async () => {
+    /*
+     * Catches the lifecycle regression where a future refactor drops
+     * the `onBeforeUnmount` cleanup and lets the listener outlive
+     * the component. Asserts by count: after unmount, dispatching
+     * Enter with a selection set on a DIFFERENT pinia must NOT fire
+     * the mock.
+     */
+    vi.mocked(commands.getAccounts).mockReturnValueOnce(ok(POPULATED_LIST))
+
+    const wrapper = await buildHarness().mountIt()
+    await flushPromises()
+
+    const initialStore = useAccountStore()
+    initialStore.selectedSid = 'sid-1'
+
+    wrapper.unmount()
+
+    /* Fresh pinia with a selection → would dispatch if the listener leaked. */
+    setActivePinia(createPinia())
+    useAccountStore().selectedSid = 'sid-1'
+    dispatchEnter()
+    await flushPromises()
+
+    expect(commands.getOtp).not.toHaveBeenCalled()
+  })
+})

--- a/tests/unit/pages/AccountList.spec.ts
+++ b/tests/unit/pages/AccountList.spec.ts
@@ -1536,6 +1536,18 @@ describe('AccountList page', () => {
     expect(configStore.get('autoPaste')).toBe('false')
   })
 
+  /*
+   * Enter-hotkey coverage lives in its own spec file
+   * (`AccountList.EnterHotkey.spec.ts`) because the window-level
+   * `keydown` listener that mirrors WPF's "select row + press Enter
+   * → Get OTP" behaviour interacts with jsdom's shared `window`
+   * across test cases — the mounts in this file intentionally
+   * never call `unmount()` (see the D1 stylistic convention above),
+   * so their listeners accumulate and would flake the Enter assertions
+   * here. Vitest's per-file jsdom isolation gives the Enter tests a
+   * fresh `window`, keeping each hotkey guard deterministic.
+   */
+
   /* ---------------------------------------------------------------- */
   /*  D7 — drag-and-drop reorder + per-game persistence                */
   /* ---------------------------------------------------------------- */

--- a/tests/unit/pages/AccountList.spec.ts
+++ b/tests/unit/pages/AccountList.spec.ts
@@ -2075,6 +2075,81 @@ describe('AccountList page', () => {
   })
 
   /* ---------------------------------------------------------------- */
+  /*  Mount fast path — no re-fetch when returning from Settings/About */
+  /* ---------------------------------------------------------------- */
+
+  /**
+   * Regression for the user-reported bug: every visit to Settings
+   * (or About) triggered an account-list re-fetch on return,
+   * making custom drag-sort orders appear to "reset" briefly
+   * before being re-applied from `Config.xml`.
+   *
+   * The fast-path predicate in `setupGameOnMount` is "store
+   * already has accounts AND session is non-null". The two tests
+   * below pin both halves:
+   *
+   * 1. Predicate holds (store seeded, session live) → the page
+   *    must NOT fire `listGames`, `setActiveService`, or
+   *    `getAccounts` on mount.
+   * 2. Predicate fails (store empty) → the full D8c bootstrap
+   *    runs (covered by the D8c specs above; this case re-asserts
+   *    the existing baseline so a future skip-by-default
+   *    regression would fail loudly here too).
+   */
+  it('skips re-fetch on remount when serviceAccounts already cached for current session', async () => {
+    /*
+     * Seed BEFORE mount: this is the "navigate back from
+     * Settings/About" shape — Pinia stores survive the route
+     * change, AccountList is the component that gets unmounted
+     * + remounted, and the cache predicate is what protects the
+     * user from the spinner-flash + sort-reset UX bug.
+     */
+    const auth = useAuthStore()
+    auth.session = FAKE_SESSION
+    const accountStore = useAccountStore()
+    accountStore.serviceAccounts = POPULATED_LIST.accounts
+    /*
+     * Selected sid survives the round-trip too — this is the
+     * "user picked an account, opened Settings, came back"
+     * flow where the OTP button must remain primed.
+     */
+    accountStore.selectedSid = POPULATED_LIST.accounts[0]!.sid
+
+    const ctx = buildHarness()
+    const wrapper = await ctx.mountIt()
+    await flushPromises()
+
+    /* Fast path took effect: no IPC calls fired from setupGameOnMount. */
+    expect(commands.listGames).not.toHaveBeenCalled()
+    expect(commands.getAccounts).not.toHaveBeenCalled()
+    expect(commands.setActiveService).not.toHaveBeenCalled()
+
+    /* Account list still rendered (loadState flipped to 'ready' on the skip). */
+    expect(wrapper.find('[data-test="account-list-rows"]').exists()).toBe(true)
+    /* Selection preserved across the remount. */
+    expect(useAccountStore().selectedSid).toBe(POPULATED_LIST.accounts[0]!.sid)
+  })
+
+  it('still re-fetches on remount when serviceAccounts cache is empty (cold mount baseline)', async () => {
+    /*
+     * Sanity-check the negative branch: empty store + live session
+     * must continue to run the full D8c bootstrap so the very
+     * first paint after login still works. If somebody ever
+     * widens the skip predicate to "session non-null only" this
+     * baseline would catch it.
+     */
+    vi.mocked(commands.getAccounts).mockReturnValueOnce(ok(POPULATED_LIST))
+    useAuthStore().session = FAKE_SESSION
+
+    const ctx = buildHarness()
+    await ctx.mountIt()
+    await flushPromises()
+
+    expect(commands.listGames).toHaveBeenCalledTimes(1)
+    expect(commands.getAccounts).toHaveBeenCalledTimes(1)
+  })
+
+  /* ---------------------------------------------------------------- */
   /*  P12.4 followup-A D5 — lastSelectedIni persistence on selection   */
   /* ---------------------------------------------------------------- */
 


### PR DESCRIPTION
Closes #234, #235, #236.

## Summary

### #234 — 遊戲帳號詳情欄位可選

- `src/windows/ServiceAccountInfo.vue` — `.service-account-info__value` 加 `user-select: text` override
- App.vue 的 global `user-select: none` 導致帳號 / 編號 / 名稱無法複製；override 後讓使用者能複製貼到客服信件裡
- WPF 原版 `ServiceAccountInfo.xaml` 對應位本來就是 selectable TextBlock，behaviour 一致

### #235 — Win10 視窗框線

- 原因：upstream [tauri-apps/tauri#11654](https://github.com/tauri-apps/tauri/issues/11654) / [#13176](https://github.com/tauri-apps/tauri/issues/13176) — Win10 上 tao undecorated-shadow inset 計算有誤，DWM 重繪後出現 1px 色差框線
- Fix：條件式 `set_shadow(false)`，**只在 Win10 套用**（build number < 22000）。Win11 保留預設 shadow 讓圓角玻璃面有立體感
- 新增 `os_info = "3"`（cfg(windows) scope, `default-features = false`）做版本偵測
- 偵測 function `is_windows_10()` 保守：非 Windows / 非 semantic version 一律 `false`（誤判 Win11 會失去 shadow → visible regression，誤判 Win10 沒套 shadow 才是保守選擇）

### #236 — 視窗自適應

`src/router/index.ts::installRouterGuards` 裡的 `fitWindow` 原本有 6 個相關 bug：

- **Bug C** (cap=900px)：Settings / AccountList 內容超過 900px 就被截斷，出現內部 scroll bar（「從設定返回有滑桿問題」）→ commit 3 改抓 `window.screen.availHeight - 50`
- **Bug A** (timing race)：`setTimeout(80)` 不對齊 Vue render flush/paint 時機，slow IPC 下會抓到未渲染完的 DOM → commit 4 改用 rAF
- **Bug B** (layout-restore race)：`height='auto'` → async `setSize().then(height='100vh')` 之間 flex layout 會崩 → commit 4 改成 frame flip
- **Bug D** (observer feedback loop)：height auto-flip 自己觸發 ResizeObserver → 多餘 frame flip → computed style 不變，coalesce 成 no-op
- **Bug E** (duplicate initial fit)：`observe()` 會帶一次 fire callback，加上初始化呼叫的 fit 重複觸發 → `skipFirstObserverCallback` flag 略過第一次
- **Bug F (follow-up)** (i18n 切換仍有 scroll)：`[data-window-root]` 永遠 `100vh`，ResizeObserver 根本沒有「內容長高」可 fire → commit 5 同時對實際內容 wrapper 的 `data-window-content` 一併 observe；skip-initial 從「第一次 callback」改為「第一個 rAF 之前一律略過」以支援多目標

額外：`pendingFrame` handle 配合 `afterEach` + observer callback 取消 → afterEach storm（`/` → `/login/` 連續兩次 redirect）自動合併為單次 fit on 真正 destination。

### 多帳號頁面太長 / OTP 被推下去（#236 延伸）

- **Commit 6** `.account-list__scroll` 改為 `overflow: hidden` 的 flex column；`__container` / `__list` / `__list-body` 沿 `flex: 1 + min-height: 0` 鏈條，讓內層 list 變唯一的 scroller，OTP footer 永遠 anchored 在視窗底部
- 移除原本 `max-height: 300px` 的 cap（這是讓 OTP 被擠出視窗外的主因）

### 選中帳號按 Enter = GetOtp（B6 parity）

- **Commit 7** `AccountList.vue` 加入 `handleGlobalEnter` + window-level keydown listener
- Guards（詳見 SUT docblock）：非 Enter / IME / repeat 忽略；focus 在 `<input>`/`<textarea>`/`<button>`/contenteditable 忽略；`.el-overlay` 內部（ElDialog/ElMessageBox）忽略、進行中 selection 變動忽略
- 新建獨立 spec `AccountList.EnterHotkey.spec.ts` 涵蓋每條 guard branch + onBeforeUnmount leak check
- 沒選 account 時還是**靜默** no-op（與 click 觸發 `MsgSelectAccount` toast 不同），減少 fat-finger Enter 被當作 UX

### 內文字體微調（#236 延伸）

- **Commit 8** 每個 class +1 字級大小（+0.0625rem，+1px@16px root），`__title` 1.625→1.75, `__row-name` 0.875→0.9375, `__otp-field` 1.125→1.25 等，相對比例不變

### 設定頁 tooltip 換行 / 寬度（用戶回報「關閉硬體加速」說明被截斷）

- **Commit 9** `Settings.vue` 全部四個 `el-tooltip` 加上 `popper-class="settings__tip-popper"`
- 新增非 scoped style block：`.settings__tip-popper.el-popper { max-width: 280px; white-space: pre-line; word-break: break-word; line-height: 1.5; }` — 因為 popper 被 teleport 到 `document.body`，scoped 樣式抓不到
- `pre-line` 讓 i18n 字串裡的 `\n` 正常換行，`max-width` + `word-break` 防止單行擠出視窗

### Session keep-alive — 連線過一段時間會斷（用戶回報舊版 5.9.1 可放好幾天不斷）

- **Commit 11** 移植 WPF `MainWindow.pingWorker_DoWork` (xaml.cs L2322-2368) → `BeanfunClient.Ping()` (bfClient.cs L193-212)
- 新增 `BeanfunClient::ping()` 打 `echo_token.ashx?webtoken=1`（與 WPF wire-shape 完全一致）
- 新增 `commands::auth::run_ping_loop` 用 `tokio::spawn` 跑 60 秒 cadence 的 keep-alive task
- `AuthContext` 加 `ping_cancel: CancellationToken` 欄位；`logout` 直接 `cancel()` 立刻收掉 background task
- `install_session_and_start_ping` helper 統一登入完成後的 (clone, install, spawn) pattern；若已有 prev `AuthContext` 也會 cancel 它的舊 token，避免「未 logout 直接 re-login」漏 leak
- 錯誤一律 `tracing::debug!` 吞掉，配合 WPF `catch { }` 的 best-effort 語意（5xx / 連線錯誤不會殺 loop）
- `tests/ping.rs` integration 6 case 鎖定 wire-shape (GET / path / `webtoken=1` / 2xx ok / 5xx Error / TW + HK 都走 portal_base)；`commands::auth::tests` 4 個 unit 鎖定 cancel-before-first-tick / cancel-during-sleep / 5xx-不殺 loop / install-會-cancel-prev

### 記憶視窗位置（用戶回報希望關掉視窗下次能從同位置開）

- **Commit 13** 接 `tauri-plugin-window-state = "2"`（官方 plugin）
- 只開 `StateFlags::POSITION` — 不存 SIZE / MAXIMIZED：`tauri.conf.json` 是 `resizable: false` 且 router 的 `fitWindow` 是 size 唯一 owner，存 size 會跟它打架（用戶看到「先回到舊 size，第一次切 route 又跳到新 size」的 flicker）
- 設定檔走標準 `appConfigDir`（Win: `%APPDATA%\tw.beanfun.app\`），跟其他 Beanfun local data 共用 uninstall path
- 前端零修改：plugin 自動 hook `WindowEvent::CloseRequested` / `Destroyed` 存、init 時自動 restore

### 從 Settings/About 返回 AccountList 不重 fetch（用戶回報拖曳排序「會被刷掉」）

- **Commit 14** `setupGameOnMount` 開頭加 fast-path：`account.serviceAccounts.length > 0 && auth.session !== null` → flip `loadState='ready'` 後直接 return
- 根因：AccountList 是 routed component，`/settings` 進去再回來會 unmount + remount，每次都跑完整 bootstrap (`game.loadGames` + `selectActiveGame` + `loadList`)。spinner + 短暫空 list flash 讓拖曳排序「看起來」被重置（實際上 `Config.xml::AccountOrder_<code>_<region>` 一直在，只是 re-apply 在 HTTP 回來之後）
- Skip 安全性：所有「真該 re-fetch」的 path 都已經會先清掉 `serviceAccounts`：
  - `auth.logout()` / `auth.session_required` → `clearAccountSession`
  - 換遊戲 → `setActiveService` 清掉 store
  - 登入後 cold mount → store 本來就空，predicate false，會跑完整 bootstrap
- 新增兩個 spec case：fast-path 命中時不該打 `listGames`/`getAccounts`/`setActiveService`；store 空時還是要走完整 bootstrap（baseline 防 over-aggressive skip）

### CI 雜項

- **Commit 12** `cargo fmt` 修 `lib.rs` 的 #235 win10 shadow helper（前一輪 CI 失敗根因：多行 `tracing::warn!` 被 rustfmt 折成單行）
- **Commit 15** Deflake `run_ping_loop_keeps_running_after_ping_failure`：原本用 `#[tokio::test(start_paused = true)]` + wiremock，paused runtime time 凍住 hyper 內部 time wheel，Windows CI 一路卡到 GitHub default 6h timeout。改為 inject interval seam (`run_ping_loop_with_interval`)，test 用 50ms 真實時間 cadence。同時把 `.github/workflows/ci.yml` 的 rust job 加上 `timeout-minutes: 25`，未來再 hang 不會再吃滿 6 小時 budget

## Why one PR

11 個 issue/feedback (3 issue + 8 follow-up requests) 都屬於 window chrome / AccountList 佈局 / session 行為 / visual polish 同一 surface area；切 11 個 PR 評述成本太高。不過每個 commit 都嚴守 scope 對應一個 bug / concern 以便 revert / cherry-pick。

## Test plan

- [x] `npx vitest run` — 597/597 pass（54 AccountList + 6 EnterHotkey + 537 其他）
- [x] `npx vue-tsc --noEmit` clean
- [x] `npx eslint` + `prettier --check` clean
- [x] `cargo check` + `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test` — auth (40) + ping integration (6) + 全 suite green on local + CI run [`24752238006`](https://github.com/pungin/Beanfun/actions/runs/24752238006) (8.4 min)
- [ ] **Win10 真環境可選** — 請看 issue #235 使用者 ([@Muerimes](https://github.com/Muerimes)) 協助驗證 merge 後 release build 框線是否消失
- [x] **Win11 smoke test** — 我端已確認：
  - #235 Win11 shadow 保留不變
  - #236 視窗自適應在首次啟動 / 登入後 / 設定 / About 返回 / **語言切換** 五個情境都正常
  - 多帳號時 OTP 永遠可見（不再 scroll）
  - 選中帳號按 Enter 觸發 GetOtp
  - 字體調整後 layout 沒崩
  - 設定頁四個 tooltip 都正常換行不被截斷
  - 拖曳視窗到第二螢幕 → 關閉 → 重啟 → 回到同位置
  - AccountList 拖曳排序後 → 進設定 → 返回 → 排序保留且無 spinner flash
- [ ] **Session keep-alive (60s ping)** — 需 long-running smoke 確認，建議 reviewer 留意 `tracing::debug!` log 看是否 60 秒一次

## Refs

- [tauri-apps/tauri#11654](https://github.com/tauri-apps/tauri/issues/11654) — Win10 undecorated shadow border bug
- [tauri-apps/tauri#13176](https://github.com/tauri-apps/tauri/issues/13176) — maintainer 確認 `shadow: false` 是 workaround
- [tao#1052](https://github.com/tauri-apps/tao/pull/1052) — Win11 shadow inset 修好（解釋為何 Win11 不受影響）
- WPF 5.9.1 `MainWindow.pingWorker_DoWork` (xaml.cs L2322-2368) + `BeanfunClient.Ping()` (bfClient.cs L193-212) — Session keep-alive 對齊原版
- [tauri-plugin-window-state](https://crates.io/crates/tauri-plugin-window-state) v2.4.1 — 用 `StateFlags::POSITION` 只存位置
