### PR TITLE
fix(gamepass): clear account cache on relogin

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,13 +1,13 @@
-name: "提出 Bug / Bug Report"
-description: "回報你遇到的問題 / Report an issue you encountered"
-labels: ["bug"]
+name: '提出 Bug / Bug Report'
+description: '回報你遇到的問題 / Report an issue you encountered'
+labels: ['bug']
 body:
   - type: input
     id: feature
     attributes:
       label: 發生問題的功能 / Affected Feature
       description: 請說明是哪個功能出了問題 / Which feature is affected?
-      placeholder: "例如 e.g. 登入 Login、啟動遊戲 Launch Game、自動輸入密碼 Auto-fill Password..."
+      placeholder: '例如 e.g. 登入 Login、啟動遊戲 Launch Game、自動輸入密碼 Auto-fill Password...'
     validations:
       required: true
 
@@ -35,7 +35,7 @@ body:
     id: os
     attributes:
       label: 作業系統版本 / OS Version
-      placeholder: "例如 e.g. Windows 10 22H2、Windows 11 24H2"
+      placeholder: '例如 e.g. Windows 10 22H2、Windows 11 24H2'
     validations:
       required: true
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -330,7 +330,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "beanfun"
-version = "5.9.7"
+version = "6.0.0"
 dependencies = [
  "aes",
  "anyhow",

--- a/src/pages/GamepassForm.vue
+++ b/src/pages/GamepassForm.vue
@@ -88,6 +88,7 @@ import { ElButton, ElMessage, ElStep, ElSteps } from 'element-plus'
 import { listen, type UnlistenFn } from '@tauri-apps/api/event'
 
 import { AUTH_ACTIONS, useAuthStore } from '../stores/auth'
+import { useAccountStore } from '../stores/account'
 import { useConfigStore } from '../stores/config'
 import { CommandInvocationError, wrapCommand } from '../services/invoke'
 import { commands } from '../types/bindings'
@@ -131,6 +132,7 @@ const STEP_COMPLETE = 4
 const { t } = useI18n()
 const router = useRouter()
 const auth = useAuthStore()
+const account = useAccountStore()
 const config = useConfigStore()
 
 /**
@@ -203,6 +205,7 @@ async function registerEventListeners(): Promise<void> {
   const successUnlisten = await listen<SessionInfo>(GAMEPASS_SUCCESS_EVENT, async (event) => {
     if (disposed) return
     step.value = STEP_COMPLETE
+    account.clearSessionData()
     auth.applyGamepassSession(event.payload)
     disposed = true
     await router.push('/accounts')

--- a/tests/unit/pages/GamepassForm.spec.ts
+++ b/tests/unit/pages/GamepassForm.spec.ts
@@ -179,6 +179,7 @@ vi.mock('@tauri-apps/api/event', () => ({
 import { commands } from '../../../src/types/bindings'
 import GamepassForm from '../../../src/pages/GamepassForm.vue'
 import { useAuthStore } from '../../../src/stores/auth'
+import { useAccountStore } from '../../../src/stores/account'
 import { useConfigStore } from '../../../src/stores/config'
 import { createAppI18n, i18nMessages, setLocale } from '../../../src/i18n'
 
@@ -425,11 +426,28 @@ describe('GamepassForm', () => {
     await flushPromises()
 
     const auth = useAuthStore()
+    const account = useAccountStore()
     const applySpy: MockInstance = vi.spyOn(auth, 'applyGamepassSession')
+    const clearSpy: MockInstance = vi.spyOn(account, 'clearSessionData')
+    account.serviceAccounts = [
+      {
+        is_enable: true,
+        visible: true,
+        is_inherited: false,
+        sid: 'stale-sid',
+        ssn: '1',
+        sname: 'Stale Account',
+        screatetime: null,
+        slastusedtime: null,
+        sauthtype: null,
+      },
+    ]
 
     await fireEvent('gamepass-login-success', SAMPLE_SESSION)
 
+    expect(clearSpy).toHaveBeenCalledTimes(1)
     expect(applySpy).toHaveBeenCalledWith(SAMPLE_SESSION)
+    expect(account.serviceAccounts).toEqual([])
     expect(wrapper.find('[data-testid="gamepass-steps"]').attributes('data-active')).toBe('4')
     expect(ctx.router.currentRoute.value.path).toBe('/accounts')
   })


### PR DESCRIPTION
## What
After GAMEPASS logout and relogin, AccountList could reuse stale service-account cache from the previous session. This meant the GAMEPASS login completed, but no accounts appeared until the app was restarted.

## Fix
Clear session-scoped account data when the GAMEPASS success event arrives, before applying the newly authenticated session and navigating to AccountList.

This forces AccountList to fetch accounts for the fresh GAMEPASS session instead of trusting stale serviceAccounts left from the previous login.

Adds regression coverage for GAMEPASS success clearing stale cached service accounts.

Closes #289