### PR TITLE
fix(AccountList): sync selected game before using cached accounts (#274)

### DIFF
--- a/src/pages/AccountList.vue
+++ b/src/pages/AccountList.vue
@@ -905,8 +905,17 @@ async function setupGameOnMount(): Promise<void> {
    * reset" because the persistent CSV (`AccountOrder_<code>_<region>`)
    * is only re-applied AFTER the HTTP response lands.
    *
-   * Skipping is safe because every code path that *should*
-   * cause a re-fetch already clears `serviceAccounts` first:
+   * Skipping is safe only when the cached account list still
+   * belongs to the same game the UI says is active. A routed
+   * remount can preserve `game.selectedGameCode` from Config.xml /
+   * previous selection even while the backend session is still
+   * pinned to the login default; in that mismatch shape we must
+   * fall through to `selectActiveGame` so `setActiveService`
+   * runs before the next account-list fetch.
+   *
+   * Every code path that *should* cause a re-fetch either clears
+   * `serviceAccounts` first or leaves selectedGame/session
+   * intentionally mismatched:
    *
    * - logout / session expired → `clearAccountSession` resets
    *   the store (router guard + `registerSessionExpiredHandler`).
@@ -920,7 +929,14 @@ async function setupGameOnMount(): Promise<void> {
    * sentinel forever (no `loadList` to flip it to `'ready'`),
    * so we flip it inline before returning.
    */
-  if (account.serviceAccounts.length > 0 && auth.session !== null) {
+  const session = auth.session
+  const selectedGameCode = game.selectedGameCode
+  const sessionGameCode =
+    session !== null ? gameCodeOf(session.service_code, session.service_region) : null
+  const cachedAccountsMatchSession =
+    selectedGameCode === null || selectedGameCode === sessionGameCode
+
+  if (account.serviceAccounts.length > 0 && session !== null && cachedAccountsMatchSession) {
     loadState.value = 'ready'
     return
   }
@@ -933,8 +949,6 @@ async function setupGameOnMount(): Promise<void> {
   }
 
   const saved = configStore.get('loginGame') ?? ''
-  const session = auth.session
-
   if (saved && session) {
     const sep = saved.lastIndexOf('_')
     if (sep > 0) {

--- a/tests/unit/pages/AccountList.spec.ts
+++ b/tests/unit/pages/AccountList.spec.ts
@@ -2193,6 +2193,51 @@ describe('AccountList page', () => {
     expect(useAccountStore().selectedSid).toBe(POPULATED_LIST.accounts[0]!.sid)
   })
 
+  it('does not fast-path cached accounts when selected game differs from session', async () => {
+    /*
+     * Regression for issue #274: the UI could retain the previous
+     * selected game (e.g. Mabinogi icon/name) while the authenticated
+     * backend session and cached account list still belonged to the
+     * login-default game (e.g. MapleStory). The old remount fast-path
+     * only checked "accounts exist", skipped `setActiveService`, and
+     * left users looking at MapleStory accounts under a Mabinogi
+     * header until they manually switched away and back.
+     */
+    vi.mocked(commands.listGames).mockReturnValueOnce(
+      ok({
+        ini: {
+          '610074_T9': MAPLESTORY_TW_INI,
+          '610153_TN': MABINOGI_TN_INI,
+        },
+        services: [MAPLESTORY_TW, MABINOGI_TN],
+      }),
+    )
+    vi.mocked(commands.getAccounts).mockReturnValueOnce(ok(POPULATED_LIST))
+
+    useAuthStore().session = { ...FAKE_SESSION, service_code: '610074', service_region: 'T9' }
+    useConfigStore().entries['loginGame'] = '610153_TN'
+
+    const gameStore = useGameStore()
+    gameStore.selectedGameCode = '610153_TN'
+
+    const accountStore = useAccountStore()
+    accountStore.serviceAccounts = POPULATED_LIST.accounts
+    accountStore.selectedSid = 'sid-stale'
+
+    const ctx = buildHarness()
+    await ctx.mountIt()
+    await flushPromises()
+
+    expect(commands.listGames).toHaveBeenCalledTimes(1)
+    expect(commands.setActiveService).toHaveBeenCalledTimes(1)
+    expect(commands.setActiveService).toHaveBeenCalledWith('610153', 'TN')
+    expect(commands.getAccounts).toHaveBeenCalledTimes(1)
+    expect(useAuthStore().session?.service_code).toBe('610153')
+    expect(useAuthStore().session?.service_region).toBe('TN')
+    expect(useGameStore().selectedGameCode).toBe('610153_TN')
+    expect(useAccountStore().selectedSid).toBe('sid-1')
+  })
+
   it('still re-fetches on remount when serviceAccounts cache is empty (cold mount baseline)', async () => {
     /*
      * Sanity-check the negative branch: empty store + live session


### PR DESCRIPTION
### What
When the UI restores a previously selected game such as Mabinogi, AccountList can still reuse cached accounts from the login-default backend session, such as MapleStory. This makes the game icon/name and account list disagree until the user manually switches to another game and back.

### Fix
Tighten the AccountList remount fast-path so cached service accounts are only reused when the selected game matches the authenticated session game.

If `game.selectedGameCode` differs from `auth.session.service_code/service_region`, fall through to the normal game bootstrap path. That lets `selectActiveGame()` call `setActiveService()` before reloading accounts, keeping the displayed game and account list in sync.

Adds regression coverage for the Mabinogi-selected / MapleStory-session mismatch.

Closes #274