### PR TITLE
feat(auth): support reCAPTCHA-gated account login via webview (#308)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -330,7 +330,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "beanfun"
-version = "6.0.1"
+version = "6.0.2"
 dependencies = [
  "aes",
  "anyhow",

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -528,6 +528,25 @@ pub async fn login_regular(
             let info = install_session_and_start_ping(&state, client, session).await;
             Ok(info)
         }
+        Err(LoginError::RecaptchaRequired { skey }) => {
+            // The TW account/password page now gates this attempt behind a
+            // Google reCAPTCHA v2 challenge that cannot be solved headlessly
+            // (see `services::beanfun::login::init_login`). Hand off to the
+            // interactive WebView login by re-using the GamePass WebView
+            // machinery: park `(client, skey)` on `pending_gamepass` — the
+            // generic "WebView login awaiting bfWebToken harvest" slot — and
+            // signal the frontend to open the account-login window via
+            // `open_account_login_window`. Clearing the sibling continuations
+            // mirrors the top-of-function resets so only one half-finished
+            // login is ever outstanding.
+            *state.pending_totp.write().await = None;
+            *state.pending_qr.write().await = None;
+            *state.pending_gamepass.write().await = Some(PendingGamepass::new(client, skey));
+            Err(CommandError::new(
+                RECAPTCHA_REQUIRED_CODE,
+                "reCAPTCHA verification is required; complete it in the login window.",
+            ))
+        }
         Err(err) => Err(err.into()),
     }
 }
@@ -852,6 +871,23 @@ pub(crate) const GAMEPASS_WINDOW_ALREADY_OPEN_CODE: &str = "auth.gamepass_window
 /// login attempt.
 const GAMEPASS_WINDOW_LABEL: &str = "gamepass-login";
 
+/// Error code surfaced by [`login_regular`] when the TW account/password
+/// login requires a Google reCAPTCHA v2 challenge for this attempt
+/// (server-side anti-bot; see
+/// [`crate::services::beanfun::login::init_login`]). The frontend reacts
+/// by calling [`open_account_login_window`] so the user can solve the
+/// challenge and finish logging in inside the real beanfun page.
+pub(crate) const RECAPTCHA_REQUIRED_CODE: &str = "auth.recaptcha_required";
+
+/// Fixed Tauri window label for the reCAPTCHA account-login WebView.
+/// Distinct from [`GAMEPASS_WINDOW_LABEL`] so the two windows' double-open
+/// guards are independent, even though both reuse the same
+/// [`AppState::pending_gamepass`] slot + completion handlers (the flows
+/// are mechanically identical — only the landing behaviour differs: the
+/// account-login window does **not** auto-click the Gama Pass button, so
+/// the user sees the normal account/password + reCAPTCHA form).
+const ACCOUNT_LOGIN_WINDOW_LABEL: &str = "account-login";
+
 /// Tauri event names emitted by the GamePass flow. Flat dash-case
 /// per the P12.1 D5 event convention.
 ///
@@ -938,6 +974,83 @@ const GAMEPASS_AUTOCLICK_JS: &str = r#"(() => {
     clickButton();
   }
 })();"#;
+
+/// Build the best-effort autofill `initialization_script` for the
+/// reCAPTCHA account-login WebView ([`open_account_login_window`]).
+///
+/// `account_js` / `password_js` must already be **JSON-encoded** string
+/// literals (e.g. via `serde_json::to_string`) so they embed safely as
+/// JS string literals — never interpolate raw user input here.
+///
+/// # Behaviour
+///
+/// beanfun's `Login/Index` is a Vue SPA that renders its account +
+/// password `<input>`s with `v-show` (both live in the DOM from first
+/// render; the password block is merely `display:none` until the
+/// account step). The script therefore:
+///
+/// - waits for the form to render (`DOMContentLoaded` + a
+///   `MutationObserver`, since Vue mounts after our init script runs),
+/// - fills both inputs via the **native** value setter + an `input`
+///   event so Vue's `v-model` reactivity picks up the change,
+/// - disconnects once both are filled (or after a 5-min safety timeout).
+///
+/// # Graceful degradation & safety
+///
+/// - Missing input (markup changed) or empty value → silent no-op; the
+///   user just types manually. Autofill never throws or blocks login
+///   (every DOM op is wrapped in `try`).
+/// - The IIFE leaks **no** globals, so beanfun's own page scripts cannot
+///   read `ACC` / `PW` back out.
+/// - We never auto-submit or auto-click — the human still solves the
+///   reCAPTCHA and presses the login buttons.
+fn build_account_autofill_script(account_js: &str, password_js: &str) -> String {
+    // Chinese placeholders are written as JS `\u` escapes so the emitted
+    // script is pure ASCII (the password `type` / `name` fallbacks make
+    // it resilient if beanfun re-words the placeholder).
+    format!(
+        r#"(() => {{
+  const ACC = {account_js};
+  const PW = {password_js};
+  const setVal = (el, val) => {{
+    if (!el || !val) return false;
+    try {{
+      const desc = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(el), "value");
+      if (desc && desc.set) {{ desc.set.call(el, val); }} else {{ el.value = val; }}
+      el.dispatchEvent(new Event("input", {{ bubbles: true }}));
+      el.dispatchEvent(new Event("change", {{ bubbles: true }}));
+      return true;
+    }} catch (e) {{ return false; }}
+  }};
+  let accDone = false, pwDone = false;
+  const tryFill = () => {{
+    if (!accDone) {{
+      const a = document.querySelector('input[placeholder="\u8acb\u8f38\u5165\u5e33\u865f"]')
+        || document.querySelector('input[name="aaa"]');
+      if (a) accDone = setVal(a, ACC);
+    }}
+    if (!pwDone) {{
+      const p = document.querySelector('input[type="password"]')
+        || document.querySelector('input[placeholder="\u8acb\u8f38\u5165\u5bc6\u78bc"]')
+        || document.querySelector('input[name="inputName"]');
+      if (p) pwDone = setVal(p, PW);
+    }}
+    return accDone && pwDone;
+  }};
+  const start = () => {{
+    if (tryFill()) return;
+    const obs = new MutationObserver(() => {{ if (tryFill()) obs.disconnect(); }});
+    obs.observe(document.documentElement, {{ childList: true, subtree: true }});
+    setTimeout(() => obs.disconnect(), 300000);
+  }};
+  if (document.readyState === "loading") {{
+    document.addEventListener("DOMContentLoaded", start, {{ once: true }});
+  }} else {{
+    start();
+  }}
+}})();"#
+    )
+}
 
 /// Strip query parameters from a URL for safe logging.
 /// Prevents session tokens (e.g. `pSKey`) from leaking into traces.
