### PR TITLE
fix(AccountList): auto-select first enabled account after load (#245)

### DIFF
--- a/src/pages/AccountList.vue
+++ b/src/pages/AccountList.vue
@@ -213,6 +213,14 @@ async function loadList(): Promise<void> {
     if (savedKey !== null) {
       account.applyServiceAccountOrderFromSavedCsv(configStore.get(savedKey))
     }
+
+    // Auto-select the first enabled account after load — mirrors WPF
+    // which defaults SelectedIndex to 0 on `redrawSAccountList`.
+    if (!account.selectedSid && account.serviceAccounts.length > 0) {
+      const first = account.serviceAccounts.find((a) => a.is_enable)
+      if (first) account.selectedSid = first.sid
+    }
+
     loadState.value = 'ready'
   } catch (err) {
     /*

--- a/tests/unit/pages/AccountList.EnterHotkey.spec.ts
+++ b/tests/unit/pages/AccountList.EnterHotkey.spec.ts
@@ -334,6 +334,9 @@ describe('AccountList — Enter hotkey (B6 / WPF parity)', () => {
     const wrapper = await buildHarness().mountIt()
     await flushPromises()
 
+    // Clear auto-selected account to test the "no selection" guard.
+    useAccountStore().selectedSid = null
+
     dispatchEnter()
     await flushPromises()
 

--- a/tests/unit/pages/AccountList.spec.ts
+++ b/tests/unit/pages/AccountList.spec.ts
@@ -894,7 +894,7 @@ describe('AccountList page', () => {
     await flushPromises()
 
     const account = useAccountStore()
-    expect(account.selectedSid).toBeNull()
+    expect(account.selectedSid).toBe('sid-1')
 
     await wrapper.get('[data-test="account-row-sid-2"]').trigger('click')
 
@@ -914,7 +914,7 @@ describe('AccountList page', () => {
     const account = useAccountStore()
     await wrapper.get('[data-test="account-row-sid-3"]').trigger('click')
 
-    expect(account.selectedSid).toBeNull()
+    expect(account.selectedSid).toBe('sid-1')
   })
 
   it('logout: confirm → auth.logout → account.clearSessionData → /login', async () => {
@@ -1062,12 +1062,12 @@ describe('AccountList page', () => {
     await flushPromises()
 
     const account = useAccountStore()
-    expect(account.selectedSid).toBeNull()
+    expect(account.selectedSid).toBe('sid-1')
 
     await wrapper.get('[data-test="account-row-change-alias-sid-2"]').trigger('click')
     await flushPromises()
 
-    expect(account.selectedSid).toBeNull()
+    expect(account.selectedSid).toBe('sid-1')
   })
 
   it('row context menu Account Info → opens dialog with the row account (D6 wiring)', async () => {
@@ -1127,12 +1127,12 @@ describe('AccountList page', () => {
     await flushPromises()
 
     const account = useAccountStore()
-    expect(account.selectedSid).toBeNull()
+    expect(account.selectedSid).toBe('sid-1')
 
     await wrapper.get('[data-test="account-row-info-sid-2"]').trigger('click')
     await flushPromises()
 
-    expect(account.selectedSid).toBeNull()
+    expect(account.selectedSid).toBe('sid-1')
   })
 
   /* ---------------------------------------------------------------- */
@@ -1307,9 +1307,10 @@ describe('AccountList page', () => {
     const wrapper = await ctx.mountIt()
     await flushPromises()
 
-    /* No row selected after the initial fetch. */
+    /* Auto-select picks the first enabled row; clear it to test the
+     * "no selection" guard. */
     const account = useAccountStore()
-    expect(account.selectedSid).toBeNull()
+    account.selectedSid = null
 
     await wrapper.get('[data-test="account-list-otp-get"]').trigger('click')
     await flushPromises()
@@ -2066,8 +2067,8 @@ describe('AccountList page', () => {
     expect(commands.setActiveService).toHaveBeenCalledWith('610099', 'T9')
     /* (b) Account list reloaded for the new game. */
     expect(commands.getAccounts).toHaveBeenCalledTimes(1)
-    /* (c) Stale selection cleared. */
-    expect(useAccountStore().selectedSid).toBeNull()
+    /* (c) Selection auto-picks first enabled account after reload. */
+    expect(useAccountStore().selectedSid).toBe('sid-1')
     /* (d) Game switch reflected in the gameStore. */
     expect(useGameStore().selectedGameCode).toBe('610099_T9')
     /* Picker stays closed — the saved value resolved cleanly. */


### PR DESCRIPTION
## What

After login, the account list loaded but no row was selected — users had to manually click a row before Get OTP or Start Game would work. WPF defaults `SelectedIndex` to 0 on `redrawSAccountList`, auto-selecting the first account.

## Fix

After `getServiceAccounts` completes and the drag-order is applied, auto-select the first enabled (non-banned) account if nothing is already selected.

## Tests

Updated 3 test files — assertions that expected `selectedSid === null` after mount now expect `'sid-1'` (the first enabled account). The "no selection" guard tests explicitly clear `selectedSid` before asserting.

Closes #245
