### PR TITLE
style: refine AccountList quick-actions layout and trim third-party branding strings

### DIFF
--- a/Lang/en.xaml
+++ b/Lang/en.xaml
@@ -72,7 +72,7 @@
   <system:String x:Key="GashRemainInGame"> (In-game {0})</system:String>
   <system:String x:Key="GashRefresh">Refresh Points</system:String>
   <system:String x:Key="GashRecharge">Top Up</system:String>
-  <system:String x:Key="AppGashRecharge">Redeem beanfun! App Gash Points</system:String>
+  <system:String x:Key="AppGashRecharge">Redeem App Gash Points</system:String>
   <system:String x:Key="MemberCenter">Member Center</system:String>
   <system:String x:Key="CustomerService">Customer Service</system:String>
   <system:String x:Key="RightClickMenu">Right-click for menu</system:String>

--- a/Lang/zh-Hans.xaml
+++ b/Lang/zh-Hans.xaml
@@ -60,7 +60,7 @@
   <system:String x:Key="GashRemainInGame"> (游戏内 {0})</system:String>
   <system:String x:Key="GashRefresh">更新点数</system:String>
   <system:String x:Key="GashRecharge">充值与购点</system:String>
-  <system:String x:Key="AppGashRecharge">兑换beanfun!App乐豆点</system:String>
+  <system:String x:Key="AppGashRecharge">兑换 App 乐豆点</system:String>
   <system:String x:Key="MemberCenter">会员中心</system:String>
   <system:String x:Key="RightClickMenu">右键开启菜单</system:String>
   <system:String x:Key="AccountBanned">账号已锁定</system:String>

--- a/Lang/zh.xaml
+++ b/Lang/zh.xaml
@@ -57,7 +57,7 @@
   <system:String x:Key="GashRemainInGame"> (遊戲內 {0})</system:String>
   <system:String x:Key="GashRefresh">更新點數</system:String>
   <system:String x:Key="GashRecharge">儲值與購點</system:String>
-  <system:String x:Key="AppGashRecharge">兌換beanfun!App樂豆點</system:String>
+  <system:String x:Key="AppGashRecharge">兌換 App 樂豆點</system:String>
   <system:String x:Key="MemberCenter">會員中心</system:String>
   <system:String x:Key="CustomerService">客服中心</system:String>
   <system:String x:Key="RightClickMenu">右鍵開啟選單</system:String>

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -269,7 +269,7 @@ const zhTW = {
     verify: '進階驗證',
     accounts: '遊戲帳號',
     settings: '設定',
-    about: '關於 beanfun! Next',
+    about: '關於 beanfun!',
     manageAccount: '管理帳號',
   },
   loginRegion: {
@@ -480,7 +480,7 @@ const zhCN = {
     verify: '进阶验证',
     accounts: '游戏帐号',
     settings: '设置',
-    about: '关于 beanfun! Next',
+    about: '关于 beanfun!',
     manageAccount: '管理帐号',
   },
   loginRegion: {
@@ -691,7 +691,7 @@ const enUS = {
     verify: 'Verification',
     accounts: 'Game Accounts',
     settings: 'Settings',
-    about: 'About beanfun! Next',
+    about: 'About beanfun!',
     manageAccount: 'Manage Accounts',
   },
   loginRegion: {

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -21,7 +21,7 @@
   "GashRemainInGame": " (In-game {0})",
   "GashRefresh": "Refresh Points",
   "GashRecharge": "Top Up",
-  "AppGashRecharge": "Redeem beanfun! App Gash Points",
+  "AppGashRecharge": "Redeem App Gash Points",
   "MemberCenter": "Member Center",
   "CustomerService": "Customer Service",
   "RightClickMenu": "Right-click for menu",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -16,7 +16,7 @@
   "GashRemainInGame": " (游戏内 {0})",
   "GashRefresh": "更新点数",
   "GashRecharge": "充值与购点",
-  "AppGashRecharge": "兑换beanfun!App乐豆点",
+  "AppGashRecharge": "兑换 App 乐豆点",
   "MemberCenter": "会员中心",
   "RightClickMenu": "右键开启菜单",
   "AccountBanned": "账号已锁定",

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -21,7 +21,7 @@
   "GashRemainInGame": " (遊戲內 {0})",
   "GashRefresh": "更新點數",
   "GashRecharge": "儲值與購點",
-  "AppGashRecharge": "兌換beanfun!App樂豆點",
+  "AppGashRecharge": "兌換 App 樂豆點",
   "MemberCenter": "會員中心",
   "CustomerService": "客服中心",
   "RightClickMenu": "右鍵開啟選單",

--- a/src/pages/AccountList.vue
+++ b/src/pages/AccountList.vue
@@ -2711,27 +2711,26 @@ onBeforeUnmount(() => {
 .account-list__quick {
   padding: 0.375rem 0.75rem;
   display: flex;
-  flex-wrap: wrap;
   align-items: center;
-  gap: 0.25rem 0.5rem;
+  justify-content: space-between;
+  gap: 0.5rem;
 }
 
 .account-list__balance {
   display: flex;
   align-items: center;
   gap: 0.375rem;
-  width: 100%;
 }
 
 .account-list__balance-label {
-  font-size: 0.6875rem;
+  font-size: 0.8125rem;
   color: var(--bf-on-surface-variant);
   font-weight: 600;
   white-space: nowrap;
 }
 
 .account-list__balance-value {
-  font-size: 0.8125rem;
+  font-size: 0.9375rem;
   font-weight: 700;
   color: var(--bf-on-surface);
   white-space: nowrap;
@@ -2772,7 +2771,8 @@ onBeforeUnmount(() => {
 }
 
 .account-list__quick-actions {
-  display: flex;
+  display: grid;
+  grid-template-columns: repeat(2, auto);
   gap: 0.25rem;
   flex-shrink: 0;
 }


### PR DESCRIPTION
## Summary

- **AccountList quick-actions layout** — Gash balance row no longer takes a full row; balance + refresh now anchors the left while the four quick-action buttons (recharge / app gash / member center / customer service) sit in a 2×2 grid on the right. Balance label/value font sizes bumped one step (11→13 px / 13→15 px) so the figure stays readable next to the heavier button cluster.
- **Branding cleanup** — drop "beanfun!" from `AppGashRecharge` ("兌換 App 樂豆點" / "Redeem App Gash Points") and the "Next" suffix from the About title ("關於 beanfun!"). Applied across both the active Vue locales (`src/i18n/messages.ts` + `src/locales/*.json`) and the legacy WPF `Lang/*.xaml` resources so the strings stay aligned.

## Notes

- Non-TW regions only render 3 quick-action buttons (no `兌換 App 樂豆點`); the 2×2 grid naturally degrades to "top 2, bottom 1" — no extra logic needed.
- Pure CSS / copy change. No template structure or behaviour change. No new tests required.

## Test plan

- [x] Open `/accounts` (TW account) — verify Gash balance on the left and 4 buttons in 2×2 on the right.
- [x] Open `/accounts` (HK account) — verify 3 buttons render as "top 2, bottom 1" without overflow.
- [x] Open `/about` — title bar reads "關於 beanfun!" (zh-TW), "关于 beanfun!" (zh-CN), "About beanfun!" (en).
- [x] Quick-actions row — `兌換 App 樂豆點` button label has no `beanfun!` prefix in all three locales.
