### PR TITLE
fix(ui): Windows DPI and Text Size scaling for WebView UI (#261)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -330,7 +330,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "beanfun"
-version = "5.9.6"
+version = "5.9.7"
 dependencies = [
  "aes",
  "anyhow",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -343,12 +343,15 @@ pub fn run() {
                 .eq_ignore_ascii_case("true");
 
         let mut args = vec![
-            // Lock rendering to 1:1 physical pixels so the app layout
-            // is immune to Windows "Text size" / DPI scaling. The
-            // router's fitWindow compensates by dividing the logical
-            // window size by the OS scale factor.
+            // Keep the existing DPI/resolution behaviour: render at
+            // 1:1 physical pixels and let the router's fitWindow
+            // compensate the logical window size.
             "--force-device-scale-factor=1".to_string(),
+            // Treat Windows Accessibility "Text size" as 100% so
+            // user text-size changes do not inflate app content.
+            "--force-text-scale-factor=1".to_string(),
         ];
+        tracing::info!("forcing WebView2 device scale and text scale factors");
 
         if disable_hw_accel {
             args.push("--disable-gpu".to_string());

--- a/src/App.vue
+++ b/src/App.vue
@@ -122,7 +122,8 @@ onMounted(async () => {
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  -webkit-text-size-adjust: 100%;
+  -webkit-text-size-adjust: none;
+  text-size-adjust: none;
 }
 
 html,

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -86,6 +86,13 @@ import { PhysicalSize } from '@tauri-apps/api/dpi'
 
 import { registerSessionExpiredHandler } from '../services/invoke'
 
+let cachedWindowZoom = 1
+
+function physicalWindowSize(width: number, height: number): PhysicalSize {
+  const zoom = Math.max(1, cachedWindowZoom)
+  return new PhysicalSize(Math.ceil(width * zoom), Math.ceil(height * zoom))
+}
+
 /**
  * Resize the Tauri window to the given logical dimensions.
  * Exported so individual pages can call it on mount when their
@@ -93,7 +100,7 @@ import { registerSessionExpiredHandler } from '../services/invoke'
  * Settings page without the Game section when unauthenticated).
  */
 export function resizeWindow(width: number, height: number): void {
-  void getCurrentWindow().setSize(new PhysicalSize(width, height))
+  void getCurrentWindow().setSize(physicalWindowSize(width, height))
 }
 
 import LoginPage from '../pages/LoginPage.vue'
@@ -554,27 +561,28 @@ export function installRouterGuards(router: Router, deps: RouterGuardDeps): void
    * Falls back to 900 when `window.screen` is unavailable (jsdom /
    * headless CI) so the spec harness keeps working.
    */
-  async function getMonitorHeight(): Promise<number> {
+  async function refreshMonitorMetrics(): Promise<void> {
     try {
       const monitor = await currentMonitor()
       if (monitor) {
-        // monitor.size is physical pixels; divide by scaleFactor to get logical pixels
-        return Math.floor(monitor.size.height / monitor.scaleFactor)
+        const isUhdMonitor = monitor.size.width >= 3840 || monitor.size.height >= 2160
+        cachedWindowZoom = isUhdMonitor ? Math.max(1, monitor.scaleFactor || 1) : 1
+        monitorHeight = Math.floor(monitor.size.height)
+        return
       }
     } catch {
       // fall through to CSS fallback
     }
     // CSS fallback — may be inaccurate on some WebView2 configs
     const avail = typeof window !== 'undefined' ? window.screen?.availHeight : undefined
-    return typeof avail === 'number' && avail > 0 ? avail : 900
+    cachedWindowZoom = 1
+    monitorHeight = typeof avail === 'number' && avail > 0 ? avail : 900
   }
 
   let monitorHeight = 900
 
-  // Fetch monitor height once on init and refresh on DPI change.
-  void getMonitorHeight().then((h) => {
-    monitorHeight = h
-  })
+  // Fetch monitor height/scale once on init and refresh on DPI change.
+  void refreshMonitorMetrics()
 
   function maxFitHeight(): number {
     // Leave 5% for taskbar + breathing room.
@@ -604,15 +612,16 @@ export function installRouterGuards(router: Router, deps: RouterGuardDeps): void
     const scrollH = root.scrollHeight
     if (scroll) scroll.style.overflow = ''
     const cap = maxFitHeight()
-    let zoom = 1.0
-    if (scrollH > cap) {
+    const nativeZoom = Math.max(1, cachedWindowZoom)
+    let zoom = nativeZoom
+    if (scrollH * zoom > cap) {
       zoom = cap / scrollH
     }
     const contentH = Math.ceil(scrollH * zoom)
     const h = Math.max(300, Math.min(contentH, cap))
     root.style.height = '100vh'
     void getCurrentWebview().setZoom(zoom)
-    void appWindow.setSize(new PhysicalSize(currentWidth, h))
+    void appWindow.setSize(new PhysicalSize(Math.ceil(currentWidth * zoom), h))
   }
 
   /**
@@ -694,6 +703,7 @@ export function installRouterGuards(router: Router, deps: RouterGuardDeps): void
     // A 1rem sentinel element detects font-size changes.
     if (typeof window !== 'undefined') {
       window.addEventListener('resize', () => scheduleOnNextPaint(fitWindow), { passive: true })
+      void refreshMonitorMetrics().then(() => scheduleOnNextPaint(fitWindow))
 
       // Sentinel: a 0-size element whose width is 1rem. When the
       // system font size changes, its pixel width changes and

--- a/src/types/bindings.ts
+++ b/src/types/bindings.ts
@@ -1113,11 +1113,21 @@ async setActiveService(serviceCode: string, serviceRegion: string) : Promise<Res
  * 
  * # Errors
  * 
- * - `auth.session_required` — no login is active.
- * - Any [`LoginError`][le] surfaced by the service (transport,
- * JSON parse, WCDES decrypt, server-side intResult ≠ 1). The
- * P10.1 `From<LoginError>` impl maps each variant to its
- * structured `CommandError` shape.
+ * - `auth.session_required` — no login is active, **or** the
+ * server-side session expired mid-flight (issue #264). The
+ * latter is detected heuristically: when the OTP HTTP steps
+ * return a login-redirect HTML page instead of the expected
+ * JavaScript/JSON content, the regex-based parsers fail with
+ * [`LoginError::OtpMissingLongPollingKey`] or
+ * [`LoginError::OtpMissingSecretCode`]. We treat these as
+ * session-expired, clear the stale local auth context, and
+ * surface the canonical `auth.session_required` code so the
+ * frontend's session-expired handler redirects to the login
+ * page (with the i18n toast "您的登入狀態已失效，請重新登入。").
+ * - Any other [`LoginError`][le] surfaced by the service
+ * (transport, JSON parse, WCDES decrypt, server-side
+ * intResult ≠ 1). The P10.1 `From<LoginError>` impl maps
+ * each variant to its structured `CommandError` shape.
  * 
  * # Frontend usage
  * 


### PR DESCRIPTION
## Summary

Fix Windows DPI/Text Size handling for the Tauri WebView UI.

This keeps the existing DPI/resolution behaviour stable while preventing Windows Accessibility Text Size from scaling the app content.

## Changes

- Keep WebView2 `--force-device-scale-factor=1` so existing DPI/resolution positioning remains stable.
- Add `--force-text-scale-factor=1` so Windows Accessibility Text Size is treated as 100%.
- Disable browser text auto scaling via `text-size-adjust: none`.
- Add UHD-only window zoom compensation:
  - 4K/UHD displays use monitor `scaleFactor` so content stays readable.
  - 1080p/2K displays keep zoom at `1` so the app does not become oversized.
- Refresh monitor scale metrics during window fitting so display changes are reflected without involving Windows Text Size.


## Notes

WebView2 browser arguments only apply when the Tauri process starts, so manual verification requires fully restarting the app process, not just Vite HMR/page reload.

Closes #261