### PR TITLE
fix(window): high-DPI scaling + tighten Settings/About spacing (#238)

### DIFF
--- a/src/pages/About.vue
+++ b/src/pages/About.vue
@@ -272,7 +272,7 @@ onMounted(() => {
           <div class="about__header-text">
             <div class="about__title-row">
               <h1 class="about__title bf-text-gradient">{{ t('AppName') }}</h1>
-              <span class="about__author">By Pungin and YCC3741</span>
+              <span class="about__author">By Pungin, YCC3741 and lshw54</span>
             </div>
             <p class="about__version-row" data-test="about-version-row">
               <span>{{ t('Version') }}</span>
@@ -322,6 +322,15 @@ onMounted(() => {
               <a
                 href="#"
                 class="about__contact-link"
+                data-test="about-email-lshw54"
+                @click.prevent="handleEmail('lshw.5454@gmail.com')"
+              >
+                <el-icon><Message /></el-icon>
+                <span>lshw54</span>
+              </a>
+              <a
+                href="#"
+                class="about__contact-link"
                 data-test="about-github"
                 @click.prevent="handleGithub"
               >
@@ -357,7 +366,7 @@ onMounted(() => {
 .about__scroll {
   flex: 1;
   overflow-y: auto;
-  padding: 1.5rem;
+  padding: 1rem 1.5rem;
 }
 
 .about__container {

--- a/src/pages/Settings.vue
+++ b/src/pages/Settings.vue
@@ -906,14 +906,14 @@ onMounted(() => {
 .settings__scroll {
   flex: 1;
   overflow-y: auto;
-  padding: 1.5rem;
+  padding: 1rem 1.5rem;
 }
 
 .settings__container {
   width: 100%;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.75rem;
 }
 
 /* --------------- header --------------- */

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -263,8 +263,8 @@ export const routes: RouteRecordRaw[] = [
     meta: {
       titleKey: 'titleBar.settings',
       titleIcon: 'settings',
-      windowWidth: 880,
-      windowHeight: 680,
+      windowWidth: 660,
+      windowHeight: 580,
     },
     /*
      * P12.4 D6: Settings page is reachable from both the
@@ -312,8 +312,8 @@ export const routes: RouteRecordRaw[] = [
       requiresAuth: true,
       titleKey: 'titleBar.manageAccount',
       titleIcon: 'manage_accounts',
-      windowWidth: 880,
-      windowHeight: 640,
+      windowWidth: 660,
+      windowHeight: 580,
     },
   },
   {
@@ -543,7 +543,12 @@ export function installRouterGuards(router: Router, deps: RouterGuardDeps): void
   function maxFitHeight(): number {
     const avail = typeof window !== 'undefined' ? window.screen?.availHeight : undefined
     if (typeof avail === 'number' && avail > 0) {
-      return Math.max(300, avail - 50)
+      // Reserve space for the Windows taskbar + some breathing room.
+      // On high-DPI displays (125%/150%), availHeight is already in
+      // CSS pixels but the effective usable area is smaller because
+      // the OS reserves more physical pixels for chrome. Using 80%
+      // of availHeight ensures the window never clips off-screen.
+      return Math.max(300, Math.floor(avail * 0.8))
     }
     return 900
   }

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -263,8 +263,8 @@ export const routes: RouteRecordRaw[] = [
     meta: {
       titleKey: 'titleBar.settings',
       titleIcon: 'settings',
-      windowWidth: 660,
-      windowHeight: 580,
+      windowWidth: 880,
+      windowHeight: 680,
     },
     /*
      * P12.4 D6: Settings page is reachable from both the
@@ -312,8 +312,8 @@ export const routes: RouteRecordRaw[] = [
       requiresAuth: true,
       titleKey: 'titleBar.manageAccount',
       titleIcon: 'manage_accounts',
-      windowWidth: 660,
-      windowHeight: 580,
+      windowWidth: 880,
+      windowHeight: 640,
     },
   },
   {


### PR DESCRIPTION
## What

On high-DPI displays (125%/150%), the window grows larger than the visible screen area. Buttons at the bottom (e.g. Settings "返回") get clipped off-screen. Reported across 4K 150%, 125% scaling, and laptop screens.

Also tightened Settings/About page spacing to reduce excess whitespace below the footer.

## Changes

- `maxFitHeight` caps at 80% of `screen.availHeight` instead of `availHeight - 50` — scales proportionally for both 4K and 768p displays
- Settings: scroll padding `1.5rem` → `1rem 1.5rem`, container gap `1rem` → `0.75rem`
- About: scroll padding `1.5rem` → `1rem 1.5rem`, added lshw54 to credits

Closes #238
