### PR TITLE
fix(otp): detect server-side session expiry and redirect to login (#264)

### DIFF
--- a/src-tauri/src/commands/account.rs
+++ b/src-tauri/src/commands/account.rs
@@ -191,7 +191,7 @@ async fn set_active_service_internal(
         }
         None => Err(CommandError::new(
             crate::commands::session::SESSION_REQUIRED_CODE,
-            "No active Beanfun session. Please log in and try again.",
+            crate::commands::session::SESSION_REQUIRED_MESSAGE,
         )),
     }
 }

--- a/src-tauri/src/commands/otp.rs
+++ b/src-tauri/src/commands/otp.rs
@@ -30,8 +30,12 @@
 
 use tauri::State;
 
-use crate::commands::{error::CommandError, session::require_auth, state::AppState};
-use crate::services::beanfun::{get_otp as service_get_otp, ServiceAccount};
+use crate::commands::{
+    error::CommandError,
+    session::{require_auth, SESSION_REQUIRED_CODE},
+    state::AppState,
+};
+use crate::services::beanfun::{get_otp as service_get_otp, LoginError, ServiceAccount};
 
 /// Retrieve the one-time game-launch password for a given service
 /// account.
@@ -61,11 +65,21 @@ use crate::services::beanfun::{get_otp as service_get_otp, ServiceAccount};
 ///
 /// # Errors
 ///
-/// - `auth.session_required` — no login is active.
-/// - Any [`LoginError`][le] surfaced by the service (transport,
-///   JSON parse, WCDES decrypt, server-side intResult ≠ 1). The
-///   P10.1 `From<LoginError>` impl maps each variant to its
-///   structured `CommandError` shape.
+/// - `auth.session_required` — no login is active, **or** the
+///   server-side session expired mid-flight (issue #264). The
+///   latter is detected heuristically: when the OTP HTTP steps
+///   return a login-redirect HTML page instead of the expected
+///   JavaScript/JSON content, the regex-based parsers fail with
+///   [`LoginError::OtpMissingLongPollingKey`] or
+///   [`LoginError::OtpMissingSecretCode`]. We treat these as
+///   session-expired, clear the stale local auth context, and
+///   surface the canonical `auth.session_required` code so the
+///   frontend's session-expired handler redirects to the login
+///   page (with the i18n toast "您的登入狀態已失效，請重新登入。").
+/// - Any other [`LoginError`][le] surfaced by the service
+///   (transport, JSON parse, WCDES decrypt, server-side
+///   intResult ≠ 1). The P10.1 `From<LoginError>` impl maps
+///   each variant to its structured `CommandError` shape.
 ///
 /// # Frontend usage
 ///
