### PR TITLE
fix(qr): fix 登入逾期 on get-password and blank first-open QR (#298)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -330,7 +330,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "beanfun"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "aes",
  "anyhow",

--- a/src-tauri/src/commands/otp.rs
+++ b/src-tauri/src/commands/otp.rs
@@ -35,7 +35,10 @@ use crate::commands::{
     session::{require_auth, SESSION_REQUIRED_CODE, SESSION_REQUIRED_MESSAGE},
     state::AppState,
 };
-use crate::services::beanfun::{get_otp as service_get_otp, LoginError, ServiceAccount};
+use crate::services::beanfun::{
+    account::get_accounts as service_get_accounts, get_otp as service_get_otp, LoginError,
+    ServiceAccount,
+};
 
 /// Retrieve the one-time game-launch password for a given service
 /// account.
@@ -111,18 +114,74 @@ pub async fn get_otp(
     {
         Ok(otp) => Ok(otp),
         Err(e) if is_likely_session_expired(&e) => {
+            // Issue #298: pressing "get password" immediately after a QR
+            // (or any) login frequently trips the session-expired
+            // heuristic even though the session is perfectly valid — the
+            // server-side portal session for the game host just isn't
+            // warm yet on the very first OTP attempt, so step 1/2 come
+            // back as a login-redirect page.
+            //
+            // WPF (5.9) tolerates this: `GetOTP` failures only show a
+            // "GetOtpError" toast and the user retries successfully. The
+            // earlier #264 fix over-corrected by nuking the auth context
+            // on the *first* failure, which surfaces as the user-visible
+            // "登入逾期" → forced re-login regression reported in #298.
+            //
+            // Re-warm the portal session exactly the way `get_accounts`
+            // does (the `auth.aspx` cookie-priming GET it runs first) and
+            // retry the OTP once. Only a *second* session-expired-looking
+            // failure is treated as a genuine expiry that clears auth.
             tracing::warn!(
                 error = %e,
-                "OTP flow detected likely server-side session expiry; clearing local auth context"
+                "OTP first attempt looked session-expired; re-warming portal session and retrying once"
             );
-            let taken = state.auth.write().await.take();
-            if let Some(ctx) = taken {
-                ctx.ping_cancel.cancel();
+
+            if let Err(rewarm_err) = service_get_accounts(
+                &client,
+                &session,
+                &session.service_code,
+                &session.service_region,
+            )
+            .await
+            {
+                // Non-fatal: the retry below may still succeed off the
+                // cookies the warm-up GET primed even if list parsing
+                // failed. Log for live-test fault isolation.
+                tracing::warn!(
+                    error = %rewarm_err,
+                    "OTP re-warm get_accounts failed; retrying OTP anyway"
+                );
             }
-            Err(CommandError::new(
-                SESSION_REQUIRED_CODE,
-                SESSION_REQUIRED_MESSAGE,
-            ))
+
+            match service_get_otp(
+                &client,
+                &session,
+                &account,
+                &session.service_code,
+                &session.service_region,
+            )
+            .await
+            {
+                Ok(otp) => {
+                    tracing::info!("OTP succeeded after portal-session re-warm");
+                    Ok(otp)
+                }
+                Err(e2) if is_likely_session_expired(&e2) => {
+                    tracing::warn!(
+                        error = %e2,
+                        "OTP still session-expired after re-warm; clearing local auth context"
+                    );
+                    let taken = state.auth.write().await.take();
+                    if let Some(ctx) = taken {
+                        ctx.ping_cancel.cancel();
+                    }
+                    Err(CommandError::new(
+                        SESSION_REQUIRED_CODE,
+                        SESSION_REQUIRED_MESSAGE,
+                    ))
+                }
+                Err(e2) => Err(CommandError::from(e2)),
+            }
         }
         Err(e) => Err(CommandError::from(e)),
     }

--- a/src/pages/QrForm.vue
+++ b/src/pages/QrForm.vue
@@ -237,6 +237,30 @@ async function doStart(): Promise<void> {
   }
 }
 
+/**
+ * Cold-start safety net (issue #298).
+ *
+ * On the very first app open the QR area sometimes stayed blank/white
+ * with no error banner, and the only recovery was manually toggling
+ * region (HK → TW) to re-trigger a fresh `loginQrStart`. Two distinct
+ * first-open hazards produce that symptom:
+ *
+ * 1. A transient cold-start network failure on the very first HTTPS
+ *    round-trip to beanfun (DNS / TLS / proxy warm-up). `doStart`
+ *    surfaces that as a toast + `connectionLost`, but a single flake
+ *    shouldn't force the user to fiddle with the region picker.
+ * 2. A navigation-storm race (the boot `/ → /login/ → /login/qr`
+ *    redirect chain) where the first `loginQrStart` is rejected by the
+ *    auth-store `withGuard` (a plain `Error`, deliberately swallowed by
+ *    `doStart`) — leaving the QR blank with no banner at all.
+ *
+ * One automatic retry after a short delay covers both: if we still
+ * have no bitmap shortly after the initial attempt, re-run `doStart`
+ * (which mints a fresh backend client + challenge). The manual Refresh
+ * button remains the user-driven fallback.
+ */
+const COLD_START_RETRY_DELAY_MS = 800
+
 onMounted(async () => {
   const region = readRegion()
   if (region !== 'TW') {
@@ -245,6 +269,12 @@ onMounted(async () => {
     await router.push({ path: '/login', query: { pick: '1' } })
     return
   }
+  await doStart()
+
+  // Auto-retry once if the first attempt produced no QR (see docblock).
+  if (disposed || bitmap.value) return
+  await new Promise((resolve) => setTimeout(resolve, COLD_START_RETRY_DELAY_MS))
+  if (disposed || bitmap.value) return
   await doStart()
 })
 


### PR DESCRIPTION
# What

Fixes two QR-login regressions reported in #298 (new 6.0.1 vs old WPF 5.9):

1. **取得密碼 → 馬上跳登入逾期** — right after scanning + confirming a QR login, pressing "get password" immediately reports 登入逾期 and kicks the user back to login. Switching account behaves the same. Worked on 5.9.
2. **首開 QR 跳白、掃碼問題** — on first app open the QR is blank; the only workaround is toggling region (切 HK 再切回 TW) to make the barcode show.

# Fix

**1. Transient 登入逾期 on get-password (`src-tauri/src/commands/otp.rs`)**
The OTP session-expired heuristic (`OtpMissingLongPollingKey` / `OtpMissingSecretCode`, added for #264) fired on the *first* OTP attempt. Right after login the game-host portal session often isn't warm yet, so OTP step 1/2 come back as a login-redirect page even though the session is valid — WPF 5.9 only toasted an error and the user retried successfully, whereas the rewrite nuked the auth context on the first failure.

`get_otp` now, on a session-expired-looking failure, re-warms the portal session (the same `auth.aspx` cookie-priming GET that `get_accounts` runs) and retries the OTP **once**. Only a *second* session-expired failure clears auth — preserving the #264 behaviour for genuine server-side session invalidation.

**2. Blank first-open QR (`src/pages/QrForm.vue`)**
A transient cold-start network flake, or a boot navigation-storm race where the first `loginQrStart` is rejected by the auth store `withGuard` (a plain `Error`, deliberately swallowed), left the QR blank with no banner. `QrForm` now auto-retries `loginQrStart` once after a short delay when the first attempt produced no bitmap; the manual Refresh button stays as the user-driven fallback.

Closes #298