### PR TITLE
feat: dark mode (#254)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![GitHub all releases](https://img.shields.io/github/downloads/pungin/Beanfun/total)](https://github.com/pungin/Beanfun/releases)
 [![Lint, Format & Test](https://github.com/pungin/Beanfun/actions/workflows/ci.yml/badge.svg)](https://github.com/pungin/Beanfun/actions/workflows/ci.yml)
 
-> **遊戲橘子旗下科技紅利遊戲的第三方啟動器**
+> **遊戲橘子數位科技旗下遊戲的第三方啟動器**
 
 **免責聲明：** 本軟體 **不是** 遊戲橘子旗下科技所開發的官方客戶端程式。若您的帳號使用第三方的方式登錄，請自行三思並且確認下載當前程式的來源是否安全。
 

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -404,6 +404,7 @@ const zhTW = {
     gameSectionEmpty: '尚未選擇任何遊戲，遊戲相關設定將於選擇遊戲後出現。',
     disableHardwareAccelerationTip:
       '關閉硬體加速可降低 GPU 使用，但介面動畫會較不流暢。\n更動後需完全重新啟動 Beanfun 才會套用。',
+    darkMode: '深色模式',
     tradLoginTip: '使用傳統登入流程（多次跳轉），\n適合自動登入失敗或無法跳出登入視窗時使用。',
     killPatcherTip: '阻止 beanfun! 啟動的更新程式 (Patcher.aspx) 自動執行。',
     skipPlayWindowTip: '直接啟動遊戲，跳過 Play 視窗確認步驟。',
@@ -614,6 +615,7 @@ const zhCN = {
     gameSectionEmpty: '尚未选择任何游戏，游戏相关设定将于选择游戏后出现。',
     disableHardwareAccelerationTip:
       '关闭硬件加速可降低 GPU 使用，但界面动画会较不流畅。\n更动后需完全重新启动 Beanfun 才会套用。',
+    darkMode: '深色模式',
     tradLoginTip: '使用传统登录流程（多次跳转），\n适合自动登录失败或无法跳出登录窗口时使用。',
     killPatcherTip: '阻止 beanfun! 启动的更新程序 (Patcher.aspx) 自动执行。',
     skipPlayWindowTip: '直接启动游戏，跳过 Play 窗口确认步骤。',
@@ -832,6 +834,7 @@ const enUS = {
     gameSectionEmpty: 'No game selected. Game-specific settings will appear once you pick one.',
     disableHardwareAccelerationTip:
       'Disabling hardware acceleration lowers GPU use but makes UI animations less smooth.\nA full Beanfun restart is required for the change to take effect.',
+    darkMode: 'Dark Mode',
     tradLoginTip:
       'Use the traditional multi-redirect login flow.\nHandy when auto-login fails or the login window does not appear.',
     killPatcherTip: 'Prevent the beanfun! launcher (Patcher.aspx) from auto-running.',

--- a/src/main.ts
+++ b/src/main.ts
@@ -42,6 +42,7 @@ import { createApp } from 'vue'
 import { createPinia } from 'pinia'
 import ElementPlus from 'element-plus'
 import 'element-plus/dist/index.css'
+import 'element-plus/theme-chalk/dark/css-vars.css'
 /*
  * Project-wide design tokens + utility classes (P12.2 D1). Loaded
  * after Element Plus's stylesheet so our `--bf-*` custom properties

--- a/src/pages/Settings.vue
+++ b/src/pages/Settings.vue
@@ -685,6 +685,16 @@ onMounted(() => {
                 </div>
               </div>
 
+              <div class="settings__row settings__row--checkbox">
+                <el-checkbox
+                  :model-value="ui.darkMode"
+                  data-test="settings-dark-mode"
+                  @change="(value) => ui.setDarkMode(Boolean(value))"
+                >
+                  {{ t('settings.darkMode') }}
+                </el-checkbox>
+              </div>
+
               <div
                 v-if="showLoginModePanel"
                 class="settings__row"

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -112,6 +112,7 @@ export const DEFAULT_LOGIN_METHOD: LoginMethodValue = '0'
  */
 export const UI_CONFIG_KEYS = {
   ThemeColor: 'ThemeColor',
+  DarkMode: 'darkMode',
   Language: 'Language',
   MinimizeToTray: 'minimize_to_tray',
   DisableHardwareAcceleration: 'disableHardwareAcceleration',
@@ -169,6 +170,8 @@ export const useUiStore = defineStore('ui', () => {
     () => config.get(UI_CONFIG_KEYS.ThemeColor) ?? DEFAULT_PRIMARY_COLOR,
   )
 
+  const darkMode = computed<boolean>(() => parseBool(config.get(UI_CONFIG_KEYS.DarkMode), false))
+
   const language = computed<AppLocale>(() => {
     const raw = config.get(UI_CONFIG_KEYS.Language)
     return isAppLocale(raw) ? raw : DEFAULT_LOCALE
@@ -213,6 +216,11 @@ export const useUiStore = defineStore('ui', () => {
   async function setThemeColor(hex: string): Promise<void> {
     await config.set(UI_CONFIG_KEYS.ThemeColor, hex)
     setPrimaryColor(hex)
+  }
+
+  async function setDarkMode(value: boolean): Promise<void> {
+    await config.set(UI_CONFIG_KEYS.DarkMode, stringifyBool(value))
+    applyDarkMode(value)
   }
 
   async function setLanguage(locale: AppLocale): Promise<void> {
@@ -269,6 +277,16 @@ export const useUiStore = defineStore('ui', () => {
    * Config value can't soft-brick boot — fall back to defaults
    * for that one setting and continue.
    */
+  function applyDarkMode(dark: boolean): void {
+    document.documentElement.setAttribute('data-theme', dark ? 'dark' : 'light')
+    // Element Plus dark mode — requires the `dark` class on <html>
+    if (dark) {
+      document.documentElement.classList.add('dark')
+    } else {
+      document.documentElement.classList.remove('dark')
+    }
+  }
+
   function applyAll(): void {
     try {
       setPrimaryColor(themeColor.value)
@@ -276,6 +294,8 @@ export const useUiStore = defineStore('ui', () => {
       console.error('[ui.applyAll] failed to apply themeColor; falling back to default', err)
       setPrimaryColor(DEFAULT_PRIMARY_COLOR)
     }
+
+    applyDarkMode(darkMode.value)
 
     if (localeApplier) {
       try {
@@ -291,6 +311,7 @@ export const useUiStore = defineStore('ui', () => {
     currentDialog,
 
     themeColor,
+    darkMode,
     language,
     minimizeToTray,
     disableHwAccel,
@@ -303,6 +324,7 @@ export const useUiStore = defineStore('ui', () => {
     loginMethod,
 
     setThemeColor,
+    setDarkMode,
     setLanguage,
     setMinimizeToTray,
     setDisableHwAccel,

--- a/src/styles/design-tokens.css
+++ b/src/styles/design-tokens.css
@@ -100,3 +100,33 @@
   --bf-motion-normal: 200ms cubic-bezier(0.2, 0, 0, 1);
   --bf-motion-emphasized: 400ms cubic-bezier(0.2, 0, 0, 1);
 }
+
+/* ---------- Dark mode overrides ---------------------------------- */
+[data-theme='dark'] {
+  --bf-surface: #1c1b1f;
+  --bf-surface-bright: #242428;
+  --bf-surface-container-lowest: #111114;
+  --bf-surface-container-low: #1e1e22;
+  --bf-surface-container: #252529;
+  --bf-surface-container-high: #2f2f33;
+  --bf-surface-variant: #3a3a3e;
+  --bf-on-surface: #e6e1e5;
+  --bf-on-surface-variant: #c9c5ca;
+  --bf-outline: #938f94;
+  --bf-outline-variant: #49454f;
+  --bf-glass-border: rgba(255, 255, 255, 0.1);
+  --bf-inverse-on-surface: #1c1b1f;
+
+  --bf-danger: #ffb4ab;
+  --bf-on-danger: #690005;
+  --bf-danger-container: #93000a;
+  --bf-on-danger-container: #ffdad6;
+  --bf-success: #9cd67f;
+  --bf-warning: #ffb95e;
+
+  --bf-shadow-panel: 0 10px 30px rgba(0, 0, 0, 0.3), 0 2px 6px rgba(0, 0, 0, 0.2);
+  --bf-shadow-card: 0 4px 12px rgba(0, 0, 0, 0.2);
+  --bf-shadow-elevated: 0 20px 48px rgba(0, 0, 0, 0.4), 0 4px 12px rgba(0, 0, 0, 0.3);
+  --bf-shadow-floating: 0 8px 32px rgba(0, 0, 0, 0.15);
+  --bf-shadow-soft: 0 4px 24px rgba(0, 0, 0, 0.15);
+}

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -257,3 +257,66 @@
 .bf-custom-scrollbar::-webkit-scrollbar-thumb:hover {
   background-color: rgba(0, 0, 0, 0.35);
 }
+
+/* =========================================================================
+ * Dark mode overrides for glass utilities
+ * ========================================================================= */
+
+[data-theme='dark'] .bf-glass-window {
+  background:
+    linear-gradient(180deg, rgba(28, 27, 31, 0.92) 0%, rgba(28, 27, 31, 0.88) 100%),
+    radial-gradient(
+      1200px 800px at 10% -10%,
+      color-mix(in srgb, var(--bf-primary-container) 15%, transparent) 0%,
+      transparent 60%
+    ),
+    radial-gradient(
+      900px 700px at 110% 110%,
+      color-mix(in srgb, var(--bf-primary) 10%, transparent) 0%,
+      transparent 55%
+    ),
+    linear-gradient(180deg, #1c1b1f 0%, #141316 100%);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.06),
+    var(--bf-shadow-panel);
+}
+
+[data-theme='dark'] .bf-glass-panel {
+  background: rgba(37, 37, 41, 0.75);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.06),
+    var(--bf-shadow-panel);
+}
+
+[data-theme='dark'] .bf-glass-floating {
+  background: rgba(37, 37, 41, 0.55);
+  border-top-color: rgba(255, 255, 255, 0.08);
+}
+
+[data-theme='dark'] .bf-glass-card {
+  background: rgba(47, 47, 51, 0.7);
+  border-color: rgba(255, 255, 255, 0.1);
+}
+
+[data-theme='dark'] .bf-ghost-border {
+  border-color: rgba(255, 255, 255, 0.08);
+}
+
+[data-theme='dark'] .bf-text-gradient {
+  background: linear-gradient(135deg, var(--bf-primary-container) 0%, var(--bf-primary) 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+[data-theme='dark'] .bf-btn-gradient {
+  background: linear-gradient(135deg, var(--bf-primary-container) 0%, var(--bf-primary) 60%);
+  color: #ffffff;
+}
+
+[data-theme='dark'] .bf-custom-scrollbar::-webkit-scrollbar-thumb {
+  background-color: rgba(255, 255, 255, 0.2);
+}
+[data-theme='dark'] .bf-custom-scrollbar::-webkit-scrollbar-thumb:hover {
+  background-color: rgba(255, 255, 255, 0.35);
+}


### PR DESCRIPTION
## What

Adds dark mode toggle to Settings. Persisted to Config.xml so it survives restarts.

## How it works

- `data-theme="dark"` attribute on `<html>` drives all custom CSS variables
- Element Plus dark mode via the `dark` class on `<html>` + imported `dark/css-vars.css`
- Config.xml key `darkMode` (`"true"` / `"false"`, default `false`)
- Applied at boot in `ui.applyAll()` so the first frame is already dark if the user previously enabled it

## Changes

- `design-tokens.css` — dark mode surface palette, shadows, semantic colors
- `utilities.css` — dark overrides for `bf-glass-window`, `bf-glass-panel`, `bf-glass-card`, `bf-ghost-border`, `bf-text-gradient`, `bf-btn-gradient`, scrollbar
- `stores/ui.ts` — `darkMode` computed getter, `setDarkMode` async setter, `applyDarkMode` DOM applier
- `main.ts` — import `element-plus/theme-chalk/dark/css-vars.css`
- `pages/Settings.vue` — dark mode checkbox after theme color picker
- `i18n/messages.ts` — `settings.darkMode` label (zh-TW: 深色模式, zh-CN: 深色模式, en: Dark Mode)

Closes #254