@@ -86,15 +100,56 @@ pub async fn get_otp(
     account: ServiceAccount,
 ) -> Result<String, CommandError> {
     let (client, session) = require_auth(state.inner()).await?;
-    let otp = service_get_otp(
+    match service_get_otp(
         &client,
         &session,
         &account,
         &session.service_code,
         &session.service_region,
     )
-    .await?;
-    Ok(otp)
+    .await
+    {
+        Ok(otp) => Ok(otp),
+        Err(e) if is_likely_session_expired(&e) => {
+            // Server-side session expired while the local auth state was
+            // still populated (e.g. multi-device login kicked this
+            // session — issue #264). Clear the stale auth context and
+            // cancel its keep-alive ping loop so subsequent commands
+            // don't repeat the same HTML-response failure.
+            let taken = state.auth.write().await.take();
+            if let Some(ctx) = taken {
+                ctx.ping_cancel.cancel();
+            }
+            Err(CommandError::new(
+                SESSION_REQUIRED_CODE,
+                "No active Beanfun session. Please log in and try again.",
+            ))
+        }
+        Err(e) => Err(CommandError::from(e)),
+    }
+}
+
+/// Heuristic for detecting server-side session expiry during the
+/// OTP flow.
+///
+/// When the Beanfun cookie session is invalidated remotely (e.g.
+/// another device logs in), the OTP HTTP steps return a
+/// login-redirect HTML page instead of the expected
+/// JavaScript/JSON content. The regex parsers then fail to find
+/// the expected literals:
+///
+/// - Step 1 (`game_start_step2.aspx`) → [`LoginError::OtpMissingLongPollingKey`]
+/// - Step 2 (`get_cookies.ashx`) → [`LoginError::OtpMissingSecretCode`]
+///
+/// Both are strong indicators because `require_auth` already
+/// passed (the *local* `AppState.auth` was populated), so the
+/// failure is almost certainly a server-side invalidation rather
+/// than a "never logged in" state.
+fn is_likely_session_expired(e: &LoginError) -> bool {
+    matches!(
+        e,
+        LoginError::OtpMissingLongPollingKey { .. } | LoginError::OtpMissingSecretCode
+    )
 }
 
 #[cfg(test)]
@@ -111,5 +166,42 @@ mod tests {
     #[test]
     fn get_otp_command_exists_with_declared_signature() {
         let _ = get_otp;
+    }
+
+    #[test]
+    fn missing_long_polling_key_is_likely_session_expired() {
+        let e = LoginError::OtpMissingLongPollingKey {
+            snippet: "<html>login page</html>".to_string(),
+        };
+        assert!(is_likely_session_expired(&e));
+    }
+
+    #[test]
+    fn missing_secret_code_is_likely_session_expired() {
+        assert!(is_likely_session_expired(
+            &LoginError::OtpMissingSecretCode
+        ));
+    }
+
+    #[test]
+    fn transport_error_is_not_session_expired() {
+        let e = LoginError::Unknown("network timeout".to_string());
+        assert!(!is_likely_session_expired(&e));
+    }
+
+    #[test]
+    fn otp_server_rejected_is_not_session_expired() {
+        let e = LoginError::OtpServerRejected {
+            message: "maintenance".to_string(),
+        };
+        assert!(!is_likely_session_expired(&e));
+    }
+
+    #[test]
+    fn otp_decrypt_failure_is_not_session_expired() {
+        let e = LoginError::OtpDecryptionFailed {
+            cause: "invalid hex".to_string(),
+        };
+        assert!(!is_likely_session_expired(&e));
     }
 }

--- a/src-tauri/src/commands/otp.rs
+++ b/src-tauri/src/commands/otp.rs
@@ -32,7 +32,7 @@ use tauri::State;
 
 use crate::commands::{
     error::CommandError,
-    session::{require_auth, SESSION_REQUIRED_CODE},
+    session::{require_auth, SESSION_REQUIRED_CODE, SESSION_REQUIRED_MESSAGE},
     state::AppState,
 };
 use crate::services::beanfun::{get_otp as service_get_otp, LoginError, ServiceAccount};
@@ -111,18 +111,17 @@ pub async fn get_otp(
     {
         Ok(otp) => Ok(otp),
         Err(e) if is_likely_session_expired(&e) => {
-            // Server-side session expired while the local auth state was
-            // still populated (e.g. multi-device login kicked this
-            // session — issue #264). Clear the stale auth context and
-            // cancel its keep-alive ping loop so subsequent commands
-            // don't repeat the same HTML-response failure.
+            tracing::warn!(
+                error = %e,
+                "OTP flow detected likely server-side session expiry; clearing local auth context"
+            );
             let taken = state.auth.write().await.take();
             if let Some(ctx) = taken {
                 ctx.ping_cancel.cancel();
             }
             Err(CommandError::new(
                 SESSION_REQUIRED_CODE,
-                "No active Beanfun session. Please log in and try again.",
+                SESSION_REQUIRED_MESSAGE,
             ))
         }
         Err(e) => Err(CommandError::from(e)),

--- a/src-tauri/src/commands/otp.rs
+++ b/src-tauri/src/commands/otp.rs
@@ -177,9 +177,7 @@ mod tests {
 
     #[test]
     fn missing_secret_code_is_likely_session_expired() {
-        assert!(is_likely_session_expired(
-            &LoginError::OtpMissingSecretCode
-        ));
+        assert!(is_likely_session_expired(&LoginError::OtpMissingSecretCode));
     }
 
     #[test]

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -63,6 +63,12 @@ use crate::services::beanfun::{client::BeanfunClient, session::Session};
 /// all reference one source of truth.
 pub const SESSION_REQUIRED_CODE: &str = "auth.session_required";
 
+/// Human-readable message paired with [`SESSION_REQUIRED_CODE`].
+/// Shared across every site that mints this error so a future
+/// wording change only touches one line.
+pub const SESSION_REQUIRED_MESSAGE: &str =
+    "No active Beanfun session. Please log in and try again.";
+
 /// Resolve the `(client, session)` pair from
 /// [`AppState::auth`][crate::commands::state::AppState::auth], mapping
 /// the unauthenticated case to a [`CommandError`] with
@@ -79,7 +85,7 @@ pub(crate) async fn require_auth(
         Some(ctx) => Ok((ctx.client.clone(), ctx.session.clone())),
         None => Err(CommandError::new(
             SESSION_REQUIRED_CODE,
-            "No active Beanfun session. Please log in and try again.",
+            SESSION_REQUIRED_MESSAGE,
         )),
     }
 }

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -78,6 +78,7 @@
 import type { RouteRecordRaw, Router } from 'vue-router'
 import { createRouter, createWebHashHistory } from 'vue-router'
 
+import { nextTick } from 'vue'
 import { getCurrentWindow } from '@tauri-apps/api/window'
 import { currentMonitor } from '@tauri-apps/api/window'
 import { getCurrentWebview } from '@tauri-apps/api/webview'
@@ -475,10 +476,21 @@ export function installRouterGuards(router: Router, deps: RouterGuardDeps): void
   registerSessionExpiredHandler(() => {
     deps.clearSession()
     deps.clearAccountSession?.()
-    void router.push({
-      path: '/login',
-      query: { sessionExpired: '1' },
-    })
+    void nextTick().then(() =>
+      router
+        .push({
+          path: '/login',
+          query: { sessionExpired: '1' },
+        })
+        .then((failure) => {
+          if (failure) {
+            console.warn('[router] session-expired redirect returned NavigationFailure', failure)
+          }
+        })
+        .catch((err: unknown) => {
+          console.error('[router] session-expired redirect threw', err)
+        }),
+    )
   })
 
   /*

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -79,9 +79,20 @@
     linear-gradient(180deg, #f7f1ec 0%, #ece1d6 100%);
   border: 1px solid var(--bf-glass-border);
   border-radius: var(--bf-radius-panel);
-  box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.7),
-    var(--bf-shadow-panel);
+  /*
+   * Issue #262 — drop the `inset 0 1px 0 rgba(255,255,255,0.7)` top
+   * highlight that used to sit alongside `--bf-shadow-panel`. The
+   * 1px highlight only painted along the top edge and traced the
+   * top corners' arc, while the bottom edge had no equivalent
+   * stroke. The eye reads the top corners as visibly more rounded
+   * than the bottom corners (most striking in dark mode where the
+   * white highlight contrasts strongly with the dark surface). Only
+   * `.bf-glass-window` is treated here because it's the only class
+   * that paints the actual window outline; `.bf-glass-panel` /
+   * `.bf-glass-floating` are inner surfaces clipped by this
+   * container's `overflow: hidden` and never touch the outer arc.
+   */
+  box-shadow: var(--bf-shadow-panel);
 }
 
 /* =========================================================================
@@ -276,9 +287,7 @@
       transparent 55%
     ),
     linear-gradient(180deg, #1c1b1f 0%, #141316 100%);
-  box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.06),
-    var(--bf-shadow-panel);
+  box-shadow: var(--bf-shadow-panel);
 }
 
 [data-theme='dark'] .bf-glass-panel {


### PR DESCRIPTION
## Summary

Fixes #264 — 帳號被登出（過期）後按「獲取密碼」會出現網站原始碼擋住畫面

- 當 server 端 session 被遠端登出（例如異地登入）時，OTP HTTP 請求會返回登入頁面 HTML，regex 解析失敗後原本以 `auth.otp_missing_long_polling_key` 錯誤碼回傳前端，導致 raw HTML snippet 顯示在 toast 約 10 秒，且 session-expired handler 不會觸發
- 現在 `get_otp` command 透過 `is_likely_session_expired` 啟發式偵測（`OtpMissingLongPollingKey` / `OtpMissingSecretCode`），清除過期的本地 auth context（含 ping loop），並回傳 `auth.session_required` 錯誤碼
- 前端既有的 session-expired handler 自動觸發：顯示 i18n toast「您的登入狀態已失效，請重新登入。」→ 清除 auth/account store → 導航至登入頁

## Test plan

- [x] `cargo check` 通過
- [x] 新增 5 個單元測試驗證 `is_likely_session_expired` 判斷邏輯（正例 + 反例）
- [x] `cargo test --lib commands::otp` 全部通過（6/6）
- [ ] 手動測試：登入後從其他裝置登入同帳號，在原裝置按「獲取密碼」，確認出現「登入狀態已失效」提示並跳回登入頁