@@ -1810,6 +1923,220 @@ pub async fn open_gamepass_window<R: tauri::Runtime>(
         step = "GamepassWindowOpened",
         label = GAMEPASS_WINDOW_LABEL,
         "GamePass webview opened; awaiting completion or cancel"
+    );
+
+    Ok(())
+}
+
+/// Open the reCAPTCHA account-login WebView window.
+///
+/// Triggered by the frontend after [`login_regular`] surfaces
+/// [`RECAPTCHA_REQUIRED_CODE`]: the TW account/password login required a
+/// Google reCAPTCHA v2 challenge for this attempt, which cannot be
+/// solved headlessly (see
+/// [`crate::services::beanfun::login::init_login`]). This opens the real
+/// `Login/Index?pSKey=…` page in a WebView so the user can type their
+/// account + password and solve the "I'm not a robot" challenge inside
+/// beanfun's own page; the resulting `bfWebToken` is harvested by the
+/// shared [`handle_gamepass_page_load`] hook exactly as GamePass does.
+///
+/// # Reuse of the GamePass machinery (deliberate)
+///
+/// The reCAPTCHA account login and GamePass login are mechanically
+/// identical — both seed the portal session cookies into an
+/// `about:blank` WebView, navigate to the same `Login/Index?pSKey=…`
+/// URL, and harvest `bfWebToken` once beanfun's redirect chain reaches
+/// `return.aspx`. So this command re-uses:
+///
+/// - [`AppState::pending_gamepass`] — parked by [`login_regular`]'s
+///   `RecaptchaRequired` arm (the generic "WebView login awaiting
+///   harvest" slot).
+/// - [`handle_gamepass_page_load`] / [`handle_gamepass_window_destroyed`]
+///   — the completion + cancel hooks.
+/// - The `gamepass-login-success` / `-failed` / `-cancelled` events
+///   (consumed unchanged by the frontend's `applyGamepassSession`).
+///
+/// The difference from [`open_gamepass_window`] is the
+/// `initialization_script`: GamePass auto-clicks the "use Gama Pass"
+/// button, whereas here we inject a **best-effort autofill** (built by
+/// [`build_account_autofill_script`]) that pre-fills the `account` +
+/// `password` the user already typed in `IdPassForm`, so they only need
+/// to solve the "I'm not a robot" challenge and submit. We never
+/// auto-click — the reCAPTCHA must be solved by the human. A distinct
+/// window label ([`ACCOUNT_LOGIN_WINDOW_LABEL`]) keeps the double-open
+/// guard independent of the GamePass window.
+///
+/// `account` / `password` come from the frontend's `loginIntent` (the
+/// same values it passed to `login_regular`); they are used **only** to
+/// pre-fill beanfun's own login form and are not persisted here. Empty
+/// strings (e.g. direct navigation) make the autofill a no-op.
+///
+/// `open_gamepass_window` is left **byte-for-byte untouched** (it was
+/// the subject of the issue #296 stale-cookie fix); the #296-critical
+/// `DeleteAllCookies` / `AddOrUpdateCookie` mechanics live in the shared
+/// [`crate::commands::cookie_native`] module, so only the (trivial)
+/// clear→seed→navigate sequencing is duplicated here.
+#[tauri::command]
+#[specta::specta]
+pub async fn open_account_login_window<R: tauri::Runtime>(
+    app: AppHandle<R>,
+    state: State<'_, AppState>,
+    account: String,
+    password: String,
+) -> Result<(), CommandError> {
+    let (client, skey) = {
+        let guard = state.pending_gamepass.read().await;
+        match guard.as_ref() {
+            Some(pg) => (pg.client.clone(), pg.skey.clone()),
+            None => {
+                return Err(CommandError::new(
+                    RECAPTCHA_REQUIRED_CODE,
+                    "No reCAPTCHA login is active; submit the account/password form first.",
+                ));
+            }
+        }
+    };
+
+    if app.get_webview_window(ACCOUNT_LOGIN_WINDOW_LABEL).is_some() {
+        return Err(CommandError::new(
+            GAMEPASS_WINDOW_ALREADY_OPEN_CODE,
+            "Account login window is already open; close it before retrying.",
+        ));
+    }
+
+    // Same `Login/Index?pSKey=…` URL the GamePass flow uses — beanfun
+    // renders the account/password + reCAPTCHA form here when the page
+    // is not auto-redirected into Gama Pass.
+    let login_url = build_gamepass_login_url(&skey)?;
+
+    // Best-effort autofill of the credentials the user already typed in
+    // `IdPassForm`. JSON-encode each value so it embeds as a safe JS
+    // string literal (quotes / specials escaped). See
+    // [`build_account_autofill_script`] for the script's behaviour and
+    // graceful-degradation guarantees.
+    let account_js = serde_json::to_string(&account).unwrap_or_else(|_| "\"\"".to_owned());
+    let password_js = serde_json::to_string(&password).unwrap_or_else(|_| "\"\"".to_owned());
+    let autofill_js = build_account_autofill_script(&account_js, &password_js);
+
+    let app_for_page_load = app.clone();
+    let app_for_destroyed = app.clone();
+
+    // `about:blank` first so the session cookies are seeded BEFORE the
+    // first real request to `Login/Index` (same rationale as
+    // `open_gamepass_window`'s D5 hotfix).
+    let about_blank: Url = "about:blank".parse().expect("about:blank is a valid URL");
+
+    let window = WebviewWindowBuilder::new(
+        &app,
+        ACCOUNT_LOGIN_WINDOW_LABEL,
+        WebviewUrl::External(about_blank),
+    )
+    .title("帳號登入 / 驗證")
+    .inner_size(900.0, 700.0)
+    .resizable(true)
+    // Best-effort credential autofill (built above). Unlike GamePass we
+    // do NOT auto-click anything — the user must see the form, solve the
+    // reCAPTCHA, and submit themselves.
+    .initialization_script(autofill_js.as_str())
+    .on_page_load(move |window, payload| {
+        if payload.event() != PageLoadEvent::Finished {
+            return;
+        }
+        let app = app_for_page_load.clone();
+        let window = window.clone();
+        let url = payload.url().clone();
+        tauri::async_runtime::spawn(async move {
+            handle_gamepass_page_load(app, window, url).await;
+        });
+    })
+    .build()
+    .map_err(|e| {
+        CommandError::new(
+            "ui.window_create_failed",
+            format!("Failed to create account-login webview window: {e}"),
+        )
+    })?;
+
+    window.on_window_event(move |event| {
+        if matches!(event, WindowEvent::Destroyed) {
+            let app = app_for_destroyed.clone();
+            tauri::async_runtime::spawn(async move {
+                handle_gamepass_window_destroyed(app).await;
+            });
+        }
+    });
+
+    trace_cookie_jar("AccountLoginWebViewSeed.JarDump", &client);
+
+    // Clear + seed the WebView2 cookie store before navigating — the
+    // same two-pass native COM dance as `open_gamepass_window` (issue
+    // #296). The #296-critical mechanics are shared via `cookie_native`.
+    #[cfg(target_os = "windows")]
+    {
+        let cleared = crate::commands::cookie_native::clear_all_cookies_native(&window);
+        tracing::info!(
+            step = "AccountLoginWebViewClear",
+            cleared = cleared,
+            "issued DeleteAllCookies before seeding (issue #296)"
+        );
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        let seeded = crate::commands::cookie_native::seed_cookies_native(&window, &client);
+        tracing::info!(
+            step = "AccountLoginWebViewSeed.Summary",
+            seeded = seeded,
+            "seeded fresh session cookies after clear (native COM)"
+        );
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        let mut seed_failures = 0usize;
+        let seeded = seed_webview_cookies_from_client(&client, |cookie| {
+            if let Err(err) = window.set_cookie(cookie.clone()) {
+                seed_failures += 1;
+                tracing::warn!(
+                    step = "AccountLoginWebViewSeed.CookieError",
+                    cookie_name = %cookie.name(),
+                    cookie_domain = ?cookie.domain(),
+                    error = ?err,
+                    "failed to seed cookie into account-login WebView; continuing"
+                );
+            }
+            Ok::<(), std::convert::Infallible>(())
+        })
+        .expect("seed closure is infallible");
+
+        tracing::info!(
+            step = "AccountLoginWebViewSeed.Summary",
+            seeded = seeded - seed_failures,
+            failed = seed_failures,
+            "cookie seed summary from BeanfunClient jar into WebView before login navigation"
+        );
+    }
+
+    tracing::info!(
+        step = "AccountLoginWebViewNavigate",
+        url = %redact_url_query(&login_url),
+        "navigating account-login WebView to login URL after cookie seed"
+    );
+    if let Err(err) = window.navigate(login_url.clone()) {
+        // Navigation failed — clear the slot ourselves so the Destroyed
+        // hook doesn't fire a spurious cancel event, then close the
+        // dangling window.
+        *state.pending_gamepass.write().await = None;
+        let _ = window.close();
+        return Err(CommandError::new(
+            "ui.account_login_navigate_failed",
+            format!("Failed to navigate account-login webview to login URL: {err}"),
+        ));
+    }
+
+    tracing::info!(
+        step = "AccountLoginWindowOpened",
+        label = ACCOUNT_LOGIN_WINDOW_LABEL,
+        "account-login webview opened; awaiting completion or cancel"
     );
 
     Ok(())

--- a/src-tauri/src/commands/error.rs
+++ b/src-tauri/src/commands/error.rs
@@ -421,6 +421,15 @@ impl From<LoginError> for CommandError {
                 CommandError::new("auth.advance_check_required", message)
                     .with_details(json!({ "url": url }))
             }
+            // The `skey` is deliberately dropped here: this `From` arm is
+            // only the fallback for an un-intercepted `RecaptchaRequired`.
+            // The real flow is `login_regular` catching it explicitly,
+            // stashing `(client, skey)` on a pending slot, and emitting
+            // this same code itself — the skey is a session bearer that
+            // must stay backend-internal (P10.2 Q4=C), never on the wire.
+            LoginError::RecaptchaRequired { .. } => {
+                CommandError::new("auth.recaptcha_required", message)
+            }
             LoginError::TotpRequired(challenge) => {
                 // P10.1 keeps the payload compact (`challenge_display`
                 // only). P10.2 will upgrade `TotpChallenge` to

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -230,6 +230,12 @@ pub fn build_specta_builder<R: tauri::Runtime>() -> Builder<R> {
         // is instantiated with (production uses `Wry`).
         auth::login_gamepass_start::<tauri::Wry>,
         auth::open_gamepass_window::<tauri::Wry>,
+        // auth (issue #308 — reCAPTCHA account login)
+        //
+        // Same `::<tauri::Wry>` turbofish rationale as the GamePass
+        // commands above: generic over `R` (builds a `WebviewWindow<R>`),
+        // pinned to `Wry` on the specta side only.
+        auth::open_account_login_window::<tauri::Wry>,
         // auth (P10.2 — verify family)
         auth::get_verify_page_info,
         auth::get_verify_captcha,

--- a/src-tauri/src/services/beanfun/error.rs
+++ b/src-tauri/src/services/beanfun/error.rs
@@ -63,6 +63,28 @@ pub enum LoginError {
     #[error("advance verification required")]
     AdvanceCheckRequired { url: Option<String> },
 
+    /// The TW account/password login page now gates the
+    /// `CheckAccountType` / `AccountLogin` POSTs behind a **Google
+    /// reCAPTCHA v2 challenge** for this attempt (server-side anti-bot,
+    /// triggered by IP / connection-fingerprint reputation and surfaced
+    /// via `Login/InitLogin`'s `IsRecaptcha` flag — see
+    /// [`crate::services::beanfun::login::init_login`]).
+    ///
+    /// A reCAPTCHA v2 token cannot be produced headlessly: it needs a
+    /// real browser, a human checkbox click, and a token bound to
+    /// beanfun's own domain. So the TW Regular flow bails here and the
+    /// command layer hands off to an interactive WebView login that
+    /// loads the real `Login/Index?pSKey=…` page. The `skey` is carried
+    /// so the WebView navigates to the **same** session the detection
+    /// ran against (its cookies are already in the client jar).
+    ///
+    /// Semantically a **continuation**, not a hard error — same stance
+    /// as [`TotpRequired`](Self::TotpRequired) and
+    /// [`AdvanceCheckRequired`](Self::AdvanceCheckRequired); it travels
+    /// the `Err` channel only to keep the happy-path return type clean.
+    #[error("reCAPTCHA challenge required; interactive WebView login needed")]
+    RecaptchaRequired { skey: String },
+
     /// WPF `need_totp` — the server response contained a `totpLoginBtn`
     /// form, meaning the account has TOTP 2FA enabled. Carries a
     /// [`TotpChallenge`] with the viewstate + URL the caller must

--- a/src-tauri/src/services/beanfun/login/init_login.rs
+++ b/src-tauri/src/services/beanfun/login/init_login.rs
@@ -1,0 +1,148 @@
+//! TW Regular reCAPTCHA-detection step — `GET Login/InitLogin`.
+//!
+//! As of 2026-06-25 the `login.beanfun.com/Login/Index` SPA gates the
+//! account/password sub-form behind a **Google reCAPTCHA Enterprise v2
+//! checkbox** whenever the server decides the client looks suspicious
+//! (IP reputation / connection fingerprint). The SPA learns this from
+//! `GET /Login/InitLogin`, whose JSON `ResultData.IsRecaptcha` flag
+//! tells it whether to render the "I'm not a robot" widget and require
+//! a token on the subsequent `CheckAccountType` / `AccountLogin` POSTs.
+//!
+//! Our headless `reqwest` flow cannot solve a reCAPTCHA v2 challenge
+//! (it needs a real browser, a human click, and a token bound to
+//! beanfun's own domain). So the TW Regular orchestrator calls this
+//! step right after `get_login_index` to find out whether reCAPTCHA is
+//! required; when it is, the flow bails to an interactive WebView login
+//! instead of attempting the headless POSTs (which would be rejected).
+//!
+//! # Why a separate step rather than reusing `qr_init`'s InitLogin call
+//!
+//! [`super::init_qr_login`] already performs a `GET Login/InitLogin`,
+//! but its parsing is tightly coupled to the QR sub-flow (it requires
+//! `Result == 0` and a non-empty `ResultData.QRImage`, raising
+//! [`LoginError::QrInitResultError`] otherwise). QR login is **not**
+//! affected by reCAPTCHA — it authenticates by app-scan, with no
+//! password sub-form — so we deliberately leave `init_qr_login`
+//! untouched and pay for one small duplicated GET here rather than
+//! risk regressing a working flow.
+//!
+//! # Request shape
+//!
+//! Mirrors what the real SPA (and `init_qr_login`) sends: a JSON GET to
+//! `Login/InitLogin?pSKey={skey}` with `Accept: application/json`,
+//! `Referer: {Login/Index URL}`, `X-Requested-With: XMLHttpRequest`,
+//! and an `Origin` of the login host.
+
+use reqwest::header;
+use serde::Deserialize;
+
+use super::ensure_success;
+use crate::services::beanfun::{BeanfunClient, LoginError};
+
+/// Subset of the `InitLogin` JSON envelope we care about for
+/// reCAPTCHA detection. Every other field the server returns
+/// (`QRImage`, `IsHK`, `RecaptchaV2PublicKey`, …) is ignored — the
+/// public reCAPTCHA site key is rendered by beanfun's own page in the
+/// WebView leg, so the backend never needs it.
+#[derive(Debug, Deserialize)]
+struct InitLoginResponse {
+    #[serde(rename = "ResultData")]
+    result_data: Option<InitLoginResultData>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct InitLoginResultData {
+    /// `true` when the server requires a reCAPTCHA token on the
+    /// following `CheckAccountType` / `AccountLogin` calls. Defaults to
+    /// `false` when the field is absent so a response-shape change
+    /// degrades to the existing headless flow rather than a hard error.
+    #[serde(rename = "IsRecaptcha", default)]
+    is_recaptcha: bool,
+}
+
+/// Ask the server whether the account/password login requires a
+/// reCAPTCHA challenge for this attempt.
+///
+/// Returns `Ok(true)` when `ResultData.IsRecaptcha` is `true`,
+/// `Ok(false)` otherwise — including when the body is missing the
+/// field, lacks `ResultData`, or is not parseable as JSON. The lenient
+/// fallback is deliberate: a `false` result routes the caller through
+/// the unchanged headless flow, so a server-side response-shape change
+/// can never make us *more* broken than today (it would simply fail
+/// later in `account_login`, exactly as it does now).
+///
+/// `index_url` is the `Login/Index?pSKey=…` URL produced by
+/// [`super::get_login_index`]; it is sent verbatim as the `Referer`.
+pub async fn check_recaptcha_required(
+    client: &BeanfunClient,
+    skey: &str,
+    index_url: &str,
+) -> Result<bool, LoginError> {
+    let init_url = client.login_url_with_skey("Login/InitLogin", skey)?;
+    let origin = client
+        .config()
+        .endpoints
+        .login_base
+        .origin()
+        .ascii_serialization();
+
+    let resp = client
+        .http()
+        .get(init_url)
+        .header(header::ACCEPT, "application/json, text/plain, */*")
+        .header(header::REFERER, index_url)
+        .header("X-Requested-With", "XMLHttpRequest")
+        .header("Origin", origin)
+        .send()
+        .await?;
+
+    ensure_success(&resp, "Login/InitLogin")?;
+    let body = client.bounded_text(resp).await?;
+
+    match serde_json::from_str::<InitLoginResponse>(&body) {
+        Ok(parsed) => Ok(parsed.result_data.map(|d| d.is_recaptcha).unwrap_or(false)),
+        Err(error) => {
+            // Not a hard failure: fall through to the headless flow.
+            tracing::warn!(
+                step = "InitLogin.Recaptcha",
+                error = %error,
+                "InitLogin body was not parseable JSON; assuming reCAPTCHA not required",
+            );
+            Ok(false)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_is_recaptcha_true() {
+        let body = r#"{"ResultData":{"IsRecaptcha":true,"RecaptchaV2PublicKey":"6Lx"}}"#;
+        let parsed: InitLoginResponse = serde_json::from_str(body).expect("valid JSON");
+        assert!(parsed.result_data.expect("ResultData present").is_recaptcha);
+    }
+
+    #[test]
+    fn parses_is_recaptcha_false() {
+        let body = r#"{"ResultData":{"IsRecaptcha":false}}"#;
+        let parsed: InitLoginResponse = serde_json::from_str(body).expect("valid JSON");
+        assert!(!parsed.result_data.expect("ResultData present").is_recaptcha);
+    }
+
+    #[test]
+    fn missing_is_recaptcha_field_defaults_to_false() {
+        // QR-shaped ResultData with no IsRecaptcha key → default false.
+        let body = r#"{"ResultData":{"QRImage":"iVBOR","IsHK":false}}"#;
+        let parsed: InitLoginResponse = serde_json::from_str(body).expect("valid JSON");
+        assert!(!parsed.result_data.expect("ResultData present").is_recaptcha);
+    }
+
+    #[test]
+    fn missing_result_data_is_none() {
+        let body = r#"{"Result":0,"ResultCode":1}"#;
+        let parsed: InitLoginResponse = serde_json::from_str(body).expect("valid JSON");
+        assert!(parsed.result_data.is_none());
+    }
+}

--- a/src-tauri/src/services/beanfun/login/init_login.rs
+++ b/src-tauri/src/services/beanfun/login/init_login.rs
@@ -36,7 +36,6 @@
 use reqwest::header;
 use serde::Deserialize;
 
-use super::ensure_success;
 use crate::services::beanfun::{BeanfunClient, LoginError};
 
 /// Subset of the `InitLogin` JSON envelope we care about for
@@ -63,13 +62,27 @@ struct InitLoginResultData {
 /// Ask the server whether the account/password login requires a
 /// reCAPTCHA challenge for this attempt.
 ///
-/// Returns `Ok(true)` when `ResultData.IsRecaptcha` is `true`,
-/// `Ok(false)` otherwise — including when the body is missing the
-/// field, lacks `ResultData`, or is not parseable as JSON. The lenient
-/// fallback is deliberate: a `false` result routes the caller through
-/// the unchanged headless flow, so a server-side response-shape change
-/// can never make us *more* broken than today (it would simply fail
-/// later in `account_login`, exactly as it does now).
+/// Returns `Ok(true)` **only** when the response positively reports
+/// `ResultData.IsRecaptcha == true`. **Every** other outcome —
+/// transport failure, non-2xx status, oversized / unreadable body,
+/// missing field, missing `ResultData`, non-JSON body — degrades to
+/// `Ok(false)`.
+///
+/// # Why fully best-effort (never `Err` on a runtime condition)
+///
+/// reCAPTCHA detection is an **additive pre-check**, not a login step:
+/// `false` simply routes the caller through the unchanged headless flow
+/// (`check_account_type` → `account_login`). Bubbling a transport /
+/// status error up from here would make a transient `InitLogin` blip
+/// fail the *entire* login — strictly worse than today, where the flow
+/// has no `InitLogin` call at all. If the network is genuinely down the
+/// subsequent headless steps surface the real error anyway, so swallowing
+/// it here loses no diagnostic signal. Only a confirmed
+/// `IsRecaptcha == true` diverts to the interactive WebView path.
+///
+/// The signature stays `Result<bool, _>` (rather than `bool`) only so
+/// the `?` on the URL builder — a programming error, not a runtime
+/// condition — can propagate; all runtime paths return `Ok`.
 ///
 /// `index_url` is the `Login/Index?pSKey=…` URL produced by
 /// [`super::get_login_index`]; it is sent verbatim as the `Referer`.
@@ -86,7 +99,7 @@ pub async fn check_recaptcha_required(
         .origin()
         .ascii_serialization();
 
-    let resp = client
+    let resp = match client
         .http()
         .get(init_url)
         .header(header::ACCEPT, "application/json, text/plain, */*")
@@ -94,10 +107,39 @@ pub async fn check_recaptcha_required(
         .header("X-Requested-With", "XMLHttpRequest")
         .header("Origin", origin)
         .send()
-        .await?;
+        .await
+    {
+        Ok(resp) => resp,
+        Err(error) => {
+            tracing::warn!(
+                step = "InitLogin.Recaptcha",
+                error = %error,
+                "InitLogin request failed; assuming reCAPTCHA not required",
+            );
+            return Ok(false);
+        }
+    };
 
-    ensure_success(&resp, "Login/InitLogin")?;
-    let body = client.bounded_text(resp).await?;
+    if !resp.status().is_success() {
+        tracing::warn!(
+            step = "InitLogin.Recaptcha",
+            status = %resp.status(),
+            "InitLogin returned non-success; assuming reCAPTCHA not required",
+        );
+        return Ok(false);
+    }
+
+    let body = match client.bounded_text(resp).await {
+        Ok(body) => body,
+        Err(error) => {
+            tracing::warn!(
+                step = "InitLogin.Recaptcha",
+                error = %error,
+                "InitLogin body read failed; assuming reCAPTCHA not required",
+            );
+            return Ok(false);
+        }
+    };
 
     match serde_json::from_str::<InitLoginResponse>(&body) {
         Ok(parsed) => Ok(parsed.result_data.map(|d| d.is_recaptcha).unwrap_or(false)),

--- a/src-tauri/src/services/beanfun/login/mod.rs
+++ b/src-tauri/src/services/beanfun/login/mod.rs
@@ -26,6 +26,7 @@ pub mod gamepass;
 pub mod hk_error;
 pub mod hk_regular;
 pub mod index;
+pub mod init_login;
 pub mod logout;
 pub mod orchestrator;
 pub mod qr_finalize;
@@ -48,6 +49,7 @@ pub use gamepass::{
 pub use hk_error::{extract_hk_error_signal, HkErrorSignal};
 pub use hk_regular::login_hk_regular;
 pub use index::{get_login_index, LoginIndex};
+pub use init_login::check_recaptcha_required;
 pub use logout::logout;
 pub use orchestrator::{login_with, LoginMethod};
 pub use qr_finalize::finalize_qr_login;

--- a/src-tauri/src/services/beanfun/login/tw_regular.rs
+++ b/src-tauri/src/services/beanfun/login/tw_regular.rs
@@ -17,8 +17,8 @@
 //! together and build the final [`Session`].
 
 use super::{
-    account_login, check_account_type, get_login_index, get_session_key, post_return_aspx,
-    send_login,
+    account_login, check_account_type, check_recaptcha_required, get_login_index, get_session_key,
+    post_return_aspx, send_login,
 };
 use crate::services::beanfun::{BeanfunClient, Credentials, LoginError, LoginRegion, Session};
 
@@ -46,6 +46,21 @@ pub async fn login_tw_regular(
     let skey = get_session_key(client).await?;
     let index = get_login_index(client, &skey).await?;
     let index_url = index.index_url.as_str().to_owned();
+
+    // As of 2026-06-25 the server may gate the account/password POSTs
+    // behind a Google reCAPTCHA v2 challenge for this attempt (see the
+    // `init_login` module docs). A v2 token cannot be produced
+    // headlessly, so bail to the interactive WebView login when
+    // required; otherwise the headless flow below is unchanged.
+    if check_recaptcha_required(client, &skey, &index_url).await? {
+        tracing::info!(
+            step = "TwRegular",
+            region = ?LoginRegion::TW,
+            account_id = %creds.account,
+            "reCAPTCHA required; deferring to interactive WebView login",
+        );
+        return Err(LoginError::RecaptchaRequired { skey });
+    }
 
     let captcha = check_account_type(
         client,

--- a/src-tauri/tests/tw_login.rs
+++ b/src-tauri/tests/tw_login.rs
@@ -65,6 +65,25 @@ async fn mount_index_with_token(server: &MockServer, token: &str) {
         .await;
 }
 
+/// Login/InitLogin — responds with `ResultData.IsRecaptcha = {is_recaptcha}`.
+///
+/// The TW Regular flow probes this right after `Login/Index` to decide
+/// whether the account/password POSTs are gated behind a reCAPTCHA v2
+/// challenge. Tests that do **not** mount this rely on the detector's
+/// best-effort degradation (a 404 → "not required" → headless flow),
+/// so only the reCAPTCHA-divert test needs to mount it explicitly.
+async fn mount_init_login(server: &MockServer, is_recaptcha: bool) {
+    let body = serde_json::json!({
+        "Result": 0,
+        "ResultData": { "IsRecaptcha": is_recaptcha }
+    });
+    Mock::given(method("GET"))
+        .and(path("/Login/InitLogin"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(body))
+        .mount(server)
+        .await;
+}
+
 /// Login/CheckAccountType — responds with the given captcha token string
 /// (pass `""` to simulate "no captcha required").
 async fn mount_check_account_type(server: &MockServer, captcha: &str) {
@@ -194,6 +213,50 @@ async fn tw_regular_happy_path_returns_session() {
     assert_eq!(session.account_id, ACCOUNT);
     assert_eq!(session.service_code, "610074");
     assert_eq!(session.service_region, "T9");
+}
+
+#[tokio::test]
+async fn recaptcha_required_diverts_to_webview_login() {
+    // When InitLogin reports IsRecaptcha=true, the headless flow must
+    // bail with RecaptchaRequired BEFORE touching CheckAccountType /
+    // AccountLogin (a reCAPTCHA v2 token can't be produced headlessly).
+    // Those two steps are intentionally left unmounted: if the flow
+    // wrongly continued past the gate it would 404 there and surface a
+    // different error, failing this test loudly.
+    let server = MockServer::start().await;
+    mount_session_key(&server).await;
+    mount_index_with_token(&server, FORM_TOKEN).await;
+    mount_init_login(&server, true).await;
+
+    let client = client_for(&server);
+    let err = login_tw_regular(&client, &creds())
+        .await
+        .expect_err("reCAPTCHA-required must divert to the WebView flow");
+
+    match err {
+        LoginError::RecaptchaRequired { skey } => assert_eq!(skey, SKEY),
+        other => panic!("expected RecaptchaRequired, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn recaptcha_false_continues_headless_flow() {
+    // The complementary guard: IsRecaptcha=false must NOT divert — the
+    // existing headless flow runs end-to-end and yields a session.
+    let server = MockServer::start().await;
+    mount_session_key(&server).await;
+    mount_index_with_token(&server, FORM_TOKEN).await;
+    mount_init_login(&server, false).await;
+    mount_check_account_type(&server, "").await;
+    mount_account_login_success(&server).await;
+    mount_send_login_happy(&server).await;
+    mount_return_aspx_with_token(&server, WEB_TOKEN).await;
+
+    let client = client_for(&server);
+    let session = login_tw_regular(&client, &creds())
+        .await
+        .expect("IsRecaptcha=false must continue the headless flow");
+    assert_eq!(session.web_token, WEB_TOKEN);
 }
 
 #[tokio::test]

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -311,6 +311,15 @@ const zhTW = {
     windowError: '無法完成 GamePass 登入，請點選重新整理重試。',
     refresh: '重新整理',
   },
+  loginRecaptcha: {
+    title: '完成「我不是機器人」驗證',
+    subtitle: '系統要求進行驗證。請在開啟的視窗中輸入帳號密碼並完成「我不是機器人」驗證以登入。',
+    opening: '正在開啟登入視窗…',
+    waiting: '請在開啟的視窗中完成登入與驗證。',
+    cancelled: '已取消驗證登入。請點選下方返回並重新登入。',
+    windowError: '無法開啟登入視窗，請點選下方返回並重新登入。',
+    altHint: '若驗證一直無法通過，可改用 QR Code 或 Gama Pass 登入。',
+  },
   accountList: {
     serviceAccountsHeading: '遊戲帳號',
     accountCount: '{count} 個帳號',
@@ -521,6 +530,15 @@ const zhCN = {
     connectionLost: '无法与 Beanfun 连接，请点选重新加载重试。',
     windowError: '无法完成 GamePass 登录，请点选重新加载重试。',
     refresh: '重新加载',
+  },
+  loginRecaptcha: {
+    title: '完成「我不是机器人」验证',
+    subtitle: '系统要求进行验证。请在打开的窗口中输入账号密码并完成「我不是机器人」验证以登录。',
+    opening: '正在打开登录窗口…',
+    waiting: '请在打开的窗口中完成登录与验证。',
+    cancelled: '已取消验证登录。请点击下方返回并重新登录。',
+    windowError: '无法打开登录窗口，请点击下方返回并重新登录。',
+    altHint: '若验证始终无法通过，可改用 QR Code 或 Gama Pass 登录。',
   },
   accountList: {
     serviceAccountsHeading: '游戏账号',
@@ -734,6 +752,16 @@ const enUS = {
     connectionLost: 'Unable to reach Beanfun. Please tap Reload and try again.',
     windowError: 'Unable to complete GamePass sign-in. Please tap Reload and try again.',
     refresh: 'Reload',
+  },
+  loginRecaptcha: {
+    title: 'Complete the "I\'m not a robot" check',
+    subtitle:
+      'Verification is required. Enter your account and password and solve the "I\'m not a robot" challenge in the window that opens to sign in.',
+    opening: 'Opening the sign-in window…',
+    waiting: 'Complete sign-in and verification in the window that opened.',
+    cancelled: 'Verification sign-in was cancelled. Tap Back below and sign in again.',
+    windowError: 'Could not open the sign-in window. Tap Back below and sign in again.',
+    altHint: 'If verification keeps failing, try QR Code or Gama Pass sign-in instead.',
   },
   accountList: {
     serviceAccountsHeading: 'Game Accounts',

--- a/src/pages/IdPassForm.vue
+++ b/src/pages/IdPassForm.vue
@@ -438,6 +438,17 @@ async function submit(): Promise<void> {
       await router.push('/login/verify')
       return
     }
+    /*
+     * issue #308 — the server required a Google reCAPTCHA v2 challenge
+     * for this account/password attempt, which can't be solved
+     * headlessly. The backend parked the session for an interactive
+     * WebView login; route to the reCAPTCHA form which opens the real
+     * beanfun login page so the user can solve "I'm not a robot" there.
+     */
+    if (auth.pendingRecaptcha) {
+      await router.push('/login/recaptcha')
+      return
+    }
   } catch {
     // The auth store already surfaced the error toast via
     // `surfaceCommandError`; staying on the form lets the user

--- a/src/pages/RecaptchaForm.vue
+++ b/src/pages/RecaptchaForm.vue
@@ -1,0 +1,285 @@
+<script setup lang="ts">
+/**
+ * reCAPTCHA account-login form (issue #308).
+ *
+ * # Why this page exists
+ *
+ * As of 2026-06-25 the TW account/password login (`Login/Index`) gates
+ * the credential POSTs behind a Google reCAPTCHA v2 "I'm not a robot"
+ * challenge whenever the server flags the client (IP / fingerprint
+ * reputation). A reCAPTCHA v2 token cannot be produced by our headless
+ * `reqwest` flow — it needs a real browser, a human checkbox click, and
+ * a token bound to beanfun's own domain. So when `loginRegular` surfaces
+ * `auth.recaptcha_required`, `IdPassForm` routes here instead of
+ * treating it as an error.
+ *
+ * # Flow
+ *
+ * ```
+ *   IdPassForm submit → loginRegular → auth.recaptcha_required
+ *     → backend parks (client, skey) on `pending_gamepass`
+ *     → router.push('/login/recaptcha')   (this page)
+ *         → mount → register gamepass-login-* listeners
+ *                 → openAccountLoginWindow  (opens real Login/Index page)
+ *                 → user types account + password + solves reCAPTCHA there
+ *                 → on gamepass-login-success → applyGamepassSession + /accounts
+ *                 → on gamepass-login-failed  → error banner
+ *                 → on gamepass-login-cancelled → "go back" prompt
+ * ```
+ *
+ * # Why it reuses the GamePass machinery
+ *
+ * The account-login WebView is mechanically identical to the GamePass
+ * WebView — both seed the session cookies, open the same
+ * `Login/Index?pSKey=…` page, and harvest `bfWebToken` once beanfun's
+ * redirect chain lands on `return.aspx`. The backend therefore reuses
+ * the same `pending_gamepass` slot, completion handlers, and
+ * `gamepass-login-*` events; this page reuses {@link useAuthStore.applyGamepassSession}
+ * the same way `GamepassForm` does. The only backend difference is that
+ * the account-login window does **not** auto-click the Gama Pass button,
+ * so the user sees the normal account/password + reCAPTCHA form.
+ *
+ * # No in-place retry
+ *
+ * Unlike `GamepassForm` (which can re-run `loginGamepassStart` to re-arm
+ * the slot), this page cannot re-arm `pending_gamepass` — that requires
+ * re-running `loginRegular` with the user's credentials, which only
+ * `IdPassForm` holds. So a cancel / failure routes the user **back to
+ * the id-pass form** to re-submit, rather than offering a same-page
+ * refresh.
+ */
+
+import { onBeforeUnmount, onMounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useRouter } from 'vue-router'
+import { ElButton } from 'element-plus'
+import { listen, type UnlistenFn } from '@tauri-apps/api/event'
+
+import { useAuthStore } from '../stores/auth'
+import { useAccountStore } from '../stores/account'
+import { CommandInvocationError } from '../services/invoke'
+import type { CommandError, SessionInfo } from '../types/bindings'
+
+/**
+ * Tauri event names emitted by the backend WebView-login flow. Shared
+ * verbatim with the GamePass flow (the backend reuses the same events);
+ * the authoritative definitions live in `src-tauri/src/commands/auth.rs`
+ * (`GAMEPASS_SUCCESS_EVENT` etc.). Kept as literals because
+ * `tauri-specta` models commands, not `app.emit(...)` events.
+ */
+const SUCCESS_EVENT = 'gamepass-login-success'
+const FAILED_EVENT = 'gamepass-login-failed'
+const CANCELLED_EVENT = 'gamepass-login-cancelled'
+
+defineOptions({ name: 'RecaptchaForm' })
+
+type Phase = 'opening' | 'waiting' | 'cancelled' | 'error'
+
+const { t } = useI18n()
+const router = useRouter()
+const auth = useAuthStore()
+const account = useAccountStore()
+
+const phase = ref<Phase>('opening')
+
+/**
+ * Disposal sentinel — set on unmount so a late event callback (after the
+ * user navigated away) is a no-op. Same rationale as `GamepassForm`.
+ */
+let disposed = false
+
+const unlistenFns: UnlistenFn[] = []
+
+async function registerEventListeners(): Promise<void> {
+  const successUnlisten = await listen<SessionInfo>(SUCCESS_EVENT, async (event) => {
+    if (disposed) return
+    account.clearSessionData()
+    auth.applyGamepassSession(event.payload)
+    disposed = true
+    await router.push('/accounts')
+  })
+  const failedUnlisten = await listen<CommandError>(FAILED_EVENT, (event) => {
+    if (disposed) return
+    // The cookie-harvest failure path doesn't go through `wrapCommand`,
+    // so the console log is the one authoritative trail for an operator.
+    console.error(`[recaptcha-form] ${FAILED_EVENT}`, event.payload)
+    phase.value = 'error'
+  })
+  const cancelledUnlisten = await listen<null>(CANCELLED_EVENT, () => {
+    if (disposed) return
+    phase.value = 'cancelled'
+  })
+  unlistenFns.push(successUnlisten, failedUnlisten, cancelledUnlisten)
+}
+
+async function openWindow(): Promise<void> {
+  phase.value = 'opening'
+  try {
+    // Pass the credentials the user already typed in `IdPassForm` (still
+    // held in `loginIntent`) so the backend can best-effort autofill
+    // beanfun's own login form — the user then only solves the reCAPTCHA
+    // and submits. Empty strings (no intent) make the autofill a no-op.
+    const intent = auth.loginIntent
+    await auth.openAccountLoginWindow(intent?.accountId ?? '', intent?.password ?? '')
+    if (disposed) return
+    phase.value = 'waiting'
+  } catch (e) {
+    if (disposed) return
+    // `openAccountLoginWindow` already toasted via `wrapCommand`; the
+    // banner adds the "go back and sign in again" affordance. A non-
+    // CommandInvocationError (e.g. withGuard "already in progress" on a
+    // double mount) is benign — leave the phase untouched.
+    if (e instanceof CommandInvocationError) {
+      phase.value = 'error'
+    }
+  }
+}
+
+onMounted(async () => {
+  // Listeners MUST register before `openAccountLoginWindow` so an eager
+  // success (harvest completes before the command Promise resolves) is
+  // not missed.
+  try {
+    await registerEventListeners()
+  } catch (e) {
+    console.error('[recaptcha-form] failed to register tauri listeners', e)
+    phase.value = 'error'
+    return
+  }
+  if (disposed) return
+  await openWindow()
+})
+
+onBeforeUnmount(() => {
+  disposed = true
+  for (const unlisten of unlistenFns) {
+    try {
+      unlisten()
+    } catch (e) {
+      console.error('[recaptcha-form] unlisten threw', e)
+    }
+  }
+  unlistenFns.length = 0
+})
+
+async function goBack(): Promise<void> {
+  disposed = true
+  await router.push('/login/id-pass')
+}
+</script>
+
+<template>
+  <section class="recaptcha-form">
+    <header class="recaptcha-form__header">
+      <h3 class="recaptcha-form__title">{{ t('loginRecaptcha.title') }}</h3>
+      <p class="recaptcha-form__subtitle">{{ t('loginRecaptcha.subtitle') }}</p>
+    </header>
+
+    <p
+      v-if="phase === 'opening' || phase === 'waiting'"
+      class="recaptcha-form__status"
+      data-testid="recaptcha-status"
+    >
+      {{ phase === 'opening' ? t('loginRecaptcha.opening') : t('loginRecaptcha.waiting') }}
+    </p>
+
+    <p
+      v-if="phase === 'cancelled'"
+      class="recaptcha-form__notice"
+      data-testid="recaptcha-cancelled"
+    >
+      {{ t('loginRecaptcha.cancelled') }}
+    </p>
+
+    <p v-if="phase === 'error'" class="recaptcha-form__error" data-testid="recaptcha-error">
+      {{ t('loginRecaptcha.windowError') }}
+    </p>
+
+    <p class="recaptcha-form__alt">{{ t('loginRecaptcha.altHint') }}</p>
+
+    <div class="recaptcha-form__actions">
+      <el-button
+        class="recaptcha-form__back"
+        type="primary"
+        size="large"
+        data-testid="recaptcha-back"
+        @click="goBack"
+      >
+        {{ t('BackRegularLogin') }}
+      </el-button>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.recaptcha-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: stretch;
+}
+
+.recaptcha-form__header {
+  text-align: center;
+}
+
+.recaptcha-form__title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+  color: #1f1a16;
+}
+
+.recaptcha-form__subtitle {
+  margin: 0.375rem 0 0;
+  font-size: 0.8125rem;
+  color: #54443a;
+}
+
+.recaptcha-form__status {
+  margin: 0;
+  padding: 0.625rem 0.875rem;
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--el-color-primary, #ff8201) 12%, transparent);
+  color: var(--bf-primary, #954a00);
+  font-size: 0.8125rem;
+  text-align: center;
+}
+
+.recaptcha-form__notice {
+  margin: 0;
+  padding: 0.625rem 0.875rem;
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--el-color-warning, #e6a23c) 14%, transparent);
+  color: var(--el-color-warning, #b88230);
+  font-size: 0.8125rem;
+  text-align: center;
+}
+
+.recaptcha-form__error {
+  margin: 0;
+  padding: 0.625rem 0.875rem;
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--el-color-danger, #f56c6c) 14%, transparent);
+  color: var(--el-color-danger, #f56c6c);
+  font-size: 0.8125rem;
+  text-align: center;
+}
+
+.recaptcha-form__alt {
+  margin: 0;
+  font-size: 0.75rem;
+  color: #54443a;
+  text-align: center;
+}
+
+.recaptcha-form__actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.recaptcha-form__back {
+  width: 100%;
+  font-weight: 700;
+}
+</style>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -108,6 +108,7 @@ import LoginRegionSelection from '../pages/LoginRegionSelection.vue'
 import IdPassForm from '../pages/IdPassForm.vue'
 import QrForm from '../pages/QrForm.vue'
 import GamepassForm from '../pages/GamepassForm.vue'
+import RecaptchaForm from '../pages/RecaptchaForm.vue'
 import LoginTotp from '../pages/LoginTotp.vue'
 import LoginWait from '../pages/LoginWait.vue'
 import VerifyPage from '../pages/VerifyPage.vue'
@@ -144,6 +145,7 @@ export const ROUTE_NAMES = {
   LoginIdPass: 'login-id-pass',
   LoginQr: 'login-qr',
   LoginGamepass: 'login-gamepass',
+  LoginRecaptcha: 'login-recaptcha',
   LoginTotp: 'login-totp',
   LoginWait: 'login-wait',
   LoginVerify: 'login-verify',
@@ -195,6 +197,17 @@ const loginChildren: RouteRecordRaw[] = [
     path: 'gamepass',
     name: ROUTE_NAMES.LoginGamepass,
     component: GamepassForm,
+    meta: {
+      titleKey: 'titleBar.login',
+      titleIcon: 'verified_user',
+      windowWidth: 420,
+      windowHeight: 460,
+    },
+  },
+  {
+    path: 'recaptcha',
+    name: ROUTE_NAMES.LoginRecaptcha,
+    component: RecaptchaForm,
     meta: {
       titleKey: 'titleBar.login',
       titleIcon: 'verified_user',

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -155,6 +155,17 @@ export interface VerifyIntent {
 const FLOW_CONTINUATION_CODES = {
   TotpRequired: 'auth.totp_required',
   AdvanceCheckRequired: 'auth.advance_check_required',
+  /**
+   * issue #308 — the TW account/password login required a Google
+   * reCAPTCHA v2 challenge for this attempt, which cannot be solved
+   * headlessly. The backend has parked the session on `pending_gamepass`
+   * (the generic "WebView login awaiting harvest" slot) and expects the
+   * UI to open the interactive account-login WebView via
+   * {@link useAuthStore.openAccountLoginWindow}. Swallowed like the other
+   * continuation codes (no toast) so `IdPassForm` can route to
+   * `/login/recaptcha` instead of surfacing it as an error.
+   */
+  RecaptchaRequired: 'auth.recaptcha_required',
 } as const
 
 /**
@@ -189,6 +200,7 @@ export const AUTH_ACTIONS = {
   LoginQrStart: 'login.qr_start',
   LoginQrCheck: 'login.qr_check',
   LoginGamepassStart: 'login.gamepass_start',
+  OpenAccountLoginWindow: 'login.open_account_login_window',
   GetVerifyPageInfo: 'verify.page_info',
   GetVerifyCaptcha: 'verify.captcha',
   SubmitVerify: 'verify.submit',
@@ -201,6 +213,14 @@ export const useAuthStore = defineStore('auth', () => {
   const session = ref<SessionInfo | null>(null)
   const pendingTotp = ref(false)
   const pendingVerify = ref(false)
+  /**
+   * issue #308 — set when {@link loginRegular} sees
+   * `auth.recaptcha_required`. Tells `IdPassForm` to route to
+   * `/login/recaptcha` (the interactive account-login WebView) instead
+   * of treating the response as a hard error. Cleared on any successful
+   * login and on {@link clearSession}.
+   */
+  const pendingRecaptcha = ref(false)
   const qrChallenge = ref<QrStart | null>(null)
   const pendingAction = ref<AuthAction | null>(null)
 
@@ -289,6 +309,7 @@ export const useAuthStore = defineStore('auth', () => {
         session.value = result.data
         pendingTotp.value = false
         pendingVerify.value = false
+        pendingRecaptcha.value = false
         qrChallenge.value = null
         advanceCheckUrl.value = null
         return result.data
@@ -300,6 +321,10 @@ export const useAuthStore = defineStore('auth', () => {
       if (result.error.code === FLOW_CONTINUATION_CODES.AdvanceCheckRequired) {
         pendingVerify.value = true
         advanceCheckUrl.value = readAdvanceCheckUrl(result.error.details)
+        return null
+      }
+      if (result.error.code === FLOW_CONTINUATION_CODES.RecaptchaRequired) {
+        pendingRecaptcha.value = true
         return null
       }
       surfaceCommandError(result.error)
@@ -321,6 +346,7 @@ export const useAuthStore = defineStore('auth', () => {
         session.value = result.data
         pendingTotp.value = false
         pendingVerify.value = false
+        pendingRecaptcha.value = false
         advanceCheckUrl.value = null
         return result.data
       }
@@ -373,6 +399,7 @@ export const useAuthStore = defineStore('auth', () => {
           qrChallenge.value = null
           pendingTotp.value = false
           pendingVerify.value = false
+          pendingRecaptcha.value = false
           advanceCheckUrl.value = null
         } else if (result.data.status === 'expired') {
           qrChallenge.value = null
@@ -436,8 +463,32 @@ export const useAuthStore = defineStore('auth', () => {
     session.value = info
     pendingTotp.value = false
     pendingVerify.value = false
+    pendingRecaptcha.value = false
     qrChallenge.value = null
     advanceCheckUrl.value = null
+  }
+
+  /**
+   * Open the interactive account-login WebView used by the issue #308
+   * reCAPTCHA flow. The backend has already parked `(client, skey)` on
+   * its `pending_gamepass` slot (via {@link loginRegular}'s
+   * `auth.recaptcha_required` branch), so this just pops the WebView.
+   *
+   * `account` / `password` are the values the user already typed in
+   * `IdPassForm` (read from {@link loginIntent}); the backend uses them
+   * only to best-effort autofill beanfun's own login form so the user
+   * just solves the reCAPTCHA + submits. Pass empty strings to skip
+   * autofill.
+   *
+   * The terminal outcome arrives via the same `gamepass-login-success` /
+   * `-failed` / `-cancelled` Tauri events the GamePass flow uses, which
+   * `RecaptchaForm.vue` listens for and routes through
+   * {@link applyGamepassSession}.
+   */
+  async function openAccountLoginWindow(account: string, password: string): Promise<void> {
+    return withGuard(AUTH_ACTIONS.OpenAccountLoginWindow, async () => {
+      await wrapCommand(commands.openAccountLoginWindow(account, password))
+    })
   }
 
   async function getVerifyPageInfo(advanceCheckUrl: string | null): Promise<VerifyPage> {
@@ -501,6 +552,7 @@ export const useAuthStore = defineStore('auth', () => {
     session.value = null
     pendingTotp.value = false
     pendingVerify.value = false
+    pendingRecaptcha.value = false
     qrChallenge.value = null
     advanceCheckUrl.value = null
     /*
@@ -580,6 +632,7 @@ export const useAuthStore = defineStore('auth', () => {
     isLoggedIn,
     pendingTotp,
     pendingVerify,
+    pendingRecaptcha,
     qrChallenge,
     advanceCheckUrl,
     pendingAction,
@@ -591,6 +644,7 @@ export const useAuthStore = defineStore('auth', () => {
     loginQrStart,
     loginQrCheck,
     loginGamepassStart,
+    openAccountLoginWindow,
     applyGamepassSession,
     getVerifyPageInfo,
     getVerifyCaptcha,

--- a/src/types/bindings.ts
+++ b/src/types/bindings.ts
@@ -11,7 +11,7 @@ export const commands = {
 /**
  * Return the static build metadata. Infallible; no parameters; no
  * state.
- *
+ * 
  * Intended as the simplest possible Tauri command — if this
  * doesn't round-trip correctly, nothing else will. Also serves as
  * the canonical example of a sync `#[tauri::command]` with a
@@ -22,12 +22,12 @@ async version() : Promise<VersionInfo> {
 },
 /**
  * Round-trip an input string through a blocking worker thread.
- *
+ * 
  * Exercises the canonical Win32-wrapping pattern: the closure runs
  * on a [`tokio::task::spawn_blocking`] pool worker (not the reactor
  * thread), sleeps for 60 ms to prove the `await` point genuinely
  * suspends, then returns `"pong: {input}"`.
- *
+ * 
  * Failure path: if the blocking task panics or is cancelled the
  * [`tokio::task::JoinError`] is mapped to
  * `system.spawn_blocking_failed`. Should never happen in steady
@@ -45,7 +45,7 @@ async ping(message: string) : Promise<Result<string, CommandError>> {
 },
 /**
  * Return host visual-environment flags used by the web UI.
- *
+ * 
  * This is deliberately separate from [`version`]: build metadata is
  * static, while this value depends on the user's OS. It is still
  * synchronous and infallible so the frontend can query it before
@@ -56,9 +56,9 @@ async windowVisualEnvironment() : Promise<WindowVisualEnvironment> {
 },
 /**
  * TW / HK regular username+password login.
- *
+ * 
  * # Protocol
- *
+ * 
  * 1. Best-effort clear [`AppState::pending_totp`]
  * ([`AppState`]) so a stale continuation from an abandoned
  * HK-TOTP attempt cannot leak into the new login's error
@@ -78,7 +78,7 @@ async windowVisualEnvironment() : Promise<WindowVisualEnvironment> {
  * [`LoginError::AdvanceCheckRequired`] which surfaces
  * `auth.advance_check_required` with the challenge URL for the
  * frontend to drive a verify flow.
- *
+ * 
  * # Why take `account` + `password` by value?
  * 
  * `#[tauri::command]` deserialises arguments from the JS invoke
@@ -391,6 +391,64 @@ async loginGamepassStart(region: LoginRegion) : Promise<Result<null, CommandErro
 async openGamepassWindow() : Promise<Result<null, CommandError>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("open_gamepass_window") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Open the reCAPTCHA account-login WebView window.
+ * 
+ * Triggered by the frontend after [`login_regular`] surfaces
+ * [`RECAPTCHA_REQUIRED_CODE`]: the TW account/password login required a
+ * Google reCAPTCHA v2 challenge for this attempt, which cannot be
+ * solved headlessly (see
+ * [`crate::services::beanfun::login::init_login`]). This opens the real
+ * `Login/Index?pSKey=…` page in a WebView so the user can type their
+ * account + password and solve the "I'm not a robot" challenge inside
+ * beanfun's own page; the resulting `bfWebToken` is harvested by the
+ * shared [`handle_gamepass_page_load`] hook exactly as GamePass does.
+ * 
+ * # Reuse of the GamePass machinery (deliberate)
+ * 
+ * The reCAPTCHA account login and GamePass login are mechanically
+ * identical — both seed the portal session cookies into an
+ * `about:blank` WebView, navigate to the same `Login/Index?pSKey=…`
+ * URL, and harvest `bfWebToken` once beanfun's redirect chain reaches
+ * `return.aspx`. So this command re-uses:
+ * 
+ * - [`AppState::pending_gamepass`] — parked by [`login_regular`]'s
+ * `RecaptchaRequired` arm (the generic "WebView login awaiting
+ * harvest" slot).
+ * - [`handle_gamepass_page_load`] / [`handle_gamepass_window_destroyed`]
+ * — the completion + cancel hooks.
+ * - The `gamepass-login-success` / `-failed` / `-cancelled` events
+ * (consumed unchanged by the frontend's `applyGamepassSession`).
+ * 
+ * The difference from [`open_gamepass_window`] is the
+ * `initialization_script`: GamePass auto-clicks the "use Gama Pass"
+ * button, whereas here we inject a **best-effort autofill** (built by
+ * [`build_account_autofill_script`]) that pre-fills the `account` +
+ * `password` the user already typed in `IdPassForm`, so they only need
+ * to solve the "I'm not a robot" challenge and submit. We never
+ * auto-click — the reCAPTCHA must be solved by the human. A distinct
+ * window label ([`ACCOUNT_LOGIN_WINDOW_LABEL`]) keeps the double-open
+ * guard independent of the GamePass window.
+ * 
+ * `account` / `password` come from the frontend's `loginIntent` (the
+ * same values it passed to `login_regular`); they are used **only** to
+ * pre-fill beanfun's own login form and are not persisted here. Empty
+ * strings (e.g. direct navigation) make the autofill a no-op.
+ * 
+ * `open_gamepass_window` is left **byte-for-byte untouched** (it was
+ * the subject of the issue #296 stale-cookie fix); the #296-critical
+ * `DeleteAllCookies` / `AddOrUpdateCookie` mechanics live in the shared
+ * [`crate::commands::cookie_native`] module, so only the (trivial)
+ * clear→seed→navigate sequencing is duplicated here.
+ */
+async openAccountLoginWindow(account: string, password: string) : Promise<Result<null, CommandError>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("open_account_login_window", { account, password }) };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
@@ -1784,7 +1842,7 @@ async killGameProcesses(pids: number[]) : Promise<Result<number[], CommandError>
 /**
  * Close MapleStory's Nexon launcher Play dialog if it is currently
  * visible.
- *
+ * 
  * Mirrors one tick of WPF `checkPlayPage_Tick`: find
  * `StartUpDlgClass` / `MapleStory` and post `WM_CLOSE`. The
  * frontend drives this command on a short interval when the
@@ -1801,7 +1859,7 @@ async closeMaplePlayWindow() : Promise<Result<boolean, CommandError>> {
 /**
  * Best-effort terminate MapleStory's `Patcher.exe` from the same
  * directory as `game_path`.
- *
+ * 
  * Mirrors one tick of WPF `checkPatcher_Tick`'s kill branch. The
  * frontend drives this command on a short interval when the
  * MapleStory-only `autoKillPatcher` preference is enabled.
@@ -3129,12 +3187,12 @@ tauri: string }
 /**
  * Runtime visual-environment hints consumed by the frontend before
  * mounting.
- *
+ * 
  * Kept intentionally narrow: the frontend only needs to know when
  * the host cannot safely use the Win11-style translucent glass recipe
  * over a transparent Tauri window.
  */
-export type WindowVisualEnvironment = {
+export type WindowVisualEnvironment = { 
 /**
  * `true` on Windows builds whose build number is below 22000
  * (Windows 10). Those hosts need an opaque CSS fallback because


### PR DESCRIPTION
## Summary

Fixes #308 — beanfun's TW account/password login now gates
`CheckAccountType` / `AccountLogin` behind a **Google reCAPTCHA v2**
challenge whenever the server flags the client (IP / connection
fingerprint), surfaced via `Login/InitLogin`'s `IsRecaptcha` flag. A v2
token cannot be produced by the headless `reqwest` flow (it needs a real
browser, a human checkbox click, and a token bound to beanfun's own
domain), so headless login simply fails for affected users.

This adds an interactive WebView fallback, gated on the server flag so
unaffected users keep the fast headless path:

- **Detect**: new `login/init_login.rs` reads `ResultData.IsRecaptcha`
  after `get_login_index` (missing/unparseable → `false`, i.e. no
  behaviour change). QR login is untouched.
- **Branch**: `login_tw_regular` bails with
  `LoginError::RecaptchaRequired { skey }` when required; otherwise the
  existing headless flow is byte-for-byte unchanged.
- **Hand off**: `login_regular` parks `(client, skey)` on the existing
  `pending_gamepass` slot and returns `auth.recaptcha_required`.
- **WebView**: new `open_account_login_window` command opens the real
  `Login/Index?pSKey=…` page so the user solves the challenge inside
  beanfun's own page; `bfWebToken` is harvested by **reusing** the
  GamePass machinery (same slot, page-load / destroyed handlers,
  `gamepass-login-*` events, cookie clear/seed via `cookie_native`).
  `open_gamepass_window` is **left untouched**.
- **Autofill**: the account/password the user already typed are
  best-effort filled into beanfun's form via an init script (JSON-encoded
  injection, `MutationObserver` for the Vue `v-show` form, graceful
  degradation), so the user only solves the reCAPTCHA and submits.
- **Frontend**: `auth` store gains `pendingRecaptcha` +
  `openAccountLoginWindow`; `IdPassForm` routes to a new
  `/login/recaptcha` page (`RecaptchaForm.vue`) which reuses
  `applyGamepassSession`. Three-locale i18n added.

## Why reuse the GamePass flow

The reCAPTCHA account login and GamePass login are mechanically
identical — both seed the portal session cookies into an `about:blank`
WebView, navigate to the same `Login/Index?pSKey=…` URL, and harvest
`bfWebToken` once the redirect chain lands on `return.aspx`. The only
difference is GamePass auto-clicks "use Gama Pass" whereas the
account-login window shows the credential + reCAPTCHA form. The
#296-critical cookie mechanics already live in the shared
`cookie_native` module, so only trivial orchestration is duplicated and
`open_gamepass_window` is not modified.

## Test plan

- [x] `cargo test --lib` (753), `cargo clippy --lib -- -D warnings`, `cargo fmt --check`
- [x] `npm run typecheck`, `npm run lint`, `npm run test` (606), `npm run format:check`
- [x] Manual: reCAPTCHA-triggered login → WebView opens real page →
      credentials autofilled → solve reCAPTCHA → `bfWebToken` harvested →
      lands on account list. ✅
- [ ] Manual: clean IP (`IsRecaptcha=false`) → unchanged headless flow, no window.
- [ ] Manual: GamePass login regression (unchanged, but worth a smoke test).

## Out of scope / follow-ups

- Multi-instance WebView2 cookie-store isolation (two launchers sharing
  one profile clobber each other's session) — pre-existing, affects
  GamePass too; tracked separately.