### PR TITLE
fix(launcher): extract locale emulator files to appdata

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,13 +1,13 @@
-name: "提出 Bug / Bug Report"
-description: "回報你遇到的問題 / Report an issue you encountered"
-labels: ["bug"]
+name: '提出 Bug / Bug Report'
+description: '回報你遇到的問題 / Report an issue you encountered'
+labels: ['bug']
 body:
   - type: input
     id: feature
     attributes:
       label: 發生問題的功能 / Affected Feature
       description: 請說明是哪個功能出了問題 / Which feature is affected?
-      placeholder: "例如 e.g. 登入 Login、啟動遊戲 Launch Game、自動輸入密碼 Auto-fill Password..."
+      placeholder: '例如 e.g. 登入 Login、啟動遊戲 Launch Game、自動輸入密碼 Auto-fill Password...'
     validations:
       required: true
 
@@ -35,7 +35,7 @@ body:
     id: os
     attributes:
       label: 作業系統版本 / OS Version
-      placeholder: "例如 e.g. Windows 10 22H2、Windows 11 24H2"
+      placeholder: '例如 e.g. Windows 10 22H2、Windows 11 24H2'
     validations:
       required: true
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -330,7 +330,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "beanfun"
-version = "5.9.7"
+version = "6.0.0"
 dependencies = [
  "aes",
  "anyhow",

--- a/src-tauri/src/commands/error.rs
+++ b/src-tauri/src/commands/error.rs
@@ -248,10 +248,7 @@
 //!
 //! | Code                                 | Origin                                                                                 | `details` fields                |
 //! | ------------------------------------ | -------------------------------------------------------------------------------------- | ------------------------------- |
-//! | `launcher.target_dir_resolve_failed` | [`super::launcher::launch_game`] — [`default_target_dir`][dtd] returned `io::Error`.   | `io_kind`                       |
 //! | `launcher.spawn_blocking_failed`     | [`super::launcher::launch_game`] — [`tokio::task::JoinError`] from `spawn_blocking`.    | `is_panic` / `is_cancelled`     |
-//!
-//! [dtd]: crate::services::game::default_target_dir
 //!
 //! # Usage at the command boundary
 //!

--- a/src-tauri/src/commands/launcher.rs
+++ b/src-tauri/src/commands/launcher.rs
@@ -77,13 +77,12 @@
 //! # Command-layer error codes
 //!
 //! See [`crate::commands::error`] for the full table. D5a / D5b
-//! introduce three **command-only** codes (no service-layer
+//! introduce two **command-only** codes (no service-layer
 //! counterpart) for failures that happen in this module's
 //! orchestration:
 //!
 //! | Code                                    | Origin                                                                                             |
 //! | --------------------------------------- | -------------------------------------------------------------------------------------------------- |
-//! | `launcher.target_dir_resolve_failed`    | [`default_target_dir`] returned an `io::Error` (current_exe / parent resolution failed).           |
 //! | `launcher.spawn_blocking_failed`        | [`tokio::task::JoinError`] from a `spawn_blocking` call (task panicked or was aborted).            |
 //! | `launcher.platform_unsupported`         | [`detect_game_path`] called on a non-Windows build (registry access is HKCU-only, Windows-specific). |
 //!
@@ -326,7 +325,7 @@
 //! [pd]: crate::services::process::auto_paste::PasteDriver
 //! [am]: crate::services::process::auto_paste
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use serde_json::json;
 use tauri::State;
@@ -335,9 +334,7 @@ use crate::commands::config::config_xml_path;
 use crate::commands::error::CommandError;
 use crate::commands::state::AppState;
 use crate::services::config as svc_config;
-use crate::services::game::{
-    self, default_target_dir, substitute_credentials, GameStartMode, LaunchRequest,
-};
+use crate::services::game::{self, substitute_credentials, GameStartMode, LaunchRequest};
 
 /// IPC-shaped summary of a running game process, returned by
 /// [`list_game_processes`].
@@ -438,16 +435,9 @@ pub struct AutoPasteRequest {
     pub special_click: bool,
 }
 
-/// Command-layer code minted when [`default_target_dir`] fails to
-/// resolve `current_exe().parent()`. Exposed as a `pub(crate)`
-/// const so [`crate::commands::error`] documentation tables and
-/// internal tests can pin the exact string without re-typing it.
-pub(crate) const TARGET_DIR_RESOLVE_FAILED_CODE: &str = "launcher.target_dir_resolve_failed";
-
 /// Command-layer code minted when [`tokio::task::spawn_blocking`]
 /// returns a [`tokio::task::JoinError`] (task panicked or was
-/// aborted). Sibling of [`TARGET_DIR_RESOLVE_FAILED_CODE`]; kept
-/// distinct from the [`crate::services::system::error::SystemError::SpawnBlockingFailed`]
+/// aborted). Kept distinct from the [`crate::services::system::error::SystemError::SpawnBlockingFailed`]
 /// code so UI telemetry can tell "launcher path panicked" apart
 /// from "open_url path panicked" (P10.1 Q8.D4 fine-grained codes).
 pub(crate) const SPAWN_BLOCKING_FAILED_CODE: &str = "launcher.spawn_blocking_failed";
@@ -521,6 +511,37 @@ pub(crate) fn build_command_line(template: &str, account: &str, password: &str) 
     }
 }
 
