### PR TITLE
fix(router): allow Manage Account before login (#314)

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -242,6 +242,10 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add src-tauri/Cargo.toml src-tauri/tauri.conf.json package.json
+          # Cargo.lock is re-synced by the Tauri build step after the
+          # Cargo.toml version rewrite; committing it here keeps the bump
+          # atomic — otherwise every local `cargo build` regenerates the
+          # lock and blocks the next `git pull` (#314 follow-up).
+          git add src-tauri/Cargo.toml src-tauri/Cargo.lock src-tauri/tauri.conf.json package.json
           git commit -m "Bump version to ${{ steps.prep_version.outputs.semantic_version }} for release ${{ steps.prep_version.outputs.tag_name }}"
           git push

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -330,7 +330,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "beanfun"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "aes",
  "anyhow",

--- a/src/pages/ManageAccount.vue
+++ b/src/pages/ManageAccount.vue
@@ -490,14 +490,10 @@ function formatLoginTime(iso: string): string {
  * (the login funnel and `AccountList`), so they fall back to
  * `/login` when history is empty. ManageAccount has exactly one
  * production entry point: `Settings.vue` (`router.push('/manage-account')`).
- * The route is also `requiresAuth: true`, so falling back to
- * `/login` would either kick the user out of their session UX
- * unnecessarily (if still authenticated) or trigger the auth
- * guard's `?redirect=/login` self-loop (if expired). `/settings`
- * is the canonical re-entry surface in both cases — and in the
- * unlikely event of an expired session, the auth guard on
- * `/settings` … wait, `/settings` is `requiresAuth: undefined`,
- * so it's public; the user lands there cleanly either way.
+ * `/settings` is therefore the canonical re-entry surface. Both
+ * routes are public (`requiresAuth` unset — see #314: the page is
+ * local Users.dat CRUD and must work pre-login like WPF), so the
+ * user lands there cleanly whether or not a session exists.
  *
  * # Edge case: direct hash entry
  *

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -24,7 +24,7 @@
  *   /login/wait                    LoginWait                 (D7 ✓)
  *   /login/verify                  VerifyPage                (D8 ✓)
  * /accounts                        AccountList               (P12.2 D1 ✓, requiresAuth)
- * /manage-account                  ManageAccount             (P12.2 D9 ✓, requiresAuth)
+ * /manage-account                  ManageAccount             (P12.2 D9 ✓, public since #314)
  * /:pathMatch(.*)*                 redirect → /              (D10 catch-all)
  * ```
  *
@@ -322,17 +322,19 @@ export const routes: RouteRecordRaw[] = [
     component: ManageAccount,
     /*
      * P12.2 D9: stored-credential CRUD page (Users.dat add / edit /
-     * delete + plaintext JSON import / export). Reachable today only
-     * via direct hash navigation (`#/manage-account`); the Settings
-     * page entry button lands in P12.4 alongside the other settings
-     * surface — the WPF parent surface is `Setting.xaml` not
-     * `Login.xaml`, so wiring an entry from `AccountList.vue` would
-     * misplace the button. `requiresAuth: true` because the stored
-     * accounts are session-scoped UX (the page only makes sense for
-     * a logged-in user managing the credentials they just used).
+     * delete + plaintext JSON import / export). Entry point is the
+     * Settings page button (P12.4), which is itself public — WPF's
+     * `Settings.xaml.cs::ManageAcc_Click` (L266-269) navigates
+     * unconditionally, with no login gate, and the page only touches
+     * the local DPAPI-encrypted Users.dat via `commands.loadAccounts`
+     * / `saveAccount` / `removeAccount` (no session-scoped backend
+     * call anywhere on the page). D9 originally shipped
+     * `requiresAuth: true` on the "session-scoped UX" theory; issue
+     * #314 showed that guess breaks the WPF pre-login flow (Settings
+     * → 管理帳號 bounced back to `/login`), so the route is public
+     * now, matching `/settings` and `/about`.
      */
     meta: {
-      requiresAuth: true,
       titleKey: 'titleBar.manageAccount',
       titleIcon: 'manage_accounts',
       windowWidth: 880,

--- a/tests/unit/router/index.spec.ts
+++ b/tests/unit/router/index.spec.ts
@@ -73,7 +73,13 @@ describe('router config', () => {
 
     expect(manageAccount.path).toBe('/manage-account')
     expect(manageAccount.name).toBe(ROUTE_NAMES.ManageAccount)
-    expect(manageAccount.meta?.requiresAuth).toBe(true)
+    /*
+     * Public since #314 — WPF's Settings → ManageAccount navigation
+     * has no login gate (the page is local Users.dat CRUD), and the
+     * SPA entry point (`/settings`) is itself public, so gating this
+     * route bounced pre-login users back to /login.
+     */
+    expect(manageAccount.meta?.requiresAuth).toBeUndefined()
 
     expect(catchAll.path).toBe('/:pathMatch(.*)*')
     expect(catchAll.redirect).toBe('/')
@@ -264,15 +270,14 @@ describe('createAppRouter', () => {
      * (the Settings entry lands in P12.4). Direct hash navigation
      * (`#/manage-account`) is the only path today, so the route
      * resolution itself is the public contract this spec locks in.
-     * `requiresAuth: true` mirrors `/accounts`; the guard-installed
-     * redirect is covered by the integration block below.
+     * Public since #314 (see the route-table spec above).
      */
     const router = createAppRouter()
     await router.push('/manage-account')
     await router.isReady()
     expect(router.currentRoute.value.name).toBe(ROUTE_NAMES.ManageAccount)
     expect(router.currentRoute.value.path).toBe('/manage-account')
-    expect(router.currentRoute.value.meta.requiresAuth).toBe(true)
+    expect(router.currentRoute.value.meta.requiresAuth).toBeUndefined()
   })
 
   it('returns a fresh instance per call (no shared singleton state)', () => {
@@ -337,10 +342,11 @@ describe('installRouterGuards — integration with production /accounts route', 
     expect(router.currentRoute.value.path).toBe('/accounts')
   })
 
-  it('redirects unauthenticated /manage-account visits to /login since the route requires auth', async () => {
+  it('lets unauthenticated /manage-account visits land on the ManageAccount route (#314)', async () => {
     /*
-     * ManageAccount is behind `requiresAuth: true`, so
-     * unauthenticated users are redirected to /login.
+     * #314: the page is local Users.dat CRUD and WPF allowed it
+     * pre-login (Settings → 管理帳號 with no session). The route is
+     * public, so no redirect happens without a session.
      */
     const router = createAppRouter()
     installRouterGuards(router, { isAuthenticated: () => false, clearSession: () => {} })
@@ -348,7 +354,8 @@ describe('installRouterGuards — integration with production /accounts route', 
     await router.push('/manage-account')
     await router.isReady()
 
-    expect(router.currentRoute.value.path).toBe('/login')
+    expect(router.currentRoute.value.name).toBe(ROUTE_NAMES.ManageAccount)
+    expect(router.currentRoute.value.path).toBe('/manage-account')
   })
 
   it('lets authenticated /manage-account visits land on the ManageAccount route', async () => {


### PR DESCRIPTION
## What

Opening Settings → 管理帳號 (Manage Account) before logging in immediately bounces back to the login screen. Logged-in users are unaffected.

Root cause: the `/manage-account` route shipped with `requiresAuth: true`, so the router's auth guard redirects unauthenticated visits to `/login`. The old WPF client has no such gate — `Settings.xaml.cs::ManageAcc_Click` navigates unconditionally — and the page itself only performs CRUD on the local DPAPI-encrypted `Users.dat` (`load_accounts` / `save_account` / `remove_account`); no session-scoped backend command is involved anywhere on the page.

This PR also fixes a release-pipeline annoyance: the version-bump commit created by the release workflow updates `Cargo.toml` / `tauri.conf.json` / `package.json` but never committed `Cargo.lock`, leaving the lockfile one version behind after every release. Any local `cargo build` then re-synced the lock, and the dirty file blocked every subsequent `git pull`.

## Fix

- `src/router/index.ts` — drop `requiresAuth: true` from the `/manage-account` route so it is public, matching `/settings` and `/about` (both already public for the same WPF pre-login parity reason). Updated the three router spec assertions accordingly.
- `.github/workflows/build-and-release.yml` — include `src-tauri/Cargo.lock` in the version-bump commit (the Tauri build step already re-syncs it on the runner after the `Cargo.toml` rewrite), and sync the currently-stale lock (6.0.2 → 6.0.3) so the tree is clean from now on.

Tested: `vue-tsc` typecheck, ESLint, and all 606 frontend unit tests pass.

Closes #314