### PR TITLE
fix(window): symmetric corner radius by dropping inset top highlight (#262)

### DIFF
--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -79,9 +79,20 @@
     linear-gradient(180deg, #f7f1ec 0%, #ece1d6 100%);
   border: 1px solid var(--bf-glass-border);
   border-radius: var(--bf-radius-panel);
-  box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.7),
-    var(--bf-shadow-panel);
+  /*
+   * Issue #262 — drop the `inset 0 1px 0 rgba(255,255,255,0.7)` top
+   * highlight that used to sit alongside `--bf-shadow-panel`. The
+   * 1px highlight only painted along the top edge and traced the
+   * top corners' arc, while the bottom edge had no equivalent
+   * stroke. The eye reads the top corners as visibly more rounded
+   * than the bottom corners (most striking in dark mode where the
+   * white highlight contrasts strongly with the dark surface). Only
+   * `.bf-glass-window` is treated here because it's the only class
+   * that paints the actual window outline; `.bf-glass-panel` /
+   * `.bf-glass-floating` are inner surfaces clipped by this
+   * container's `overflow: hidden` and never touch the outer arc.
+   */
+  box-shadow: var(--bf-shadow-panel);
 }
 
 /* =========================================================================
@@ -276,9 +287,7 @@
       transparent 55%
     ),
     linear-gradient(180deg, #1c1b1f 0%, #141316 100%);
-  box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.06),
-    var(--bf-shadow-panel);
+  box-shadow: var(--bf-shadow-panel);
 }
 
 [data-theme='dark'] .bf-glass-panel {


### PR DESCRIPTION
## Summary

- Drop the asymmetric `inset 0 1px 0 rgba(255,255,255,0.7)` top-only highlight from `.bf-glass-window` that caused the top corners to appear visibly more rounded than the bottom corners (most striking in dark mode).
- All four window corners now render with identical visual weight in both light and dark mode.
- Inner surfaces (`.bf-glass-panel` / `.bf-glass-floating`) are unaffected — their top-highlight glass effect is preserved since they never touch the outer window arc.

## Test plan

- [ ] `npm run typecheck` — passes
- [ ] `npm run lint` — only pre-existing build-artifact error (unrelated)
- [ ] Visual: launch app in **light mode**, verify all four corners of the window have equal radius/weight
- [ ] Visual: launch app in **dark mode**, verify the same symmetry (this was the primary regression)
- [ ] Navigate to AccountList, Settings, About pages — all use `.bf-glass-window` and should show consistent corners

Closes #262