+pub(crate) fn build_launch_request(
+    storage_root: &Path,
+    game_path: String,
+    mode: GameStartMode,
+    command_line_template: String,
+    account: String,
+    password: String,
+) -> LaunchRequest {
+    // WPF splits the INI `exe` field into `game_exe` (filename) and
+    // `game_commandLine` (args with %s placeholders) via:
+    //   game_exe = Regex("(.*).exe").Match(exe) + ".exe"
+    //   game_commandLine = Regex(".exe (.*)").Match(exe)
+    // Only `game_commandLine` is used for credential substitution.
+    // We replicate the split here so the command line passed to
+    // CreateProcess matches WPF byte-for-byte.
+    let args_template = if let Some(pos) = command_line_template.to_ascii_lowercase().find(".exe ")
+    {
+        &command_line_template[pos + 5..]
+    } else {
+        ""
+    };
+    let command_line = build_command_line(args_template, &account, &password);
+
+    LaunchRequest {
+        game_path: PathBuf::from(game_path),
+        command_line,
+        mode,
+        target_dir: storage_root.to_path_buf(),
+    }
+}
+
 /// Launch the configured game binary with the current account
 /// credentials.
 ///
@@ -529,12 +550,9 @@ pub(crate) fn build_command_line(template: &str, account: &str, password: &str) 
 /// policy, and blocking-isolation contract. The command performs
 /// three orchestration steps before delegating:
 ///
-/// 1. Resolve the LocaleRemulator staging directory via
-///    [`default_target_dir`]. Fails with
-///    `launcher.target_dir_resolve_failed` if `current_exe()` or
-///    its `.parent()` is unavailable (extremely rare — only
-///    happens when the main binary has been deleted while
-///    running).
+/// 1. Resolve the LocaleRemulator staging directory from
+///    [`AppState::storage_root`], the same `%APPDATA%\Beanfun`
+///    directory that holds `Config.xml`.
 /// 2. Assemble the command-line string via [`build_command_line`]
 ///    (see that helper's docs for the empty-string short-circuit
 ///    semantics).
@@ -579,51 +597,54 @@ pub(crate) fn build_command_line(template: &str, account: &str, password: &str) 
 #[tauri::command]
 #[specta::specta]
 pub async fn launch_game(
+    state: State<'_, AppState>,
     game_path: String,
     mode: GameStartMode,
     command_line_template: String,
     account: String,
     password: String,
 ) -> Result<(), CommandError> {
-    let target_dir = default_target_dir().map_err(|err| {
-        CommandError::new(
-            TARGET_DIR_RESOLVE_FAILED_CODE,
-            format!("failed to resolve default target directory: {err}"),
-        )
-        .with_details(json!({ "io_kind": format!("{:?}", err.kind()) }))
-    })?;
+    launch_game_from_storage_root(
+        state.storage_root.clone(),
+        game_path,
+        mode,
+        command_line_template,
+        account,
+        password,
+    )
+    .await
+}
 
