### PR TITLE
fix(theme): restore dark-mode contrast for QR enlarge/copy buttons

### DIFF
--- a/src/pages/QrForm.vue
+++ b/src/pages/QrForm.vue
@@ -556,6 +556,15 @@ function handleGameStart(): void {
   background: rgba(255, 255, 255, 0.9);
 }
 
+[data-theme='dark'] .qr-form__qr-btn {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.12);
+}
+
+[data-theme='dark'] .qr-form__qr-btn:hover {
+  background: rgba(255, 255, 255, 0.16);
+}
+
 .qr-form__overlay {
   position: fixed;
   inset: 0;


### PR DESCRIPTION
## Summary
- The QR login page's Enlarge and Copy QR buttons use a local scoped class `.qr-form__qr-btn` instead of the shared `bf-btn-secondary`, so the #272 dark-mode contrast fix (73f7821) missed them
- In dark mode the buttons still render with `rgba(255,255,255,0.6)` white background, making the text nearly invisible
- Add `[data-theme='dark']` overrides mirroring the `bf-btn-secondary` dark recipe: 8% white lift / 12% white border / 16% hover

## Test plan
- [ ] Switch to dark mode, navigate to the QR login page, and verify the Enlarge and Copy QR buttons have readable text
- [ ] Confirm hover state shows a visible brightness lift
- [ ] Confirm light-mode button appearance is unaffected
