### PR TITLE
fix(Windows): use opaque glass fallback on Windows 10

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -199,6 +199,7 @@ pub fn build_specta_builder<R: tauri::Runtime>() -> Builder<R> {
         // system (P10.1)
         system::version,
         system::ping,
+        system::window_visual_environment,
         // auth (P10.2 — regular family)
         auth::login_regular,
         auth::login_totp,
@@ -426,6 +427,7 @@ mod bindings_file_tests {
         // --- P10.1 — system smoke ------------------------------------
         "version",
         "ping",
+        "windowVisualEnvironment",
         // --- P10.2 — auth regular family -----------------------------
         "loginRegular",
         "loginTotp",
@@ -538,6 +540,7 @@ mod bindings_file_tests {
         // --- P10.1 ---------------------------------------------------
         "CommandError",
         "VersionInfo",
+        "WindowVisualEnvironment",
         // --- P10.2 — auth / session ---------------------------------
         "SessionInfo",
         "LoginRegion",

--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -73,6 +73,21 @@ pub struct VersionInfo {
     pub tauri: String,
 }
 
+/// Runtime visual-environment hints consumed by the frontend before
+/// mounting.
+///
+/// Kept intentionally narrow: the frontend only needs to know when
+/// the host cannot safely use the Win11-style translucent glass recipe
+/// over a transparent Tauri window.
+#[derive(Debug, Clone, Serialize, Type)]
+pub struct WindowVisualEnvironment {
+    /// `true` on Windows builds whose build number is below 22000
+    /// (Windows 10). Those hosts need an opaque CSS fallback because
+    /// DWM/WebView2 transparency does not match Windows 11's Mica-like
+    /// composition.
+    pub is_windows_10: bool,
+}
+
 /// Return the static build metadata. Infallible; no parameters; no
 /// state.
 ///
@@ -86,6 +101,20 @@ pub fn version() -> VersionInfo {
     VersionInfo {
         app: env!("CARGO_PKG_VERSION").to_string(),
         tauri: tauri::VERSION.to_string(),
+    }
+}
+
+/// Return host visual-environment flags used by the web UI.
+///
+/// This is deliberately separate from [`version`]: build metadata is
+/// static, while this value depends on the user's OS. It is still
+/// synchronous and infallible so the frontend can query it before
+/// mounting without adding an error surface to startup.
+#[tauri::command]
+#[specta::specta]
+pub fn window_visual_environment() -> WindowVisualEnvironment {
+    WindowVisualEnvironment {
+        is_windows_10: crate::is_windows_10(),
     }
 }
 
@@ -224,6 +253,15 @@ mod tests {
             !info.tauri.is_empty(),
             "tauri::VERSION must not be empty at build time"
         );
+    }
+
+    #[test]
+    fn window_visual_environment_reports_non_windows_as_not_windows_10() {
+        let info = window_visual_environment();
+        #[cfg(not(target_os = "windows"))]
+        assert!(!info.is_windows_10);
+        #[cfg(target_os = "windows")]
+        let _ = info.is_windows_10;
     }
 
     #[tokio::test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -139,7 +139,7 @@ fn resolve_storage_root() -> Result<PathBuf, CommandError> {
 /// whereas wrongly disabling it on a Win11 host would cause a visible
 /// regression there.
 #[cfg(target_os = "windows")]
-fn is_windows_10() -> bool {
+pub(crate) fn is_windows_10() -> bool {
     let info = os_info::get();
     if info.os_type() != os_info::Type::Windows {
         return false;
@@ -148,6 +148,11 @@ fn is_windows_10() -> bool {
         os_info::Version::Semantic(_, _, build) => *build < 22000,
         _ => false,
     }
+}
+
+#[cfg(not(target_os = "windows"))]
+pub(crate) fn is_windows_10() -> bool {
+    false
 }
 
 /// Regenerate `src/types/bindings.ts` from the live

--- a/src/main.ts
+++ b/src/main.ts
@@ -60,6 +60,18 @@ import { createAppRouter, installRouterGuards } from './router'
 import { useAccountStore } from './stores/account'
 import { useAuthStore } from './stores/auth'
 import { useGameStore } from './stores/game'
+import { commands } from './types/bindings'
+
+async function applyPlatformVisualHints(): Promise<void> {
+  try {
+    const environment = await commands.windowVisualEnvironment()
+    if (environment.is_windows_10) {
+      document.documentElement.dataset.platform = 'windows-10'
+    }
+  } catch (err) {
+    console.warn('[main] window_visual_environment failed; using default visual style', err)
+  }
+}
 
 const app = createApp(App)
 
@@ -111,7 +123,9 @@ installRouterGuards(router, {
 
 document.addEventListener('contextmenu', (e) => e.preventDefault())
 
-app.mount('#app')
+void applyPlatformVisualHints().finally(() => {
+  app.mount('#app')
+})
 
 /*
  * Disable the browser right-click context menu so the app feels

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -354,3 +354,78 @@
 [data-theme='dark'] .bf-custom-scrollbar::-webkit-scrollbar-thumb:hover {
   background-color: rgba(255, 255, 255, 0.35);
 }
+
+/* =========================================================================
+ * Windows 10 fallback
+ *
+ * Windows 10 does not compose transparent Tauri/WebView2 windows the same
+ * way Windows 11 does. Keep the borderless rounded shell, but make every
+ * glass surface effectively opaque so desktop/app content cannot bleed
+ * through the UI.
+ * ========================================================================= */
+
+:root[data-platform='windows-10'] .bf-glass-window {
+  background:
+    radial-gradient(
+      900px 560px at 0% -10%,
+      color-mix(in srgb, var(--bf-primary-container) 16%, transparent) 0%,
+      transparent 58%
+    ),
+    linear-gradient(180deg, #fffaf5 0%, #f5ece3 100%);
+  border-color: rgba(133, 115, 106, 0.32);
+  box-shadow: 0 16px 36px rgba(34, 26, 17, 0.18);
+}
+
+:root[data-platform='windows-10'] .bf-glass-panel,
+:root[data-platform='windows-10'] .bf-glass-floating,
+:root[data-platform='windows-10'] .bf-glass-card {
+  background: rgba(255, 255, 255, 0.94);
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+  border-color: rgba(133, 115, 106, 0.24);
+  box-shadow: 0 6px 18px rgba(34, 26, 17, 0.08);
+}
+
+:root[data-platform='windows-10'] .bf-btn-secondary,
+:root[data-platform='windows-10'] .bf-btn-ghost-icon {
+  background: rgba(255, 255, 255, 0.9);
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+  border-color: rgba(133, 115, 106, 0.22);
+}
+
+:root[data-platform='windows-10'] .bf-btn-secondary:hover,
+:root[data-platform='windows-10'] .bf-btn-ghost-icon:hover {
+  background: #ffffff;
+}
+
+:root[data-platform='windows-10'][data-theme='dark'] .bf-glass-window {
+  background:
+    radial-gradient(
+      900px 560px at 0% -10%,
+      color-mix(in srgb, var(--bf-primary-container) 12%, transparent) 0%,
+      transparent 58%
+    ),
+    linear-gradient(180deg, #242428 0%, #18181b 100%);
+  border-color: rgba(255, 255, 255, 0.18);
+  box-shadow: 0 16px 36px rgba(0, 0, 0, 0.5);
+}
+
+:root[data-platform='windows-10'][data-theme='dark'] .bf-glass-panel,
+:root[data-platform='windows-10'][data-theme='dark'] .bf-glass-floating,
+:root[data-platform='windows-10'][data-theme='dark'] .bf-glass-card {
+  background: rgba(47, 47, 51, 0.96);
+  border-color: rgba(255, 255, 255, 0.14);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.28);
+}
+
+:root[data-platform='windows-10'][data-theme='dark'] .bf-btn-secondary,
+:root[data-platform='windows-10'][data-theme='dark'] .bf-btn-ghost-icon {
+  background: rgba(255, 255, 255, 0.1);
+  border-color: rgba(255, 255, 255, 0.16);
+}
+
+:root[data-platform='windows-10'][data-theme='dark'] .bf-btn-secondary:hover,
+:root[data-platform='windows-10'][data-theme='dark'] .bf-btn-ghost-icon:hover {
+  background: rgba(255, 255, 255, 0.18);
+}

--- a/src/types/bindings.ts
+++ b/src/types/bindings.ts
@@ -11,7 +11,7 @@ export const commands = {
 /**
  * Return the static build metadata. Infallible; no parameters; no
  * state.
- * 
+ *
  * Intended as the simplest possible Tauri command — if this
  * doesn't round-trip correctly, nothing else will. Also serves as
  * the canonical example of a sync `#[tauri::command]` with a
@@ -21,8 +21,19 @@ async version() : Promise<VersionInfo> {
     return await TAURI_INVOKE("version");
 },
 /**
+ * Return host visual-environment flags used by the web UI.
+ *
+ * This is deliberately separate from [`version`]: build metadata is
+ * static, while this value depends on the user's OS. It is still
+ * synchronous and infallible so the frontend can query it before
+ * mounting without adding an error surface to startup.
+ */
+async windowVisualEnvironment() : Promise<WindowVisualEnvironment> {
+    return await TAURI_INVOKE("window_visual_environment");
+},
+/**
  * Round-trip an input string through a blocking worker thread.
- * 
+ *
  * Exercises the canonical Win32-wrapping pattern: the closure runs
  * on a [`tokio::task::spawn_blocking`] pool worker (not the reactor
  * thread), sleeps for 60 ms to prove the `await` point genuinely
@@ -3081,6 +3092,22 @@ app: string;
  * Tauri framework version ([`tauri::VERSION`] at compile time).
  */
 tauri: string }
+/**
+ * Runtime visual-environment hints consumed by the frontend before
+ * mounting.
+ *
+ * Kept intentionally narrow: the frontend only needs to know when
+ * the host cannot safely use the Win11-style translucent glass recipe
+ * over a transparent Tauri window.
+ */
+export type WindowVisualEnvironment = {
+/**
+ * `true` on Windows builds whose build number is below 22000
+ * (Windows 10). Those hosts need an opaque CSS fallback because
+ * DWM/WebView2 transparency does not match Windows 11's Mica-like
+ * composition.
+ */
+is_windows_10: boolean }
 
 /** tauri-specta globals **/
 


### PR DESCRIPTION
### What
Windows 10 users report the app window becoming visibly transparent, with desktop/other app content bleeding through the Beanfun UI. The colors also look noticeably different from Windows 11 because the current translucent glass styling depends on Win11-style DWM/WebView2 composition.

### Fix
Expose a small runtime visual-environment command from Rust to detect Windows 10 hosts, then tag the document with `data-platform="windows-10"` before Vue mounts.

On Windows 10 only, switch the glass window, panels, cards, and ghost buttons to an opaque fallback palette. This keeps the borderless rounded UI but prevents background bleed-through and makes colors consistent.

Windows 11 keeps the existing translucent glass styling.
