### PR TITLE
fix(theme): restore dark-mode contrast for QR form title, secondary buttons, and OTP field

### DIFF
--- a/src/pages/AccountList.vue
+++ b/src/pages/AccountList.vue
@@ -3262,7 +3262,20 @@ onBeforeUnmount(() => {
 
 .account-list__otp-field {
   width: 100%;
-  background: rgba(226, 226, 226, 0.3);
+  /*
+   * Issue #272 — was a literal `rgba(226, 226, 226, 0.3)` (a
+   * light-grey wash that read fine on the warm light-mode
+   * glass panel). In dark mode the same grey overlay landed
+   * on top of the `#252529` panel and produced a low-contrast
+   * smudge with the placeholder text inside it. Route the
+   * background through `color-mix` against the token's
+   * on-surface colour: 8% in light mode reproduces the same
+   * faint grey lift the original literal achieved, and in
+   * dark mode the same 8% becomes a subtle white tint (on
+   * `#e6e1e5`) that gives the field a visible chrome edge
+   * without blowing out brightness.
+   */
+  background: color-mix(in srgb, var(--bf-on-surface) 8%, transparent);
   border: 0;
   border-bottom: 2px solid var(--bf-outline-variant);
   font-family: 'JetBrains Mono', 'Consolas', ui-monospace, monospace;
@@ -3274,6 +3287,19 @@ onBeforeUnmount(() => {
   color: var(--bf-on-surface);
   cursor: default;
   transition: border-color var(--bf-motion-fast);
+}
+
+/*
+ * Issue #272 — the OTP "尚未取得" placeholder used the browser
+ * default (`color` * ~54% in WebView2), which produced
+ * unreadable dark-grey-on-dark-grey in dark mode. Pin the
+ * placeholder to `--bf-on-surface-variant` (`#54443a` light /
+ * `#c9c5ca` dark) at 70% opacity so it still reads as
+ * secondary text while staying legible in both themes.
+ */
+.account-list__otp-field::placeholder {
+  color: var(--bf-on-surface-variant);
+  opacity: 0.7;
 }
 
 .account-list__otp-field:focus {

--- a/src/pages/QrForm.vue
+++ b/src/pages/QrForm.vue
@@ -432,13 +432,29 @@ function handleGameStart(): void {
   margin: 0;
   font-size: 1rem;
   font-weight: 700;
-  color: #1f1a16;
+  /*
+   * Issue #272 — was hardcoded `#1f1a16` (the light-mode WPF dark
+   * brown). In dark mode the page background flips to ~#1c1b1f
+   * but this dark-on-dark text became unreadable. Route through
+   * `--bf-on-surface` so the token bridge in `design-tokens.css`
+   * (`#221a11` light / `#e6e1e5` dark) handles the contrast flip
+   * for free, matching every other glass-panel heading.
+   */
+  color: var(--bf-on-surface);
 }
 
 .qr-form__subtitle {
   margin: 0.375rem 0 0;
   font-size: 0.8125rem;
-  color: #54443a;
+  /*
+   * Issue #272 — same fix as the title. The literal `#54443a`
+   * was the light-mode WPF "muted body copy" color; in dark
+   * mode it would render as a barely-visible smudge against the
+   * dark glass background. `--bf-on-surface-variant` flips to
+   * `#c9c5ca` in dark mode, mirroring the contrast tier the
+   * mockups use for secondary text.
+   */
+  color: var(--bf-on-surface-variant);
 }
 
 .qr-form__display {

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -323,6 +323,31 @@
   color: #ffffff;
 }
 
+/*
+ * Issue #272 — `.bf-btn-secondary` baseline (above) hardcodes
+ * `background: rgba(255, 255, 255, 0.6)` for the light-mode
+ * frosted look, but the `color` property routes through
+ * `--bf-on-surface` (which flips to `#e6e1e5` in dark mode).
+ * The result on the dark theme was a white-on-white button
+ * (Settings page "管理帳號" / "工具" / "返回") that the user
+ * couldn't read. Mirror the bf-glass-card dark recipe: drop
+ * the white sheet to an 8%-alpha lift over the dark panel
+ * (visible chrome edge without blasting the eye), match the
+ * border to the same 12% white the glass-card uses, and bump
+ * the hover state to 16% for the same +0.08 alpha delta the
+ * light theme uses (0.6 → 0.85, ~+0.25 visual lift). `color`
+ * stays on the token — `--bf-on-surface` `#e6e1e5` reads
+ * cleanly against the new 8% lift.
+ */
+[data-theme='dark'] .bf-btn-secondary {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.12);
+}
+
+[data-theme='dark'] .bf-btn-secondary:hover {
+  background: rgba(255, 255, 255, 0.16);
+}
+
 [data-theme='dark'] .bf-custom-scrollbar::-webkit-scrollbar-thumb {
   background-color: rgba(255, 255, 255, 0.2);
 }


### PR DESCRIPTION
Closes #272.

## Summary

Restore dark-mode contrast on three surfaces called out in #272:

1. **QR login page header** (`pages/QrForm.vue`) — title + subtitle were hardcoded to light-mode dark-brown hex (`#1f1a16` / `#54443a`), producing dark-on-dark text on the dark theme. Route both through the existing `--bf-on-surface` / `--bf-on-surface-variant` tokens.
2. **Secondary buttons on the Settings page** (`styles/utilities.css`) — `.bf-btn-secondary` baseline pins `background: rgba(255, 255, 255, 0.6)` but `color` follows `--bf-on-surface`, which becomes `#e6e1e5` in dark mode → the **Manage Account / Tools / Back** buttons rendered as white-on-white. Add a `[data-theme='dark']` override that drops the white sheet to an 8 % lift (16 % on hover) over the dark panel, matching the existing `bf-glass-card` dark recipe.
3. **OTP "尚未取得" placeholder** (`pages/AccountList.vue`) — `.account-list__otp-field` used a literal grey wash for the background and relied on the browser-default placeholder colour. Both collapsed to dark-on-dark in dark mode. Route the background through `color-mix` against `--bf-on-surface` (so the lift flips with the theme) and pin the placeholder to `--bf-on-surface-variant` at 70 % opacity.

## Why the token approach

`src/styles/design-tokens.css` already bridges every `--bf-*` colour to a `[data-theme='dark']` counterpart. The three regressions all came from local CSS that bypassed the bridge — either by inlining a light-mode hex (issues 1 & 3) or by inlining a light-mode rgba while still routing the foreground through a token (issue 2). Re-routing through the existing tokens (and adding the one missing dark override for `.bf-btn-secondary`) keeps the fix DRY without re-declaring colours, and any future theme adjustment lands in one place (`design-tokens.css`).

## Changes

| File | Change |
| --- | --- |
| `src/pages/QrForm.vue` | `.qr-form__title` / `.qr-form__subtitle` `color` → `--bf-on-surface` / `--bf-on-surface-variant` |
| `src/styles/utilities.css` | new `[data-theme='dark'] .bf-btn-secondary` + hover override (rgba 0.08 / 0.16, border 0.12) |
| `src/pages/AccountList.vue` | `.account-list__otp-field` background → `color-mix(in srgb, var(--bf-on-surface) 8%, transparent)`; new `::placeholder` rule pinned to `--bf-on-surface-variant` at opacity 0.7 |

## Test plan

- [x] `npx prettier --check` on the three touched files — passes
- [x] `npm run typecheck` — passes
- [x] `npm test` — 41 files / 599 tests pass
- [x] `npm run lint` — only the pre-existing `src-tauri/target-test/.../__global-api-script.js` build-artifact warning (same one previous PRs noted as out-of-scope)
- [ ] Manual smoke (reviewer): switch to dark mode + verify
  - QR login page title/subtitle are legible
  - Settings page **Manage Account / Tools / Back** buttons read cleanly
  - AccountList OTP **尚未取得** placeholder is readable when the field is empty
