### PR TITLE
fix(auth): prefetch accounts during login to eliminate loading gap

### DIFF
--- a/src-tauri/src/commands/account.rs
+++ b/src-tauri/src/commands/account.rs
@@ -79,6 +79,24 @@ use crate::services::beanfun::{
 /// [bc]: crate::services::beanfun::BeanfunClient
 /// [sesh]: crate::services::beanfun::Session
 async fn list_accounts_internal(state: &AppState) -> Result<AccountListResult, CommandError> {
+    /*
+     * #263: Check if accounts were prefetched during login. If so, return
+     * the cached data immediately (mirrors WPF where `BeanfunClient.Login`
+     * already called `GetAccounts`). This eliminates the "blank loading
+     * state" gap between login and AccountList render.
+     */
+    {
+        let mut guard = state.prefetched_accounts.write().await;
+        if let Some(accounts) = guard.take() {
+            tracing::debug!(
+                account_count = accounts.accounts.len(),
+                "get_accounts: returning prefetched data"
+            );
+            return Ok(accounts);
+        }
+    }
+
+    // No prefetched data — fetch from server
     let (client, session) = require_auth(state).await?;
     let result = service_get_accounts(
         &client,

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -100,6 +100,7 @@ use crate::commands::{
     state::{AppState, AuthContext, PendingGamepass, PendingQr, PendingTotp, PendingVerify},
 };
 use crate::services::beanfun::{
+    account::get_accounts as service_get_accounts,
     client::{BeanfunClient, ClientConfig, LoginRegion},
     login::{
         finalize_qr_login, get_session_key, init_qr_login, inject_webview_cookies,
@@ -158,7 +159,7 @@ async fn install_session_and_start_ping(
     session: Session,
 ) -> SessionInfo {
     let info = SessionInfo::from(&session);
-    let ctx = AuthContext::new(client, session);
+    let ctx = AuthContext::new(client.clone(), session.clone());
     let ping_client = ctx.client.clone();
     let ping_cancel = ctx.ping_cancel.clone();
 
@@ -170,6 +171,39 @@ async fn install_session_and_start_ping(
     let prev = state.auth.write().await.replace(ctx);
     if let Some(prev_ctx) = prev {
         prev_ctx.ping_cancel.cancel();
+    }
+
+    /*
+     * #263: Prefetch accounts immediately after login success, mirroring
+     * WPF behaviour where `BeanfunClient.Login` calls `GetAccounts` before
+     * returning. This ensures account data is available by the time the
+     * frontend navigates to AccountList, eliminating the "blank loading
+     * state" gap. Errors are logged but not surfaced — the frontend will
+     * still call `get_accounts` and handle the error there with proper UX.
+     */
+    match service_get_accounts(
+        &client,
+        &session,
+        &session.service_code,
+        &session.service_region,
+    )
+    .await
+    {
+        Ok(accounts) => {
+            tracing::debug!(
+                account_count = accounts.accounts.len(),
+                "prefetch: accounts loaded during login"
+            );
+            // Store the prefetched accounts so the frontend can use them immediately
+            let mut guard = state.prefetched_accounts.write().await;
+            *guard = Some(accounts);
+        }
+        Err(err) => {
+            tracing::warn!(
+                ?err,
+                "prefetch: get_accounts failed during login (frontend will retry)"
+            );
+        }
     }
 
     spawn_ping_loop(ping_client, ping_cancel);
@@ -1794,6 +1828,7 @@ pub async fn submit_verify(
 /// `tracing` logs (if any) read consistently in debugging.
 async fn clear_all_auth_state(state: &AppState) {
     *state.auth.write().await = None;
+    *state.prefetched_accounts.write().await = None;
     *state.pending_totp.write().await = None;
     *state.pending_qr.write().await = None;
     *state.pending_verify.write().await = None;

--- a/src-tauri/src/commands/state.rs
+++ b/src-tauri/src/commands/state.rs
@@ -457,6 +457,14 @@ pub struct AppState {
     /// logout) are rare and exclusive.
     pub auth: RwLock<Option<AuthContext>>,
 
+    /// #263: Prefetched account list from the login flow.
+    /// Populated by `install_session_and_start_ping` (mirrors WPF's
+    /// `BeanfunClient.Login` calling `GetAccounts` before returning).
+    /// The frontend `get_accounts` command checks this slot first and
+    /// returns the cached data if present, eliminating the "blank
+    /// loading state" gap. Cleared on logout and after being consumed.
+    pub prefetched_accounts: RwLock<Option<crate::services::beanfun::account::AccountListResult>>,
+
     /// Backend-held TOTP continuation — see [`PendingTotp`] for the
     /// full lifecycle. `None` whenever no login is awaiting a
     /// 6-digit OTP response. Uses its own [`RwLock`] rather than
@@ -524,6 +532,7 @@ impl AppState {
         Self {
             storage_root,
             auth: RwLock::new(None),
+            prefetched_accounts: RwLock::new(None),
             pending_totp: RwLock::new(None),
             pending_qr: RwLock::new(None),
             pending_verify: RwLock::new(None),

--- a/src/pages/AccountList.vue
+++ b/src/pages/AccountList.vue
@@ -192,7 +192,14 @@ const launcher = useGameLauncher()
 
 type LoadState = 'loading' | 'ready' | 'error'
 
-const loadState = ref<LoadState>('loading')
+/*
+ * #263: Initialize loadState based on whether data is already present
+ * from a login-form prefetch. This eliminates the "blank loading state"
+ * gap when navigating from login forms that already called getServiceAccounts.
+ * Mirrors WPF behaviour where `BeanfunClient.Login` populates `accountList`
+ * before navigation, so `redrawSAccountList` renders immediately.
+ */
+const loadState = ref<LoadState>(account.serviceAccounts.length > 0 ? 'ready' : 'loading')
 /**
  * Backend-supplied error message kept alongside `loadState` so the
  * inline banner can surface the actual server reason without the
@@ -202,7 +209,14 @@ const loadState = ref<LoadState>('loading')
 const loadError = ref<string | null>(null)
 
 async function loadList(): Promise<void> {
-  loadState.value = 'loading'
+  /*
+   * #263: Only show loading state if there's no data yet. If the store
+   * already has accounts (from login-form prefetch), keep showing the
+   * existing data while the refresh runs in the background.
+   */
+  if (account.serviceAccounts.length === 0) {
+    loadState.value = 'loading'
+  }
   loadError.value = null
   try {
     await account.getServiceAccounts()


### PR DESCRIPTION
Fixes the race condition where the AccountList page shows a blank loading state after successful login. The issue was that the SPA performed login and account fetching as separate async operations, causing a visible gap between navigation and data display.

This PR mirrors the WPF behaviour where `BeanfunClient.Login` calls `GetAccounts` internally before returning, ensuring account data is available immediately when the AccountList page mounts.