### PR TITLE
fix(accounts): keep drag order across store-internal refreshes (#317)

### DIFF
--- a/src/stores/account.ts
+++ b/src/stores/account.ts
@@ -234,9 +234,38 @@ export const useAccountStore = defineStore('account', () => {
     return serviceAccounts.value.find((a) => a.sid === selectedSid.value) ?? null
   })
 
+  /**
+   * The most recent explicit display order, remembered for the
+   * lifetime of the session (#317).
+   *
+   * WPF re-applies the saved drag order after **every** fetch —
+   * `BeanfunClient.Account.cs::GetAccounts` L137-139 calls
+   * `AccountList.Current.ApplyAccountOrder()` unconditionally. The
+   * SPA only re-applied it on the `AccountList.vue::loadList` path,
+   * so any store-internal refresh (`changeServiceAccountName` /
+   * `addServiceAccount` / the refresh button) reset the list to
+   * server order and visibly scrambled a user-defined arrangement.
+   *
+   * The store can't read the persisted CSV itself (Config.xml
+   * access is deliberately outside this store — see the
+   * `setServiceAccountOrder` docblock), so it remembers the last
+   * order that flowed through {@link setServiceAccountOrder}
+   * (either a drag or the page's saved-CSV apply) and replays it in
+   * {@link applyAccountListResult}. Replay is safe across game
+   * switches without an explicit reset: sids are per-game, so a
+   * stale order from another game matches nothing and the
+   * "skip unknown / append tail" invariants leave the fresh
+   * server order untouched until the page applies the new game's
+   * CSV.
+   */
+  let sessionOrderedSids: readonly string[] = []
+
   function applyAccountListResult(r: AccountListResult): void {
     serviceAccounts.value = r.accounts
     amountLimitNotice.value = r.amount_limit_notice
+    if (sessionOrderedSids.length > 0) {
+      setServiceAccountOrder(sessionOrderedSids)
+    }
   }
 
   /**
@@ -340,6 +369,14 @@ export const useAccountStore = defineStore('account', () => {
    *   reactive ref for consumers that prefer to watch).
    */
   function setServiceAccountOrder(orderedSids: readonly string[]): ServiceAccount[] {
+    /*
+     * Remember the order before any early return so a replayed
+     * refresh (#317, see `sessionOrderedSids`) still honours an
+     * order that was set while the list happened to be empty
+     * (e.g. saved-CSV apply racing a slow first fetch).
+     */
+    sessionOrderedSids = [...orderedSids]
+
     if (serviceAccounts.value.length === 0) return serviceAccounts.value
 
     const remaining = new Map<string, ServiceAccount>()
@@ -425,6 +462,7 @@ export const useAccountStore = defineStore('account', () => {
   function clearSessionData(): void {
     serviceAccounts.value = []
     amountLimitNotice.value = { kind: 'none' }
+    sessionOrderedSids = []
     selectedSid.value = null
     email.value = null
     remainPoint.value = null

--- a/tests/unit/stores/account.spec.ts
+++ b/tests/unit/stores/account.spec.ts
@@ -467,6 +467,96 @@ describe('useAccountStore — service-account ordering (D7)', () => {
   })
 })
 
+/* ------------------------------------------------------------------ */
+/* #317 — session order replay on store-internal refreshes            */
+/* ------------------------------------------------------------------ */
+
+/**
+ * WPF re-applies the saved drag order after **every** fetch
+ * (`BeanfunClient.Account.cs::GetAccounts` L137-139 →
+ * `ApplyAccountOrder`). The SPA only re-applied it on the
+ * `AccountList.vue::loadList` path, so `changeServiceAccountName` /
+ * `addServiceAccount` (which auto-refresh inside the store) reset
+ * the list to server order — issue #317's "帳號清單排序被打亂".
+ * The store now remembers the last order that flowed through
+ * `setServiceAccountOrder` and replays it in
+ * `applyAccountListResult`.
+ */
+describe('useAccountStore — session order replay (#317)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    for (const fn of Object.values(commands) as ReturnType<typeof vi.fn>[]) fn.mockReset()
+  })
+
+  const THIRD_SA: ServiceAccount = {
+    ...SERVICE_ACCOUNT,
+    sid: 'sid-3',
+    ssn: '00003',
+    sname: 'Three',
+  }
+
+  const THREE_LIST: AccountListResult = {
+    accounts: [SERVICE_ACCOUNT, SECOND_SA, THIRD_SA],
+    amount_limit_notice: { kind: 'none' },
+  }
+
+  it('changeServiceAccountName keeps the drag order across its auto-refresh', async () => {
+    vi.mocked(commands.getAccounts).mockReturnValueOnce(ok(THREE_LIST))
+    vi.mocked(commands.changeDisplayName).mockReturnValueOnce(ok(true))
+    /* Backend refresh returns server (ssn) order — the pre-#317 scramble. */
+    vi.mocked(commands.refresh).mockReturnValueOnce(ok(THREE_LIST))
+    const store = useAccountStore()
+    await store.getServiceAccounts()
+
+    store.setServiceAccountOrder(['sid-3', 'sid-1', 'sid-2'])
+    await store.changeServiceAccountName('Renamed', SERVICE_ACCOUNT)
+
+    expect(store.serviceAccounts.map((a) => a.sid)).toEqual(['sid-3', 'sid-1', 'sid-2'])
+  })
+
+  it('addServiceAccount appends the new row after the remembered order', async () => {
+    vi.mocked(commands.getAccounts).mockReturnValueOnce(ok(ACCOUNT_LIST))
+    vi.mocked(commands.addServiceAccount).mockReturnValueOnce(ok(true))
+    vi.mocked(commands.refresh).mockReturnValueOnce(ok(THREE_LIST))
+    const store = useAccountStore()
+    await store.getServiceAccounts()
+
+    store.setServiceAccountOrder(['sid-2', 'sid-1'])
+    await store.addServiceAccount('Three')
+
+    /* sid-3 is unknown to the remembered order → appended at the tail. */
+    expect(store.serviceAccounts.map((a) => a.sid)).toEqual(['sid-2', 'sid-1', 'sid-3'])
+  })
+
+  it('explicit refreshServiceAccounts also replays the remembered order', async () => {
+    vi.mocked(commands.getAccounts).mockReturnValueOnce(ok(THREE_LIST))
+    vi.mocked(commands.refresh).mockReturnValueOnce(ok(THREE_LIST))
+    const store = useAccountStore()
+    await store.getServiceAccounts()
+
+    store.setServiceAccountOrder(['sid-2', 'sid-3', 'sid-1'])
+    await store.refreshServiceAccounts()
+
+    expect(store.serviceAccounts.map((a) => a.sid)).toEqual(['sid-2', 'sid-3', 'sid-1'])
+  })
+
+  it('clearSessionData forgets the remembered order (logout must not leak)', async () => {
+    vi.mocked(commands.getAccounts)
+      .mockReturnValueOnce(ok(THREE_LIST))
+      .mockReturnValueOnce(ok(THREE_LIST))
+    const store = useAccountStore()
+    await store.getServiceAccounts()
+    store.setServiceAccountOrder(['sid-3', 'sid-2', 'sid-1'])
+
+    store.clearSessionData()
+    await store.getServiceAccounts()
+
+    /* Fresh session → server order untouched. */
+    expect(store.serviceAccounts.map((a) => a.sid)).toEqual(['sid-1', 'sid-2', 'sid-3'])
+  })
+})
+
 describe('useAccountStore — session-scoped lookups', () => {
   beforeEach(() => {
     setActivePinia(createPinia())


### PR DESCRIPTION
## What

Drag-reordering the game account list, then editing any account's display name (使用者名稱), scrambles the list back to server order.

Root cause: the custom order is persisted to `Config.xml::AccountOrder_<gameCode>` but only re-applied on the `AccountList.vue::loadList` path. `changeServiceAccountName` and `addServiceAccount` auto-refresh **inside the account store** (`refresh()` → `applyAccountListResult`), which reassigns `serviceAccounts` to the server-sorted result without re-applying the saved order. WPF has no such gap — `BeanfunClient.Account.cs::GetAccounts` calls `ApplyAccountOrder()` unconditionally after every fetch.

## Fix

`src/stores/account.ts` — the store now remembers the last display order that flowed through `setServiceAccountOrder` (a drag or the page's saved-CSV apply) and replays it in `applyAccountListResult`, so every refresh path (rename, add, manual refresh) preserves the arrangement. The existing WPF-parity invariants (skip unknown sids / append unmentioned rows at the tail) keep newly added and removed accounts correct, and the remembered order is cleared on logout. Stale orders from another game match no sids, so game switching is unaffected.

Added 4 regression tests (rename keeps order, add appends at tail, manual refresh replays, logout forgets). `vue-tsc`, ESLint, and all 610 frontend unit tests pass.

Closes #317