### PR TITLE
fix: Elsword launch, double game-start crash, ping diagnostics (#247)

### DIFF
--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -233,11 +233,16 @@ async fn run_ping_loop_with_interval(
             biased;
             _ = cancel.cancelled() => return,
             res = client.ping() => {
-                if let Err(err) = res {
-                    tracing::debug!(
-                        error = ?err,
-                        "session keep-alive ping failed; will retry next tick"
-                    );
+                match res {
+                    Ok(()) => {
+                        tracing::debug!("session keep-alive ping ok");
+                    }
+                    Err(err) => {
+                        tracing::warn!(
+                            error = ?err,
+                            "session keep-alive ping failed; will retry next tick"
+                        );
+                    }
                 }
             }
         }

--- a/src-tauri/src/commands/launcher.rs
+++ b/src-tauri/src/commands/launcher.rs
@@ -593,7 +593,22 @@ pub async fn launch_game(
         .with_details(json!({ "io_kind": format!("{:?}", err.kind()) }))
     })?;
 
-    let command_line = build_command_line(&command_line_template, &account, &password);
+    // WPF splits the INI `exe` field into `game_exe` (filename) and
+    // `game_commandLine` (args with %s placeholders) via:
+    //   game_exe = Regex("(.*).exe").Match(exe) + ".exe"
+    //   game_commandLine = Regex(".exe (.*)").Match(exe)
+    // Only `game_commandLine` is used for credential substitution.
+    // We replicate the split here so the command line passed to
+    // CreateProcess matches WPF byte-for-byte.
+    let args_template = if let Some(pos) = command_line_template
+        .to_ascii_lowercase()
+        .find(".exe ")
+    {
+        &command_line_template[pos + 5..]
+    } else {
+        ""
+    };
+    let command_line = build_command_line(args_template, &account, &password);
 
     tracing::info!(
         game_path = %game_path,

--- a/src-tauri/src/commands/launcher.rs
+++ b/src-tauri/src/commands/launcher.rs
@@ -600,9 +600,7 @@ pub async fn launch_game(
     // Only `game_commandLine` is used for credential substitution.
     // We replicate the split here so the command line passed to
     // CreateProcess matches WPF byte-for-byte.
-    let args_template = if let Some(pos) = command_line_template
-        .to_ascii_lowercase()
-        .find(".exe ")
+    let args_template = if let Some(pos) = command_line_template.to_ascii_lowercase().find(".exe ")
     {
         &command_line_template[pos + 5..]
     } else {

--- a/src-tauri/src/commands/launcher.rs
+++ b/src-tauri/src/commands/launcher.rs
@@ -595,6 +595,16 @@ pub async fn launch_game(
 
     let command_line = build_command_line(&command_line_template, &account, &password);
 
+    tracing::info!(
+        game_path = %game_path,
+        mode = ?mode,
+        template_len = command_line_template.len(),
+        command_line_len = command_line.len(),
+        has_account = !account.is_empty(),
+        has_password = !password.is_empty(),
+        "launch_game: preparing to spawn"
+    );
+
     let req = LaunchRequest {
         game_path: PathBuf::from(game_path),
         command_line,

--- a/src/pages/AccountList.vue
+++ b/src/pages/AccountList.vue
@@ -1243,6 +1243,7 @@ const otpLaunchChain = computed<boolean>(() => {
  *   `bfClient.GetOTP(account, ...)` needs a target.
  */
 const startGameDisabled = computed<boolean>(() => {
+  if (launchingGame.value) return true
   if (!game.selectedGame) return true
   if (startGameDirect.value) return false
   return account.selectedServiceAccount === null
@@ -1267,16 +1268,24 @@ const startGameDisabled = computed<boolean>(() => {
  * Adding a global busy guard here would just reproduce the WPF
  * foot-gun where a slow launch blocks Logout.
  */
+const launchingGame = ref(false)
+
 async function handleStartGame(): Promise<void> {
+  if (launchingGame.value) return
   if (!game.selectedGame) {
     ElMessage.warning(t('GameSelected'))
     return
   }
-  if (startGameDirect.value) {
-    await launcher.runGame()
-    return
+  launchingGame.value = true
+  try {
+    if (startGameDirect.value) {
+      await launcher.runGame()
+      return
+    }
+    await handleGetOtp()
+  } finally {
+    launchingGame.value = false
   }
-  await handleGetOtp()
 }
 
 /* --------------- per-row context menu (D4) --------------- */


### PR DESCRIPTION
## What

Fixes for issues reported in #247. The Elsword launch failure was the biggest — root cause was a command-line argument mismatch introduced in the WPF → Tauri rewrite.

## Changes

### Elsword (and potentially other games) can't launch
WPF splits the INI `exe` field (e.g. `elsword.exe host port BeanFun %s %s`) into two parts:
- `game_exe` = `elsword.exe` (used as the process to spawn)
- `game_commandLine` = `host port BeanFun %s %s` (used for `%s` credential substitution)

Only `game_commandLine` is passed as `ProcessStartInfo.Arguments`. The Tauri rewrite was passing the **entire** `exe` field (including the exe filename) as the command-line arguments, so games received the exe name as an extra argument. MapleStory happened to tolerate this, but Elsword rejected the malformed arguments and fell back to the traditional login page — which Elsword has fully disabled, causing the game to close immediately.

Fix: replicate the WPF `.exe ` split in `launch_game` so only the args portion is used for credential substitution.

### Double game-start crash
Pressing Start Game twice quickly could spawn two concurrent launch sequences, leaving the app suspended in Task Manager. Added a `launchingGame` in-flight guard — the button is now disabled while a launch is in progress.

### Session expiry diagnostics
Ping keep-alive failure was logged at `debug` level (invisible in normal output). Upgraded to `warn` and added success logging at `debug` level so session expiry issues can be diagnosed from terminal output.

### Still investigating
- **Session expiry after ~5 min** — ping loop is correct (60s interval, same as WPF). The `-1` remainPoint comes from the server. Need user logs to determine if pings are failing or if the server is invalidating sessions for another reason.
- **GamePass records** — WPF by design does not save GamePass login credentials (`SaveLoginCredentials` explicitly skips GamePass). The Tauri rewrite follows the same behaviour.

Closes #247