-    // WPF splits the INI `exe` field into `game_exe` (filename) and
-    // `game_commandLine` (args with %s placeholders) via:
-    //   game_exe = Regex("(.*).exe").Match(exe) + ".exe"
-    //   game_commandLine = Regex(".exe (.*)").Match(exe)
-    // Only `game_commandLine` is used for credential substitution.
-    // We replicate the split here so the command line passed to
-    // CreateProcess matches WPF byte-for-byte.
-    let args_template = if let Some(pos) = command_line_template.to_ascii_lowercase().find(".exe ")
-    {
-        &command_line_template[pos + 5..]
-    } else {
-        ""
-    };
-    let command_line = build_command_line(args_template, &account, &password);
-
-    tracing::info!(
-        game_path = %game_path,
-        mode = ?mode,
-        template_len = command_line_template.len(),
-        command_line_len = command_line.len(),
-        has_account = !account.is_empty(),
-        has_password = !password.is_empty(),
-        "launch_game: preparing to spawn"
+pub(crate) async fn launch_game_from_storage_root(
+    storage_root: PathBuf,
+    game_path: String,
+    mode: GameStartMode,
+    command_line_template: String,
+    account: String,
+    password: String,
+) -> Result<(), CommandError> {
+    let template_len = command_line_template.len();
+    let has_account = !account.is_empty();
+    let has_password = !password.is_empty();
+    let req = build_launch_request(
+        &storage_root,
+        game_path,
+        mode,
+        command_line_template,
+        account,
+        password,
     );
 
-    let req = LaunchRequest {
-        game_path: PathBuf::from(game_path),
-        command_line,
-        mode,
-        target_dir,
-    };
+    tracing::info!(
+        game_path = %req.game_path.display(),
+        mode = ?mode,
+        template_len,
+        command_line_len = req.command_line.len(),
+        target_dir = %req.target_dir.display(),
+        has_account,
+        has_password,
+        "launch_game: preparing to spawn"
+    );
 
     tokio::task::spawn_blocking(move || game::launch_game(&req))
         .await
@@ -1140,6 +1161,22 @@ mod tests {
         assert_eq!(got, "alice/swordfish/%s");
     }
 
+    #[test]
+    fn build_launch_request_uses_storage_root_as_lr_target_dir() {
+        let storage_root = PathBuf::from(r"C:\Users\Alice\AppData\Roaming\Beanfun");
+        let req = build_launch_request(
+            &storage_root,
+            r"C:\Games\MapleStory\MapleStory.exe".into(),
+            GameStartMode::LocaleRemulator,
+            "MapleStory.exe /u:%s /p:%s".into(),
+            "alice".into(),
+            "swordfish".into(),
+        );
+
+        assert_eq!(req.target_dir, storage_root);
+        assert_eq!(req.command_line, "/u:alice /p:swordfish");
+    }
+
     // ---- GameStartMode IPC serde ----------------------------------------
 
     #[test]
@@ -1180,7 +1217,9 @@ mod tests {
         // covers the underlying GameError::PathEmpty; this test
         // adds the command-layer contract (correct code string,
         // async+spawn_blocking wiring).
-        let err = launch_game(
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let err = launch_game_from_storage_root(
+            dir.path().to_path_buf(),
             String::new(),
             GameStartMode::Normal,
             String::new(),
@@ -1196,7 +1235,8 @@ mod tests {
     async fn launch_game_missing_file_surfaces_game_path_not_found() {
         let dir = tempfile::TempDir::new().expect("tempdir");
         let missing = dir.path().join("does-not-exist.exe");
-        let err = launch_game(
+        let err = launch_game_from_storage_root(
+            dir.path().to_path_buf(),
             missing.to_string_lossy().into_owned(),
             GameStartMode::Normal,
             String::new(),
@@ -1633,14 +1673,10 @@ mod tests {
 
     #[test]
     fn command_layer_codes_are_stable_strings() {
-        // Lock the exact spelling of the three command-only codes
+        // Lock the exact spelling of the command-only codes
         // so a refactor that touches the module docs or the
         // `CommandError::new(...)` call-site doesn't silently
         // change the code the frontend branches on.
-        assert_eq!(
-            TARGET_DIR_RESOLVE_FAILED_CODE,
-            "launcher.target_dir_resolve_failed"
-        );
         assert_eq!(SPAWN_BLOCKING_FAILED_CODE, "launcher.spawn_blocking_failed");
         assert_eq!(PLATFORM_UNSUPPORTED_CODE, "launcher.platform_unsupported");
     }

--- a/src/types/bindings.ts
+++ b/src/types/bindings.ts
@@ -21,24 +21,13 @@ async version() : Promise<VersionInfo> {
     return await TAURI_INVOKE("version");
 },
 /**
- * Return host visual-environment flags used by the web UI.
- *
- * This is deliberately separate from [`version`]: build metadata is
- * static, while this value depends on the user's OS. It is still
- * synchronous and infallible so the frontend can query it before
- * mounting without adding an error surface to startup.
- */
-async windowVisualEnvironment() : Promise<WindowVisualEnvironment> {
-    return await TAURI_INVOKE("window_visual_environment");
-},
-/**
  * Round-trip an input string through a blocking worker thread.
  *
  * Exercises the canonical Win32-wrapping pattern: the closure runs
  * on a [`tokio::task::spawn_blocking`] pool worker (not the reactor
  * thread), sleeps for 60 ms to prove the `await` point genuinely
  * suspends, then returns `"pong: {input}"`.
- * 
+ *
  * Failure path: if the blocking task panics or is cancelled the
  * [`tokio::task::JoinError`] is mapped to
  * `system.spawn_blocking_failed`. Should never happen in steady
@@ -55,8 +44,19 @@ async ping(message: string) : Promise<Result<string, CommandError>> {
 }
 },
 /**
+ * Return host visual-environment flags used by the web UI.
+ *
+ * This is deliberately separate from [`version`]: build metadata is
+ * static, while this value depends on the user's OS. It is still
+ * synchronous and infallible so the frontend can query it before
+ * mounting without adding an error surface to startup.
+ */
+async windowVisualEnvironment() : Promise<WindowVisualEnvironment> {
+    return await TAURI_INVOKE("window_visual_environment");
+},
+/**
  * TW / HK regular username+password login.
- * 
+ *
  * # Protocol
  * 
  * 1. Best-effort clear [`AppState::pending_totp`]
@@ -1549,12 +1549,9 @@ async checkUpdate(channel: Channel, localVersion: string | null) : Promise<Updat
  * policy, and blocking-isolation contract. The command performs
  * three orchestration steps before delegating:
  * 
- * 1. Resolve the LocaleRemulator staging directory via
- * [`default_target_dir`]. Fails with
- * `launcher.target_dir_resolve_failed` if `current_exe()` or
- * its `.parent()` is unavailable (extremely rare — only
- * happens when the main binary has been deleted while
- * running).
+ * 1. Resolve the LocaleRemulator staging directory from
+ * [`AppState::storage_root`], the same `%APPDATA%\Beanfun`
+ * directory that holds `Config.xml`.
  * 2. Assemble the command-line string via [`build_command_line`]
  * (see that helper's docs for the empty-string short-circuit
  * semantics).


### PR DESCRIPTION
## What
LocaleRemulator support files were being extracted next to the running executable/current app path. This could leave released files outside the app data directory while `Config.xml` already lives under `%APPDATA%\Beanfun`.

## Fix
Use `AppState::storage_root` as the launcher extraction/staging target directory, so LocaleRemulator files are released under the same `%APPDATA%\Beanfun` root as `Config.xml`.

The launcher command now builds its `LaunchRequest.target_dir` from the managed app storage root instead of resolving the executable parent directory. The obsolete command-layer target-dir resolution error path was removed, bindings were regenerated, and `Cargo.lock` was synced to `6.0.0`.

Adds regression coverage that the launch request uses the storage root as the LocaleRemulator target directory.

Closes #285