### PR TITLE
fix(ui): announcement banner clears the page, 30s read, robust seen-state

### DIFF
--- a/src/components/AnnouncementModal.vue
+++ b/src/components/AnnouncementModal.vue
@@ -208,7 +208,6 @@ async function open(url: string): Promise<void> {
   <div v-if="visible" class="ann" data-testid="announcement">
     <div class="ann__card" role="dialog" aria-modal="true">
       <header class="ann__head">
-        <span class="ann__badge" aria-hidden="true">📢</span>
         <h2 class="ann__title">{{ t('announcement.title') }}</h2>
       </header>
 
@@ -305,11 +304,6 @@ async function open(url: string): Promise<void> {
   align-items: center;
   gap: 10px;
   margin-bottom: 14px;
-}
-
-.ann__badge {
-  font-size: 1.35rem;
-  line-height: 1;
 }
 
 .ann__title {

--- a/src/components/AnnouncementModal.vue
+++ b/src/components/AnnouncementModal.vue
@@ -13,17 +13,20 @@
  *   single form (e.g. the login page); showing the notice temporarily grows
  *   the OS window so the announcement isn't crammed, and restores the
  *   previous size on close.
- * - **Re-openable afterwards.** Once acknowledged (or on any later launch of
- *   the same version) a slim full-width banner sits just under the title bar
- *   so the user can re-open and re-read the notice at will — this time
- *   without the forced countdown. The banner's × hides it for the session
- *   (it returns next launch).
+ * - **Re-openable afterwards, permanently.** Once acknowledged (or on any
+ *   later launch of the same version) a slim full-width banner sits just
+ *   under the title bar so the user can re-open and re-read the notice at
+ *   will — always without the forced countdown. The banner is permanent
+ *   (no dismiss) and reserves its own strip so it never overlaps the page.
+ * - **Robust "seen" state.** The acknowledged version is stored in both
+ *   Config.xml and WebView localStorage; either one counts as seen, so
+ *   hand-wiping one store doesn't re-trigger the forced read.
  *
  * Mounted once at the app root ({@link App.vue}) so it overlays whatever
  * route is active.
  */
 
-import { onBeforeUnmount, onMounted, ref } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { getCurrentWindow } from '@tauri-apps/api/window'
 import { LogicalSize } from '@tauri-apps/api/dpi'
@@ -34,8 +37,13 @@ import { setWindowFitSuspended } from '../services/windowFit'
 import { useConfigStore } from '../stores/config'
 
 /** Seconds the user must wait before the dismiss button enables. */
-const READ_SECONDS = 60
-/** Config.xml key holding the last app version the user acknowledged. */
+const READ_SECONDS = 30
+/**
+ * Key holding the last app version the user acknowledged. Written to
+ * BOTH Config.xml and WebView localStorage; "seen" if *either* matches
+ * (see {@link isSeen}). Two independent stores means hand-deleting one
+ * (e.g. editing Config.xml) doesn't silently force the forced-read again.
+ */
 const SEEN_KEY = 'announcementSeenVersion'
 /** Logical size the window grows to while the notice is shown. */
 const BIG_W = 640
@@ -50,9 +58,32 @@ const config = useConfigStore()
 
 /** Version loaded → the re-open banner may render. */
 const ready = ref(false)
-/** Session-only: user hid the re-open banner (comes back next launch). */
-const bannerHidden = ref(false)
 const visible = ref(false)
+
+/**
+ * The slim re-open banner is **permanent**: whenever the notice card
+ * itself is closed it sits under the title bar so the announcement is
+ * always one click away (no session-dismiss). It never triggers the
+ * countdown — {@link reopen} is review mode.
+ */
+const bannerVisible = computed(() => ready.value && !visible.value)
+
+/**
+ * Reserve a strip under the title bar while the banner is up so the
+ * `position: fixed` banner never overlaps the page content (it used to
+ * cover the top of the login form). Toggles a global body class picked
+ * up by the unscoped style block below; the router's content-fit
+ * resizer then re-measures and grows the window to include the strip.
+ */
+watch(
+  bannerVisible,
+  (open) => {
+    if (typeof document !== 'undefined') {
+      document.body.classList.toggle('bf-ann-banner-open', open)
+    }
+  },
+  { immediate: true },
+)
 /** `true` = the auto-shown, countdown-gated first read; `false` = review. */
 const forced = ref(false)
 const remaining = ref(READ_SECONDS)
@@ -93,7 +124,27 @@ async function restoreWindow(): Promise<void> {
 }
 
 function isSeen(): boolean {
-  return config.get(SEEN_KEY) === appVersion
+  if (config.get(SEEN_KEY) === appVersion) return true
+  try {
+    return localStorage.getItem(SEEN_KEY) === appVersion
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Record the current version as acknowledged in BOTH stores so the
+ * forced read is never repeated for this version — and stays that way
+ * even if one store is later wiped by hand. Only the next app *update*
+ * (a new {@link appVersion}) brings the notice back.
+ */
+async function markSeen(): Promise<void> {
+  try {
+    localStorage.setItem(SEEN_KEY, appVersion)
+  } catch {
+    /* localStorage unavailable — Config.xml below still records it */
+  }
+  await config.set(SEEN_KEY, appVersion)
 }
 
 async function openForced(): Promise<void> {
@@ -122,8 +173,9 @@ async function close(): Promise<void> {
   stopTimer()
   await restoreWindow()
   // Persist on the first (forced) acknowledgement so it won't auto-pop
-  // again until the next version. Idempotent for review closes.
-  if (!isSeen()) await config.set(SEEN_KEY, appVersion)
+  // — nor count down — again until the next version. Idempotent for
+  // review closes.
+  if (!isSeen()) await markSeen()
 }
 
 onMounted(async () => {
@@ -140,7 +192,12 @@ onMounted(async () => {
   if (!isSeen()) await openForced()
 })
 
-onBeforeUnmount(stopTimer)
+onBeforeUnmount(() => {
+  stopTimer()
+  if (typeof document !== 'undefined') {
+    document.body.classList.remove('bf-ann-banner-open')
+  }
+})
 
 async function open(url: string): Promise<void> {
   await safeInvoke(commands.openUrl(url))
@@ -202,7 +259,7 @@ async function open(url: string): Promise<void> {
     </div>
   </div>
 
-  <div v-else-if="ready && !bannerHidden" class="ann-banner" data-testid="announcement-banner">
+  <div v-else-if="bannerVisible" class="ann-banner" data-testid="announcement-banner">
     <button
       class="ann-banner__open"
       type="button"
@@ -211,15 +268,6 @@ async function open(url: string): Promise<void> {
     >
       <span class="ann-banner__text">{{ t('announcement.title') }}</span>
       <span class="ann-banner__cta">{{ t('announcement.reopen') }} ›</span>
-    </button>
-    <button
-      class="ann-banner__x"
-      type="button"
-      :aria-label="t('announcement.close')"
-      data-testid="announcement-banner-hide"
-      @click="bannerHidden = true"
-    >
-      ×
     </button>
   </div>
 </template>
@@ -372,7 +420,7 @@ async function open(url: string): Promise<void> {
   display: flex;
   align-items: center;
   height: 30px;
-  padding: 0 4px 0 12px;
+  padding: 0 12px;
   background: color-mix(
     in srgb,
     var(--el-color-primary, #ff8201) 16%,
@@ -411,21 +459,20 @@ async function open(url: string): Promise<void> {
   font-weight: 800;
   color: var(--bf-primary, #954a00);
 }
+</style>
 
-.ann-banner__x {
-  flex: 0 0 auto;
-  width: 22px;
-  height: 22px;
-  border: none;
-  border-radius: 6px;
-  background: none;
-  color: var(--bf-on-surface-variant, #54443a);
-  font-size: 1.05rem;
-  line-height: 1;
-  cursor: pointer;
-}
-
-.ann-banner__x:hover {
-  background: color-mix(in srgb, var(--bf-on-surface, #000) 12%, transparent);
+<!--
+  Global (unscoped) offset. The banner is `position: fixed` under the 40px
+  title bar, so on its own it floats over the page content (it used to
+  cover the top of the login form). Every page roots at
+  `[data-window-root]` with `<TitleBar class="bf-titlebar">` as its first
+  child, so reserving a banner-height strip below the title bar pushes the
+  content down exactly under the banner. Scoped styles can't reach
+  TitleBar in other components, hence the global rule gated by the body
+  class toggled in script.
+-->
+<style>
+body.bf-ann-banner-open [data-window-root] > .bf-titlebar {
+  margin-bottom: 30px;
 }
 </style>

--- a/tests/unit/components/AnnouncementModal.spec.ts
+++ b/tests/unit/components/AnnouncementModal.spec.ts
@@ -28,6 +28,8 @@ const mockOpenUrl = vi.mocked(commands.openUrl)
 const mockSetConfig = vi.mocked(commands.setConfig)
 
 const SEEN_KEY = 'announcementSeenVersion'
+/** Forced-read countdown in ms — mirrors READ_SECONDS (30) in the SUT. */
+const READ_MS = 30_000
 const VERSION = { app: '6.0.3', tauri: '2.0.0' } as Awaited<ReturnType<typeof commands.version>>
 
 let pinia: ReturnType<typeof createPinia>
@@ -41,6 +43,10 @@ describe('AnnouncementModal', () => {
     pinia = createPinia()
     setActivePinia(pinia)
     vi.useFakeTimers()
+    // The "seen" flag is now also mirrored into localStorage, which is a
+    // shared global across tests in this file — wipe it so each test
+    // starts from an unacknowledged state.
+    localStorage.clear()
     for (const fn of Object.values(commands) as ReturnType<typeof vi.fn>[]) fn.mockReset()
     mockVersion.mockResolvedValue(VERSION)
     mockOpenUrl.mockReturnValue(ok(null))
@@ -89,16 +95,39 @@ describe('AnnouncementModal', () => {
     expect(commands.setConfig).not.toHaveBeenCalled()
   })
 
-  it('hides the re-open banner for the session when its × is clicked', async () => {
+  it('keeps the re-open banner permanent (no session-hide control)', async () => {
     const config = useConfigStore()
     config.entries[SEEN_KEY] = VERSION.app
     const wrapper = mountModal()
     await flushPromises()
 
     expect(wrapper.find('[data-testid="announcement-banner"]').exists()).toBe(true)
-    await wrapper.get('[data-testid="announcement-banner-hide"]').trigger('click')
+    // The banner is permanent — there is no × / hide affordance.
+    expect(wrapper.find('[data-testid="announcement-banner-hide"]').exists()).toBe(false)
+  })
+
+  it('treats the version as seen when only localStorage records it (Config.xml wiped)', async () => {
+    // Config.xml has no seen entry, but localStorage does — either store
+    // alone must suppress the forced read so hand-editing one file can't
+    // re-trigger the countdown on the next launch.
+    localStorage.setItem(SEEN_KEY, VERSION.app)
+    const wrapper = mountModal()
     await flushPromises()
-    expect(wrapper.find('[data-testid="announcement-banner"]').exists()).toBe(false)
+
+    expect(wrapper.find('[data-testid="announcement"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="announcement-banner"]').exists()).toBe(true)
+  })
+
+  it('mirrors the acknowledged version into localStorage on forced dismiss', async () => {
+    const wrapper = mountModal()
+    await flushPromises()
+
+    vi.advanceTimersByTime(READ_MS)
+    await nextTick()
+    await wrapper.get('[data-testid="announcement-dismiss"]').trigger('click')
+    await flushPromises()
+
+    expect(localStorage.getItem(SEEN_KEY)).toBe(VERSION.app)
   })
 
   it('disables dismiss during the forced-read countdown, then enables it', async () => {
@@ -107,7 +136,7 @@ describe('AnnouncementModal', () => {
     const btn = () => wrapper.get('[data-testid="announcement-dismiss"]')
     expect((btn().element as HTMLButtonElement).disabled).toBe(true)
 
-    vi.advanceTimersByTime(60_000)
+    vi.advanceTimersByTime(READ_MS)
     await nextTick()
     expect((btn().element as HTMLButtonElement).disabled).toBe(false)
   })
@@ -116,7 +145,7 @@ describe('AnnouncementModal', () => {
     const wrapper = mountModal()
     await flushPromises()
 
-    vi.advanceTimersByTime(60_000)
+    vi.advanceTimersByTime(READ_MS)
     await nextTick()
     await wrapper.get('[data-testid="announcement-dismiss"]').trigger('click')
     await flushPromises()


### PR DESCRIPTION
## What

Follow-ups to the #323 announcement (merged in #325), from live use:

1. The re-open banner (`position: fixed` under the title bar) floated **over** the page content and covered the top account field on the login form.
2. The forced-read countdown was 60s; it should be 30s.
3. The banner should be permanently pinned (no session-dismiss).
4. The "already read" state should be robust so it isn't easily wiped by hand, which would otherwise re-trigger the 30s forced read on the next launch.

## Fix

- **No overlap** — reserve a banner-height strip below the title bar while the banner is up (a global `body.bf-ann-banner-open` class toggled from the component; every page roots at `[data-window-root] > .bf-titlebar`, so one rule offsets them all). The content-fit resizer then grows the window to include the strip.
- **30s** — `READ_SECONDS` 60 → 30.
- **Permanent banner** — removed the session-hide × so the banner always stays pinned; re-opening is review mode (never counts down).
- **Robust seen-state** — the acknowledged version is written to **both** Config.xml and WebView localStorage, and either one counts as seen. Hand-deleting one store no longer forces the read again; only a genuine app-version bump brings the notice back.

## Tests

AnnouncementModal.spec updated: permanence (no × control), localStorage-only "seen", localStorage mirrored on dismiss, 30s countdown. 10 passing; full suite 628 green (typecheck / lint / format clean).

## Note

Overlap + window-grow are WebView behaviours not exercised by jsdom — worth a quick on-device look, but the offset rule is a plain CSS reservation validated against every page's root structure.