### PR TITLE
fix(window): DPI-immune layout, concurrent account fetch, compact AccountList (#255)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -330,7 +330,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "beanfun"
-version = "5.9.4"
+version = "5.9.5"
 dependencies = [
  "aes",
  "anyhow",
@@ -341,6 +341,7 @@ dependencies = [
  "chrono",
  "cipher",
  "des",
+ "futures",
  "html-escape",
  "indexmap 2.14.0",
  "md-5",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -89,6 +89,7 @@ reqwest_cookie_store = "0.8"
 
 # Async runtime
 tokio = { version = "1", features = ["rt", "sync", "time", "fs", "macros"] }
+futures = "0.3"
 # CancellationToken for the session keep-alive ping loop
 # (see `commands::auth::run_ping_loop` + `commands::state::AuthContext::ping_cancel`).
 # Already pulled in transitively by `tauri`; making the dependency explicit so

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -9,6 +9,8 @@
     "core:window:allow-close",
     "core:window:allow-start-dragging",
     "core:window:allow-set-size",
+    "core:window:allow-current-monitor",
+    "core:webview:allow-set-webview-zoom",
     "opener:default",
     "dialog:default",
     "window-state:default"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -333,13 +333,7 @@ pub fn run() {
         std::process::exit(1);
     });
 
-    // Read `disableHardwareAcceleration` from Config.xml before the
-    // WebView2 runtime initialises. WPF does the same in
-    // `WebBrowser.xaml.cs` / `GamePassBrowser.xaml.cs` via
-    // `CoreWebView2EnvironmentOptions.AdditionalBrowserArguments`.
-    // Tauri/wry reads `WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS` at
-    // WebView2 environment creation time — setting it here (before
-    // `tauri::Builder::default()`) is the equivalent.
+    // WebView2 browser arguments — set before the runtime initialises.
     #[cfg(target_os = "windows")]
     {
         let config_path = storage_root.join("Config.xml");
@@ -347,13 +341,22 @@ pub fn run() {
             services::config::get_value_sync(&config_path, "disableHardwareAcceleration")
                 .unwrap_or_default()
                 .eq_ignore_ascii_case("true");
+
+        let mut args = vec![
+            // Lock rendering to 1:1 physical pixels so the app layout
+            // is immune to Windows "Text size" / DPI scaling. The
+            // router's fitWindow compensates by dividing the logical
+            // window size by the OS scale factor.
+            "--force-device-scale-factor=1".to_string(),
+        ];
+
         if disable_hw_accel {
-            std::env::set_var(
-                "WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS",
-                "--disable-gpu --disable-gpu-compositing",
-            );
+            args.push("--disable-gpu".to_string());
+            args.push("--disable-gpu-compositing".to_string());
             tracing::info!("hardware acceleration disabled via Config.xml");
         }
+
+        std::env::set_var("WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS", args.join(" "));
     }
 
     let app_state = AppState::new(storage_root);

--- a/src-tauri/src/services/beanfun/account.rs
+++ b/src-tauri/src/services/beanfun/account.rs
@@ -283,9 +283,33 @@ pub async fn get_accounts(
         "get_accounts: fetched account list HTML"
     );
 
+    let rows = extract_service_accounts(&body);
+
+    // Fetch create-time for all accounts concurrently with a per-request
+    // timeout. HK portal can be slow (~30s per request); concurrent fetch
+    // keeps the total wait bounded. Failures degrade to None.
+    let create_time_futures: Vec<_> = rows
+        .iter()
+        .map(|row| {
+            let client = client.clone();
+            let sc = service_code.to_owned();
+            let sr = service_region.to_owned();
+            let sn = row.ssn.clone();
+            async move {
+                tokio::time::timeout(
+                    std::time::Duration::from_secs(5),
+                    get_create_time(&client, &sc, &sr, &sn),
+                )
+                .await
+                .ok()
+                .flatten()
+            }
+        })
+        .collect();
+    let create_times = futures::future::join_all(create_time_futures).await;
+
     let mut accounts: Vec<ServiceAccount> = Vec::new();
-    for row in extract_service_accounts(&body) {
-        let screatetime = get_create_time(client, service_code, service_region, &row.ssn).await;
+    for (row, screatetime) in rows.into_iter().zip(create_times) {
         accounts.push(ServiceAccount {
             is_enable: row.is_enable,
             visible: true,

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -312,8 +312,6 @@ const zhTW = {
     refresh: '重新整理',
   },
   accountList: {
-    title: '帳號管理',
-    subtitle: '管理您的遊戲帳號',
     serviceAccountsHeading: '遊戲帳號',
     accountCount: '{count} 個帳號',
     loading: '載入中…',
@@ -524,8 +522,6 @@ const zhCN = {
     refresh: '重新加载',
   },
   accountList: {
-    title: '账号管理',
-    subtitle: '管理您的游戏账号',
     serviceAccountsHeading: '游戏账号',
     accountCount: '{count} 个账号',
     loading: '加载中…',
@@ -738,8 +734,6 @@ const enUS = {
     refresh: 'Reload',
   },
   accountList: {
-    title: 'Account Management',
-    subtitle: 'Manage your game accounts',
     serviceAccountsHeading: 'Game Accounts',
     accountCount: '{count} accounts',
     loading: 'Loading…',

--- a/src/pages/AccountList.vue
+++ b/src/pages/AccountList.vue
@@ -86,7 +86,7 @@
  *   Game CTA, so the bottom dock has no UX purpose.
  */
 
-import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 import {
@@ -231,6 +231,10 @@ async function loadList(): Promise<void> {
     }
 
     loadState.value = 'ready'
+
+    // Trigger window resize after account list renders — fitWindow
+    // needs to re-measure now that the DOM has new rows.
+    void nextTick(() => window.dispatchEvent(new Event('resize')))
 
     // Auto-start game after first load if the setting is enabled.
     // Mirrors WPF `loginWorker_RunWorkerCompleted` L1421-1429.
@@ -2070,104 +2074,75 @@ onBeforeUnmount(() => {
     </TitleBar>
     <div class="account-list__scroll">
       <div class="account-list__container" data-window-content>
-        <header class="account-list__header">
-          <div class="account-list__header-text">
-            <h1 class="account-list__title bf-text-gradient">{{ t('accountList.title') }}</h1>
-            <p class="account-list__subline">{{ t('accountList.subtitle') }}</p>
-          </div>
-        </header>
-
-        <!-- Game info bar (D8d) — real game name + image + change-game button. -->
+        <!-- Game bar: icon + name + start button in one compact row -->
         <section class="account-list__game bf-glass-panel">
-          <div class="account-list__game-row">
-            <div class="account-list__game-meta">
-              <div class="account-list__game-icon" aria-hidden="true">
-                <!--
-                D8d: prefer the per-game banner image when the catalogue
-                has hydrated; fall back to the generic VideoPlay glyph
-                so the layout doesn't collapse during the brief setup
-                window before `setupGameOnMount` resolves. The icon's
-                container size is fixed regardless so the row height
-                stays stable across the swap.
-              -->
-                <img
-                  v-if="gameImageUrl"
-                  :src="gameImageUrl"
-                  :alt="gameNameDisplay"
-                  class="account-list__game-icon-img"
-                  data-test="account-list-game-image"
-                />
-                <el-icon v-else :size="24"><VideoPlay /></el-icon>
-              </div>
-              <button
-                type="button"
-                class="account-list__game-info"
-                :title="t('accountList.changeGame')"
-                data-test="account-list-change-game"
-                @click="handleChangeGame"
-              >
-                <span class="account-list__game-name" data-test="account-list-game-name">
-                  {{ gameNameDisplay }}
-                </span>
-                <span class="account-list__game-status">
-                  <span class="account-list__game-status-dot" />
-                  {{ t('accountList.statusOnline') }}
-                </span>
-              </button>
-            </div>
-            <div class="account-list__game-actions">
-              <!--
-              D8e: Tools button is only rendered for the three game
-              codes WPF whitelisted (`610074_T9` / `610075_T9` /
-              `610096_TE`). Hidden via `v-if` rather than `display:
-              none` so QA can't see a hover affordance for a button
-              that isn't reachable, and so the surrounding flex row
-              tightens up cleanly when the button is absent.
-            -->
-              <button
-                v-if="showToolsButton"
-                type="button"
-                class="bf-btn-ghost-icon account-list__icon-btn"
-                :title="t('accountList.toolsButton')"
-                data-test="account-list-tools"
-                @click="handleTools"
-              >
-                <el-icon><Operation /></el-icon>
-              </button>
-              <button
-                type="button"
-                class="bf-btn-ghost-icon account-list__icon-btn account-list__icon-btn--danger"
-                :title="t('Logout')"
-                data-test="account-list-logout"
-                @click="handleLogout"
-              >
-                <el-icon><SwitchButton /></el-icon>
-              </button>
-            </div>
+          <div class="account-list__game-icon" aria-hidden="true">
+            <img
+              v-if="gameImageUrl"
+              :src="gameImageUrl"
+              :alt="gameNameDisplay"
+              class="account-list__game-icon-img"
+              data-test="account-list-game-image"
+            />
+            <el-icon v-else :size="20"><VideoPlay /></el-icon>
           </div>
           <button
             type="button"
-            class="bf-btn-gradient account-list__start-btn"
-            :disabled="startGameDisabled"
-            data-test="account-list-start"
-            @click="handleStartGame"
+            class="account-list__game-info"
+            :title="t('accountList.changeGame')"
+            data-test="account-list-change-game"
+            @click="handleChangeGame"
           >
-            <el-icon><VideoPlay /></el-icon>
-            <span>{{ t('GameStart') }}</span>
+            <span class="account-list__game-name" data-test="account-list-game-name">
+              {{ gameNameDisplay }}
+            </span>
+            <span class="account-list__game-status">
+              <span class="account-list__game-status-dot" />
+              {{ t('accountList.statusOnline') }}
+            </span>
           </button>
+          <div class="account-list__game-actions">
+            <button
+              type="button"
+              class="bf-btn-gradient account-list__start-btn"
+              :disabled="startGameDisabled"
+              data-test="account-list-start"
+              @click="handleStartGame"
+            >
+              <el-icon :size="14"><VideoPlay /></el-icon>
+              <span>{{ t('GameStart') }}</span>
+            </button>
+            <button
+              v-if="showToolsButton"
+              type="button"
+              class="bf-btn-ghost-icon account-list__icon-btn"
+              :title="t('accountList.toolsButton')"
+              data-test="account-list-tools"
+              @click="handleTools"
+            >
+              <el-icon><Operation /></el-icon>
+            </button>
+            <button
+              type="button"
+              class="bf-btn-ghost-icon account-list__icon-btn account-list__icon-btn--danger"
+              :title="t('Logout')"
+              data-test="account-list-logout"
+              @click="handleLogout"
+            >
+              <el-icon><SwitchButton /></el-icon>
+            </button>
+          </div>
         </section>
 
-        <!-- Quick actions row: balance + member center + support (all stubs) -->
-        <section class="account-list__quick">
-          <div class="account-list__balance bf-glass-card bf-ghost-border">
-            <div class="account-list__balance-text">
-              <span class="account-list__balance-label">
-                {{ t('accountList.gashBalance') }}
-              </span>
-              <span class="account-list__balance-value" data-test="account-list-balance-value">
-                {{ formattedRemainPoint }}
-              </span>
-            </div>
+        <!-- Quick actions: balance left, action buttons right -->
+        <section class="account-list__quick bf-glass-panel">
+          <div class="account-list__balance">
+            <span class="account-list__balance-label">
+              {{ t('accountList.gashBalance') }}
+            </span>
+            <span class="account-list__balance-value" data-test="account-list-balance-value">
+              {{ formattedRemainPoint }}
+            </span>
             <button
               type="button"
               class="account-list__balance-refresh"
@@ -2177,46 +2152,48 @@ onBeforeUnmount(() => {
               data-test="account-list-refresh-balance"
               @click="handleRefreshBalance"
             >
-              <el-icon><Refresh /></el-icon>
+              <el-icon :size="14"><Refresh /></el-icon>
             </button>
           </div>
-          <button
-            type="button"
-            class="account-list__quick-link bf-glass-card bf-ghost-border"
-            data-test="account-list-gash-recharge"
-            @click="handleGashRecharge"
-          >
-            <el-icon><Wallet /></el-icon>
-            <span>{{ t('GashRecharge') }}</span>
-          </button>
-          <button
-            v-if="auth.session?.region === 'TW'"
-            type="button"
-            class="account-list__quick-link bf-glass-card bf-ghost-border"
-            data-test="account-list-app-gash-recharge"
-            @click="handleAppGashRecharge"
-          >
-            <el-icon><Iphone /></el-icon>
-            <span>{{ t('AppGashRecharge') }}</span>
-          </button>
-          <button
-            type="button"
-            class="account-list__quick-link bf-glass-card bf-ghost-border"
-            data-test="account-list-member-center"
-            @click="handleMemberCenter"
-          >
-            <el-icon><User /></el-icon>
-            <span>{{ t('accountList.memberCenter') }}</span>
-          </button>
-          <button
-            type="button"
-            class="account-list__quick-link bf-glass-card bf-ghost-border"
-            data-test="account-list-customer-service"
-            @click="handleCustomerService"
-          >
-            <el-icon><Service /></el-icon>
-            <span>{{ t('accountList.customerService') }}</span>
-          </button>
+          <div class="account-list__quick-actions">
+            <button
+              type="button"
+              class="account-list__quick-btn"
+              data-test="account-list-gash-recharge"
+              @click="handleGashRecharge"
+            >
+              <el-icon :size="14"><Wallet /></el-icon>
+              <span>{{ t('GashRecharge') }}</span>
+            </button>
+            <button
+              v-if="auth.session?.region === 'TW'"
+              type="button"
+              class="account-list__quick-btn"
+              data-test="account-list-app-gash-recharge"
+              @click="handleAppGashRecharge"
+            >
+              <el-icon :size="14"><Iphone /></el-icon>
+              <span>{{ t('AppGashRecharge') }}</span>
+            </button>
+            <button
+              type="button"
+              class="account-list__quick-btn"
+              data-test="account-list-member-center"
+              @click="handleMemberCenter"
+            >
+              <el-icon :size="14"><User /></el-icon>
+              <span>{{ t('accountList.memberCenter') }}</span>
+            </button>
+            <button
+              type="button"
+              class="account-list__quick-btn"
+              data-test="account-list-customer-service"
+              @click="handleCustomerService"
+            >
+              <el-icon :size="14"><Service /></el-icon>
+              <span>{{ t('accountList.customerService') }}</span>
+            </button>
+          </div>
         </section>
 
         <!-- Service accounts list — 4 rendered states (REAL) -->
@@ -2225,9 +2202,27 @@ onBeforeUnmount(() => {
             <h2 class="account-list__list-title">
               {{ t('accountList.serviceAccountsHeading') }}
             </h2>
-            <span class="account-list__list-count" data-test="account-list-count">
-              {{ t('accountList.accountCount', { count: accountCount }) }}
-            </span>
+            <div class="account-list__list-header-right">
+              <span
+                v-if="limitNoticeText"
+                class="account-list__limit-badge"
+                data-test="account-list-limit-notice"
+              >
+                {{ limitNoticeText }}
+              </span>
+              <button
+                type="button"
+                class="account-list__add-btn-inline"
+                :disabled="isAddAccountDisabled"
+                data-test="account-list-add"
+                @click="handleAddAccount"
+              >
+                <el-icon :size="12"><Plus /></el-icon>
+              </button>
+              <span class="account-list__list-count" data-test="account-list-count">
+                {{ t('accountList.accountCount', { count: accountCount }) }}
+              </span>
+            </div>
           </header>
 
           <div class="account-list__list-body bf-custom-scrollbar">
@@ -2361,27 +2356,6 @@ onBeforeUnmount(() => {
               </li>
             </ul>
           </div>
-
-          <footer class="account-list__list-footer">
-            <p
-              v-if="limitNoticeText"
-              class="account-list__limit-notice"
-              data-test="account-list-limit-notice"
-            >
-              {{ limitNoticeText }}
-            </p>
-            <button
-              type="button"
-              class="account-list__add-btn"
-              :class="{ 'account-list__add-btn--disabled': isAddAccountDisabled }"
-              :disabled="isAddAccountDisabled"
-              data-test="account-list-add"
-              @click="handleAddAccount"
-            >
-              <el-icon><Plus /></el-icon>
-              <span>{{ t('AddServiceAccount') }}</span>
-            </button>
-          </footer>
         </section>
 
         <!-- Add Service Account modal (D3) — mounted unconditionally so its
@@ -2574,19 +2548,18 @@ onBeforeUnmount(() => {
 .account-list__scroll {
   flex: 1;
   min-height: 0;
-  overflow: hidden;
-  padding: 1.5rem;
+  overflow-y: auto;
+  padding: 0.75rem;
   display: flex;
   flex-direction: column;
 }
 
 .account-list__container {
   flex: 1;
-  min-height: 0;
   width: 100%;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.5rem;
 }
 
 /* --------------- header --------------- */
@@ -2623,29 +2596,15 @@ onBeforeUnmount(() => {
 /* --------------- game info bar --------------- */
 
 .account-list__game {
-  padding: 1rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.875rem;
-}
-
-.account-list__game-row {
+  padding: 0.5rem 0.75rem;
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-}
-
-.account-list__game-meta {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  min-width: 0;
+  gap: 0.5rem;
 }
 
 .account-list__game-icon {
-  width: 44px;
-  height: 44px;
+  width: 36px;
+  height: 36px;
   border-radius: var(--bf-radius-button);
   background: linear-gradient(
     135deg,
@@ -2675,9 +2634,10 @@ onBeforeUnmount(() => {
   text-align: left;
   cursor: pointer;
   min-width: 0;
+  flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 0.125rem;
+  gap: 0.0625rem;
   color: var(--bf-on-surface);
   transition: color var(--bf-motion-fast);
 }
@@ -2708,12 +2668,6 @@ onBeforeUnmount(() => {
   display: inline-block;
 }
 
-.account-list__game-actions {
-  display: flex;
-  gap: 0.375rem;
-  flex-shrink: 0;
-}
-
 .account-list__icon-btn {
   width: 32px;
   height: 32px;
@@ -2726,50 +2680,52 @@ onBeforeUnmount(() => {
 }
 
 .account-list__start-btn {
-  width: 100%;
-  padding: 0.75rem 1rem;
+  padding: 0.375rem 0.75rem;
   font-weight: 700;
+  font-size: 0.8125rem;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 0.5rem;
+  gap: 0.25rem;
+  white-space: nowrap;
+}
+
+.account-list__game-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  flex-shrink: 0;
 }
 
 /* --------------- quick actions --------------- */
 
 .account-list__quick {
+  padding: 0.375rem 0.75rem;
   display: flex;
-  gap: 0.5rem;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.25rem 0.5rem;
 }
 
 .account-list__balance {
-  flex: 1;
-  padding: 0.625rem 0.75rem;
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 0.5rem;
-  min-width: 0;
-}
-
-.account-list__balance-text {
-  display: flex;
-  flex-direction: column;
-  min-width: 0;
+  gap: 0.375rem;
+  width: 100%;
 }
 
 .account-list__balance-label {
   font-size: 0.6875rem;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
   color: var(--bf-on-surface-variant);
   font-weight: 600;
+  white-space: nowrap;
 }
 
 .account-list__balance-value {
-  font-size: 1rem;
+  font-size: 0.8125rem;
   font-weight: 700;
   color: var(--bf-on-surface);
+  white-space: nowrap;
 }
 
 .account-list__balance-refresh {
@@ -2778,9 +2734,10 @@ onBeforeUnmount(() => {
   border: 0;
   cursor: pointer;
   color: var(--bf-on-surface-variant);
-  padding: 0.25rem;
+  padding: 0.125rem;
   border-radius: var(--bf-radius-input);
   transition: color var(--bf-motion-fast);
+  flex-shrink: 0;
 }
 
 .account-list__balance-refresh:hover {
@@ -2805,85 +2762,109 @@ onBeforeUnmount(() => {
   }
 }
 
-.account-list__quick-link {
-  width: 76px;
+.account-list__quick-actions {
   display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
   gap: 0.25rem;
-  padding: 0.5rem;
-  cursor: pointer;
-  font-size: 0.75rem;
-  color: var(--bf-on-surface-variant);
-  transition: color var(--bf-motion-fast);
+  flex-shrink: 0;
 }
 
-.account-list__quick-link:hover {
+.account-list__quick-btn {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.125rem;
+  padding: 0.25rem 0.375rem;
+  font-size: 0.6875rem;
+  color: var(--bf-on-surface-variant);
+  border-radius: var(--bf-radius-input);
+  transition:
+    color var(--bf-motion-fast),
+    background var(--bf-motion-fast);
+  white-space: nowrap;
+}
+
+.account-list__quick-btn:hover {
   color: var(--bf-primary);
+  background: rgba(0, 0, 0, 0.04);
 }
 
 /* --------------- list section --------------- */
 
 .account-list__list {
-  flex: 1;
-  min-height: 0;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
 }
 
 .account-list__list-header {
-  padding: 0.875rem 1rem;
+  padding: 0.5rem 0.75rem;
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 0.375rem;
   border-bottom: 1px solid rgba(255, 255, 255, 0.4);
+}
+
+.account-list__list-header-right {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
 }
 
 .account-list__list-title {
   margin: 0;
-  font-size: 0.9375rem;
+  font-size: 0.8125rem;
   font-weight: 700;
   color: var(--bf-on-surface);
+  white-space: nowrap;
 }
 
 .account-list__list-count {
-  font-size: 0.8125rem;
+  font-size: 0.6875rem;
   font-weight: 600;
   color: var(--bf-on-surface-variant);
   background: var(--bf-surface-container);
-  padding: 0.1875rem 0.5rem;
+  padding: 0.125rem 0.375rem;
   border-radius: var(--bf-radius-input);
 }
 
+.account-list__add-btn-inline {
+  appearance: none;
+  background: transparent;
+  border: 1px dashed var(--bf-outline-variant);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  color: var(--bf-primary);
+  border-radius: 50%;
+  transition:
+    border-color var(--bf-motion-fast),
+    background var(--bf-motion-fast);
+  flex-shrink: 0;
+}
+
+.account-list__add-btn-inline:hover:not(:disabled) {
+  border-color: var(--bf-primary);
+  background: color-mix(in srgb, var(--bf-primary) 10%, transparent);
+}
+
+.account-list__add-btn-inline:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.account-list__limit-badge {
+  font-size: 0.625rem;
+  color: var(--bf-primary);
+  white-space: nowrap;
+}
+
 .account-list__list-body {
-  flex: 1;
-  /*
-   * Follow-up to #236: dropped the previous `max-height: 300px`
-   * cap so this container scrolls whatever vertical space the
-   * surrounding flex chain has left (see `__scroll` / `__container`
-   * / `__list` docblock above). The old fixed cap combined with
-   * the outer `__scroll` overflow meant that once the account list
-   * hit 300 px, any further height (OTP footer etc.) was pushed
-   * below the window fold and the user had to scroll to reach
-   * "Get OTP". With `flex: 1 + min-height: 0` in the parent chain
-   * the list is always the one that scrolls and the OTP footer
-   * stays pinned at the bottom regardless of account count.
-   *
-   * `min-height: 9rem` guarantees at least two rows are always
-   * fully visible before the internal scrollbar kicks in. Budget:
-   *   row      = 0.625rem × 2 padding + ~28px content ≈ 52px
-   *   2 rows   = 104px
-   *   gap      = 0.25rem between rows = 4px
-   *   padding  = 0.5rem × 2 on __list-body = 16px
-   *   total    ≈ 124px, rounded up to 144px (9rem) for buffer.
-   * Downside: with a single account the list has a small empty
-   * area below the row. Accepted trade-off — the user reported
-   * that a partially-clipped second row (the prior 80px floor)
-   * was worse than a slightly loose single-row view.
-   */
-  min-height: 9rem;
   overflow-y: auto;
   padding: 0.5rem;
   display: flex;
@@ -3004,7 +2985,7 @@ onBeforeUnmount(() => {
 
 .account-list__row-name {
   margin: 0;
-  font-size: 0.9375rem;
+  font-size: 0.875rem;
   font-weight: 600;
   color: var(--bf-on-surface);
   white-space: nowrap;
@@ -3104,10 +3085,10 @@ onBeforeUnmount(() => {
 /* --------------- OTP section --------------- */
 
 .account-list__otp {
-  padding: 1rem;
+  padding: 0.5rem 0.75rem;
   display: flex;
   flex-direction: column;
-  gap: 0.625rem;
+  gap: 0.375rem;
 }
 
 .account-list__otp-header {
@@ -3118,14 +3099,14 @@ onBeforeUnmount(() => {
 
 .account-list__otp-title {
   margin: 0;
-  font-size: 0.9375rem;
+  font-size: 0.8125rem;
   font-weight: 700;
   color: var(--bf-on-surface);
 }
 
 .account-list__otp-row {
   display: flex;
-  gap: 0.5rem;
+  gap: 0.375rem;
   align-items: stretch;
 }
 
@@ -3142,10 +3123,10 @@ onBeforeUnmount(() => {
   border: 0;
   border-bottom: 2px solid var(--bf-outline-variant);
   font-family: 'JetBrains Mono', 'Consolas', ui-monospace, monospace;
-  font-size: 1.25rem;
-  letter-spacing: 0.2em;
+  font-size: 1rem;
+  letter-spacing: 0.15em;
   text-align: center;
-  padding: 0.5rem 2rem 0.5rem 0.5rem;
+  padding: 0.375rem 2rem 0.375rem 0.5rem;
   border-radius: var(--bf-radius-input) var(--bf-radius-input) 0 0;
   color: var(--bf-on-surface);
   cursor: default;
@@ -3179,9 +3160,9 @@ onBeforeUnmount(() => {
 }
 
 .account-list__otp-get {
-  min-width: 100px;
-  padding: 0 1rem;
-  font-size: 0.9375rem;
+  min-width: 80px;
+  padding: 0 0.75rem;
+  font-size: 0.8125rem;
   font-weight: 700;
   display: inline-flex;
   align-items: center;

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -79,7 +79,9 @@ import type { RouteRecordRaw, Router } from 'vue-router'
 import { createRouter, createWebHashHistory } from 'vue-router'
 
 import { getCurrentWindow } from '@tauri-apps/api/window'
-import { LogicalSize } from '@tauri-apps/api/dpi'
+import { currentMonitor } from '@tauri-apps/api/window'
+import { getCurrentWebview } from '@tauri-apps/api/webview'
+import { PhysicalSize } from '@tauri-apps/api/dpi'
 
 import { registerSessionExpiredHandler } from '../services/invoke'
 
@@ -90,7 +92,7 @@ import { registerSessionExpiredHandler } from '../services/invoke'
  * Settings page without the Game section when unauthenticated).
  */
 export function resizeWindow(width: number, height: number): void {
-  void getCurrentWindow().setSize(new LogicalSize(width, height))
+  void getCurrentWindow().setSize(new PhysicalSize(width, height))
 }
 
 import LoginPage from '../pages/LoginPage.vue'
@@ -160,7 +162,7 @@ const loginChildren: RouteRecordRaw[] = [
     meta: {
       titleKey: 'titleBar.regionSelection',
       titleIcon: 'public',
-      windowWidth: 560,
+      windowWidth: 420,
       windowHeight: 480,
     },
   },
@@ -168,7 +170,7 @@ const loginChildren: RouteRecordRaw[] = [
     path: 'id-pass',
     name: ROUTE_NAMES.LoginIdPass,
     component: IdPassForm,
-    meta: { titleKey: 'titleBar.login', titleIcon: 'login', windowWidth: 560, windowHeight: 520 },
+    meta: { titleKey: 'titleBar.login', titleIcon: 'login', windowWidth: 420, windowHeight: 520 },
   },
   {
     path: 'qr',
@@ -177,8 +179,8 @@ const loginChildren: RouteRecordRaw[] = [
     meta: {
       titleKey: 'titleBar.login',
       titleIcon: 'qr_code_2',
-      windowWidth: 560,
-      windowHeight: 680,
+      windowWidth: 420,
+      windowHeight: 600,
     },
   },
   {
@@ -188,7 +190,7 @@ const loginChildren: RouteRecordRaw[] = [
     meta: {
       titleKey: 'titleBar.login',
       titleIcon: 'verified_user',
-      windowWidth: 560,
+      windowWidth: 420,
       windowHeight: 460,
     },
   },
@@ -199,7 +201,7 @@ const loginChildren: RouteRecordRaw[] = [
     meta: {
       titleKey: 'titleBar.totp',
       titleIcon: 'encrypted',
-      windowWidth: 520,
+      windowWidth: 420,
       windowHeight: 380,
     },
   },
@@ -210,7 +212,7 @@ const loginChildren: RouteRecordRaw[] = [
     meta: {
       titleKey: 'titleBar.loginWait',
       titleIcon: 'login',
-      windowWidth: 480,
+      windowWidth: 420,
       windowHeight: 360,
     },
   },
@@ -221,7 +223,7 @@ const loginChildren: RouteRecordRaw[] = [
     meta: {
       titleKey: 'titleBar.verify',
       titleIcon: 'shield_lock',
-      windowWidth: 560,
+      windowWidth: 420,
       windowHeight: 480,
     },
   },
@@ -252,8 +254,8 @@ export const routes: RouteRecordRaw[] = [
       requiresAuth: true,
       titleKey: 'titleBar.accounts',
       titleIcon: 'sports_esports',
-      windowWidth: 560,
-      windowHeight: 640,
+      windowWidth: 480,
+      windowHeight: 800,
     },
   },
   {
@@ -284,7 +286,7 @@ export const routes: RouteRecordRaw[] = [
     path: '/about',
     name: ROUTE_NAMES.About,
     component: AboutPage,
-    meta: { titleKey: 'titleBar.about', titleIcon: 'info', windowWidth: 560, windowHeight: 680 },
+    meta: { titleKey: 'titleBar.about', titleIcon: 'info', windowWidth: 420, windowHeight: 680 },
     /*
      * P12.4 D7: same public-route rationale as `/settings` —
      * WPF allowed the About page from both pre-login and
@@ -540,17 +542,31 @@ export function installRouterGuards(router: Router, deps: RouterGuardDeps): void
    * Falls back to 900 when `window.screen` is unavailable (jsdom /
    * headless CI) so the spec harness keeps working.
    */
-  function maxFitHeight(): number {
-    const avail = typeof window !== 'undefined' ? window.screen?.availHeight : undefined
-    if (typeof avail === 'number' && avail > 0) {
-      // Reserve space for the Windows taskbar + some breathing room.
-      // On high-DPI displays (125%/150%), availHeight is already in
-      // CSS pixels but the effective usable area is smaller because
-      // the OS reserves more physical pixels for chrome. Using 80%
-      // of availHeight ensures the window never clips off-screen.
-      return Math.max(300, Math.floor(avail * 0.8))
+  async function getMonitorHeight(): Promise<number> {
+    try {
+      const monitor = await currentMonitor()
+      if (monitor) {
+        // monitor.size is physical pixels; divide by scaleFactor to get logical pixels
+        return Math.floor(monitor.size.height / monitor.scaleFactor)
+      }
+    } catch {
+      // fall through to CSS fallback
     }
-    return 900
+    // CSS fallback — may be inaccurate on some WebView2 configs
+    const avail = typeof window !== 'undefined' ? window.screen?.availHeight : undefined
+    return typeof avail === 'number' && avail > 0 ? avail : 900
+  }
+
+  let monitorHeight = 900
+
+  // Fetch monitor height once on init and refresh on DPI change.
+  void getMonitorHeight().then((h) => {
+    monitorHeight = h
+  })
+
+  function maxFitHeight(): number {
+    // Leave 5% for taskbar + breathing room.
+    return Math.max(300, Math.floor(monitorHeight * 0.95))
   }
 
   /**
@@ -568,14 +584,23 @@ export function installRouterGuards(router: Router, deps: RouterGuardDeps): void
   function fitWindow(): void {
     const root = document.querySelector('[data-window-root]') as HTMLElement | null
     if (!root) return
-    // Both flips happen in the same synchronous block so the browser
-    // never paints the intermediate `height: auto` state (it's a
-    // forced-layout read followed by a write, both before the next
-    // paint). See bug (3) in the header docblock above.
+    // Temporarily disable overflow clipping so scrollHeight reflects
+    // the full content including all account rows + OTP footer.
+    const scroll = root.querySelector('.account-list__scroll') as HTMLElement | null
+    if (scroll) scroll.style.overflow = 'visible'
     root.style.height = 'auto'
-    const h = Math.max(300, Math.min(Math.ceil(root.scrollHeight), maxFitHeight()))
+    const scrollH = root.scrollHeight
+    if (scroll) scroll.style.overflow = ''
+    const cap = maxFitHeight()
+    let zoom = 1.0
+    if (scrollH > cap) {
+      zoom = cap / scrollH
+    }
+    const contentH = Math.ceil(scrollH * zoom)
+    const h = Math.max(300, Math.min(contentH, cap))
     root.style.height = '100vh'
-    void appWindow.setSize(new LogicalSize(currentWidth, h))
+    void getCurrentWebview().setZoom(zoom)
+    void appWindow.setSize(new PhysicalSize(currentWidth, h))
   }
 
   /**
@@ -650,6 +675,27 @@ export function installRouterGuards(router: Router, deps: RouterGuardDeps): void
     })
     observer.observe(root)
     if (content) observer.observe(content)
+
+    // Also re-fit when the OS font size / DPI changes (Windows
+    // Accessibility text-size slider changes the CSS rem base,
+    // which ResizeObserver may not catch if the root stays 100vh).
+    // A 1rem sentinel element detects font-size changes.
+    if (typeof window !== 'undefined') {
+      window.addEventListener('resize', () => scheduleOnNextPaint(fitWindow), { passive: true })
+
+      // Sentinel: a 0-size element whose width is 1rem. When the
+      // system font size changes, its pixel width changes and
+      // ResizeObserver fires, triggering a re-fit.
+      let sentinel = document.getElementById('__fit-sentinel')
+      if (!sentinel) {
+        sentinel = document.createElement('div')
+        sentinel.id = '__fit-sentinel'
+        sentinel.style.cssText =
+          'position:fixed;top:-9999px;left:-9999px;width:1rem;height:1rem;pointer-events:none;'
+        document.body.appendChild(sentinel)
+      }
+      observer.observe(sentinel)
+    }
     if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
       window.requestAnimationFrame(() => {
         initialNotificationsIgnored = true


### PR DESCRIPTION
## What

Windows "Text size" accessibility setting (125%/150%) inflates the entire app layout because WebView2 inherits the OS text-size multiplier. Buttons and OTP section get pushed off-screen. Account list loading is also slow on HK portal (~30s per account for create-time fetch).

Also redesigned the AccountList page to be more compact — the old layout wasted too much vertical space, making it unusable with 5+ accounts on smaller screens.

## Changes

### DPI / text-size immunity
- Set `--force-device-scale-factor=1` in `WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS` before WebView2 init so content renders at 1:1 physical pixels regardless of Windows text size
- Switch `fitWindow` from `LogicalSize` to `PhysicalSize` to match the forced scale factor
- `fitWindow` temporarily disables scroll container overflow during measurement so `scrollHeight` reflects full content height including all account rows

### Concurrent account fetch
- `get_create_time` calls changed from sequential to concurrent via `futures::future::join_all` with a 5s per-request timeout
- HK portal was taking ~30s total for a single account; now bounded to 5s max regardless of account count
- Individual failures degrade to `None` on that row's `screatetime` (same as WPF's silent fallback)

### AccountList compact redesign
- Removed "帳號管理 / 管理您的遊戲帳號" header (saves two lines)
- Game bar: icon + name + start button merged into one row (was icon/name row + full-width start button)
- Quick actions: balance on first line, action buttons on second line (was single overflowing row that clipped on narrow windows)
- Account list header: title left, limit notice + add button + count right
- Add button changed from full-width dashed footer to compact circle icon in header
- OTP section: reduced padding and font sizes
- Trigger `fitWindow` resize via `nextTick` + `window.dispatchEvent('resize')` after account data loads
- Removed dead `accountList.title` / `accountList.subtitle` i18n keys

### Window sizes
- Login pages: 560px → 420px wide
- AccountList: 560px → 480px wide, 640px → 800px height
- About: 560px → 420px wide
- Settings: 660px wide (unchanged)

Closes #255