### PR TITLE
fix(auth): gate reCAPTCHA on the robot message only + surface tracking-prevention COM failure

### DIFF
--- a/src-tauri/src/commands/cookie_native.rs
+++ b/src-tauri/src/commands/cookie_native.rs
@@ -31,11 +31,16 @@ pub fn disable_tracking_prevention_native<R: tauri::Runtime>(window: &WebviewWin
     let done = Arc::new(AtomicBool::new(false));
     let done_inner = done.clone();
 
+    // Each failure path names its `stage` at WARN so the exact COM step that
+    // fails on a given WebView2 runtime is visible in the log (e.g.
+    // `cast_v13` / `cast_profile3` = runtime too old for the interface;
+    // `set_level` = interface present but the call was rejected). Grep
+    // `stage=` under `step="TrackingPrevention"` to pinpoint it.
     let result = window.with_webview(move |webview| unsafe {
         let core = match webview.controller().CoreWebView2() {
             Ok(c) => c,
             Err(e) => {
-                tracing::info!(step = "TrackingPrevention", error = ?e, "CoreWebView2");
+                tracing::warn!(step = "TrackingPrevention", stage = "core_webview2", error = ?e, "tracking-prevention disable failed");
                 return;
             }
         };
@@ -43,7 +48,7 @@ pub fn disable_tracking_prevention_native<R: tauri::Runtime>(window: &WebviewWin
         let core13: ICoreWebView2_13 = match Interface::cast(&core) {
             Ok(c) => c,
             Err(e) => {
-                tracing::info!(step = "TrackingPrevention", error = ?e, "cast v13");
+                tracing::warn!(step = "TrackingPrevention", stage = "cast_v13", error = ?e, "tracking-prevention disable failed (runtime lacks ICoreWebView2_13)");
                 return;
             }
         };
@@ -51,7 +56,7 @@ pub fn disable_tracking_prevention_native<R: tauri::Runtime>(window: &WebviewWin
         let profile = match core13.Profile() {
             Ok(p) => p,
             Err(e) => {
-                tracing::info!(step = "TrackingPrevention", error = ?e, "Profile");
+                tracing::warn!(step = "TrackingPrevention", stage = "profile", error = ?e, "tracking-prevention disable failed");
                 return;
             }
         };
@@ -59,7 +64,7 @@ pub fn disable_tracking_prevention_native<R: tauri::Runtime>(window: &WebviewWin
         let profile3: ICoreWebView2Profile3 = match Interface::cast(&profile) {
             Ok(p) => p,
             Err(e) => {
-                tracing::info!(step = "TrackingPrevention", error = ?e, "cast profile3");
+                tracing::warn!(step = "TrackingPrevention", stage = "cast_profile3", error = ?e, "tracking-prevention disable failed (runtime lacks ICoreWebView2Profile3)");
                 return;
             }
         };
@@ -69,13 +74,13 @@ pub fn disable_tracking_prevention_native<R: tauri::Runtime>(window: &WebviewWin
         {
             Ok(()) => done_inner.store(true, Ordering::SeqCst),
             Err(e) => {
-                tracing::info!(step = "TrackingPrevention", error = ?e, "SetLevel");
+                tracing::warn!(step = "TrackingPrevention", stage = "set_level", error = ?e, "tracking-prevention disable failed");
             }
         }
     });
 
     if let Err(e) = result {
-        tracing::info!(step = "TrackingPrevention", error = ?e, "with_webview");
+        tracing::warn!(step = "TrackingPrevention", stage = "with_webview", error = ?e, "tracking-prevention disable failed");
         return false;
     }
     done.load(Ordering::SeqCst)

--- a/src-tauri/src/services/beanfun/login/account_login.rs
+++ b/src-tauri/src/services/beanfun/login/account_login.rs
@@ -145,22 +145,17 @@ pub async fn account_login(
     let text = client.bounded_text(resp).await?;
     let parsed: AccountLoginResponse = parse_step_json(&text, "AccountLogin")?;
 
-    // Empty-first escalation. A reCAPTCHA demand takes precedence over the
-    // ResultCode/Result truth table — BUT only when the server actually
-    // asks for the "我不是機器人" check, or sets the `IsRecaptcha` flag on
-    // an empty-first probe (no token sent yet). The flag can also linger
-    // alongside a real error message *after* we already replayed a token
-    // (e.g. `資料驗證錯誤次數已達上限` — the ~15-min IP lock, task spec §8);
-    // treating that as "needs reCAPTCHA" is exactly what looped #313/#315/#318,
-    // so we fall through to surface the error message instead.
+    // Empty-first escalation. reCAPTCHA is demanded **only** when the server
+    // explicitly asks for the "我不是機器人" check in the message. The
+    // `IsRecaptcha` flag is deliberately NOT a trigger: live traffic shows
+    // it set to `true` even on advance-check responses (`ResultCode==2`)
+    // that log in fine with no token, so gating on it pops the widget when
+    // it isn't needed. It also lingers next to a real error after a token
+    // was replayed (`資料驗證錯誤次數已達上限` — the ~15-min IP lock, task
+    // spec §8), which is exactly what looped #313/#315/#318. The flag is
+    // still parsed + logged below purely for diagnostics.
     let msg = parsed.result_message.as_deref().unwrap_or_default();
-    let flag = parsed.is_recaptcha
-        || parsed
-            .result_data
-            .as_ref()
-            .map(|d| d.is_recaptcha)
-            .unwrap_or(false);
-    let recaptcha = message_demands_recaptcha(msg) || (flag && captcha.is_empty());
+    let recaptcha = message_demands_recaptcha(msg);
 
     // Diagnostic (issues #313/#315/#318): the exact server verdict is the
     // only way to tell "token rejected → re-challenge" apart from a real
@@ -347,49 +342,40 @@ mod tests {
     }
 
     /// Recognition of a reCAPTCHA gate the way `account_login` does it at
-    /// runtime (before `classify_outcome`): the robot prompt always
-    /// escalates; the bare `IsRecaptcha` flag only escalates on an
-    /// empty-first probe (`captcha_empty`).
-    fn is_recaptcha_gate(body: &str, captcha_empty: bool) -> bool {
+    /// runtime (before `classify_outcome`): **only** the robot prompt in
+    /// the message escalates. The bare `IsRecaptcha` flag is not a trigger.
+    fn is_recaptcha_gate(body: &str) -> bool {
         let p: AccountLoginResponse = serde_json::from_str(body).expect("valid JSON");
         let msg = p.result_message.as_deref().unwrap_or_default();
-        let flag = p.is_recaptcha
-            || p.result_data
-                .as_ref()
-                .map(|d| d.is_recaptcha)
-                .unwrap_or(false);
-        message_demands_recaptcha(msg) || (flag && captcha_empty)
+        message_demands_recaptcha(msg)
     }
 
     #[test]
-    fn empty_first_is_recaptcha_flag_escalates() {
-        // No token yet + IsRecaptcha → open the widget.
-        assert!(is_recaptcha_gate(
-            r#"{"IsRecaptcha":true,"ResultCode":"1"}"#,
-            true
+    fn bare_is_recaptcha_flag_does_not_escalate() {
+        // The flag alone (no robot message) must NOT open the widget — live
+        // traffic sets it even on advance-check responses that log in fine
+        // without a token. Only the message escalates.
+        assert!(!is_recaptcha_gate(
+            r#"{"IsRecaptcha":true,"ResultCode":"1"}"#
         ));
-        assert!(is_recaptcha_gate(
-            r#"{"ResultData":{"IsRecaptcha":true}}"#,
-            true
-        ));
+        assert!(!is_recaptcha_gate(r#"{"ResultData":{"IsRecaptcha":true}}"#));
     }
 
     #[test]
     fn robot_message_always_escalates() {
         assert!(is_recaptcha_gate(
             r#"{"ResultCode":"1","ResultMessage":"請點選「我不是機器人」"}"#,
-            false
         ));
     }
 
     /// The #313/#315/#318 loop fix: a lingering `IsRecaptcha` flag next to a
-    /// real error (the ~15-min IP lock) AFTER a token was already replayed
-    /// must NOT re-trigger reCAPTCHA — it surfaces as a server message.
+    /// real error (the ~15-min IP lock) must NOT trigger reCAPTCHA — it
+    /// surfaces as a server message. (Message-only gating makes this trivially
+    /// true, but the assertion pins the behaviour against a regression.)
     #[test]
     fn lock_message_with_flag_after_token_is_not_a_recaptcha_gate() {
         let body = r#"{"ResultCode":"0","Result":"0","ResultData":{"IsRecaptcha":true},"ResultMessage":"資料驗證錯誤次數已達上限，請於15分鐘後再重新登入驗證。"}"#;
-        // captcha_empty = false (we already sent a solved token).
-        assert!(!is_recaptcha_gate(body, false));
+        assert!(!is_recaptcha_gate(body));
         // And the classic table surfaces the lock text to the user.
         let p: AccountLoginResponse = serde_json::from_str(body).expect("valid JSON");
         assert_matches!(
@@ -404,9 +390,6 @@ mod tests {
 
     #[test]
     fn ordinary_success_is_not_a_recaptcha_gate() {
-        assert!(!is_recaptcha_gate(
-            r#"{"ResultCode":"1","Result":"0"}"#,
-            true
-        ));
+        assert!(!is_recaptcha_gate(r#"{"ResultCode":"1","Result":"0"}"#));
     }
 }

--- a/src-tauri/src/services/beanfun/login/check_account_type.rs
+++ b/src-tauri/src/services/beanfun/login/check_account_type.rs
@@ -128,37 +128,38 @@ pub async fn check_account_type(
     }
 
     let parsed: CheckAccountTypeResponse = parse_step_json(&text, "CheckAccountType")?;
-    Ok(classify_check_response(
-        parsed
-            .result_data
-            .as_ref()
-            .map(|d| d.is_recaptcha)
-            .unwrap_or(false),
-        parsed.message.as_deref().unwrap_or_default(),
-        captcha_token.is_empty(),
-        parsed
-            .result_data
-            .and_then(|d| d.captcha)
-            .unwrap_or_default(),
-    ))
+
+    let message = parsed.message.clone().unwrap_or_default();
+    let (is_recaptcha, server_captcha) = match parsed.result_data {
+        Some(d) => (d.is_recaptcha, d.captcha.unwrap_or_default()),
+        None => (false, String::new()),
+    };
+
+    // Diagnostic parity with `AccountLogin.Verdict` (#313/#315/#318). The
+    // `IsRecaptcha` flag is logged but deliberately NOT acted on — only the
+    // robot message gates reCAPTCHA (see `classify_check_response`).
+    tracing::info!(
+        step = "CheckAccountType.Verdict",
+        is_recaptcha = is_recaptcha,
+        captcha_sent = !captcha_token.is_empty(),
+        message = %message,
+        "CheckAccountType server response classified"
+    );
+
+    Ok(classify_check_response(&message, server_captcha))
 }
 
 /// Pure mapping from the parsed response fields to a [`CheckAccountOutcome`].
 /// Kept separate so the reCAPTCHA-detection table is unit-testable without
 /// a mock HTTP server.
 ///
-/// Escalates to a reCAPTCHA solve only when the server asks for the
-/// "我不是機器人" check, or sets `IsRecaptcha` on an empty-first probe
-/// (`captcha_empty`). A flag lingering alongside a real error after a token
-/// was already replayed surfaces as the error instead of looping (see
-/// `account_login` for the same rule / the #313/#315/#318 rationale).
-fn classify_check_response(
-    is_recaptcha: bool,
-    message: &str,
-    captcha_empty: bool,
-    server_captcha: String,
-) -> CheckAccountOutcome {
-    if message_demands_recaptcha(message) || (is_recaptcha && captcha_empty) {
+/// Escalates to a reCAPTCHA solve **only** when the server asks for the
+/// "我不是機器人" check in the message. The bare `IsRecaptcha` flag is not a
+/// trigger — live traffic sets it even on advance-check responses that log
+/// in fine without a token (see `account_login` for the same rule and the
+/// #313/#315/#318 rationale).
+fn classify_check_response(message: &str, server_captcha: String) -> CheckAccountOutcome {
+    if message_demands_recaptcha(message) {
         CheckAccountOutcome::RecaptchaRequired
     } else {
         CheckAccountOutcome::Proceed { server_captcha }
@@ -170,21 +171,10 @@ mod tests {
     use super::*;
 
     fn parse(body: &str) -> CheckAccountOutcome {
-        // Empty-first probe (no token yet) — the common escalation path.
-        parse_with(body, true)
-    }
-
-    fn parse_with(body: &str, captcha_empty: bool) -> CheckAccountOutcome {
         let r: CheckAccountTypeResponse = serde_json::from_str(body).expect("valid JSON");
-        classify_check_response(
-            r.result_data
-                .as_ref()
-                .map(|d| d.is_recaptcha)
-                .unwrap_or(false),
-            r.message.as_deref().unwrap_or_default(),
-            captcha_empty,
-            r.result_data.and_then(|d| d.captcha).unwrap_or_default(),
-        )
+        let message = r.message.clone().unwrap_or_default();
+        let server_captcha = r.result_data.and_then(|d| d.captcha).unwrap_or_default();
+        classify_check_response(&message, server_captcha)
     }
 
     /// Reach into the private DTO to assert the JToken coercion
@@ -231,16 +221,20 @@ mod tests {
     }
 
     #[test]
-    fn is_recaptcha_flag_demands_recaptcha() {
+    fn bare_is_recaptcha_flag_does_not_demand() {
+        // The flag alone (no robot message) must NOT escalate — it is set
+        // even on advance-check responses that log in without a token.
         assert_eq!(
             parse(r#"{"ResultData":{"IsRecaptcha":true}}"#),
-            CheckAccountOutcome::RecaptchaRequired
+            CheckAccountOutcome::Proceed {
+                server_captcha: String::new()
+            }
         );
     }
 
     #[test]
     fn robot_message_demands_recaptcha() {
-        // Even without the flag, a 機器人 message escalates.
+        // The 機器人 message is the only thing that escalates.
         assert_eq!(
             parse(r#"{"Message":"請點選「我不是機器人」","ResultData":{"Captcha":""}}"#),
             CheckAccountOutcome::RecaptchaRequired
@@ -248,15 +242,11 @@ mod tests {
     }
 
     #[test]
-    fn lingering_flag_after_token_does_not_loop() {
-        // IsRecaptcha still set but a token was already replayed
-        // (captcha_empty=false) and the message isn't a robot prompt →
-        // proceed instead of re-opening the widget (#313/#315/#318).
+    fn flag_with_non_robot_message_proceeds() {
+        // IsRecaptcha set but the message isn't a robot prompt → proceed
+        // instead of opening the widget (#313/#315/#318 loop guard).
         assert_eq!(
-            parse_with(
-                r#"{"Message":"資料驗證錯誤","ResultData":{"IsRecaptcha":true,"Captcha":"X"}}"#,
-                false,
-            ),
+            parse(r#"{"Message":"資料驗證錯誤","ResultData":{"IsRecaptcha":true,"Captcha":"X"}}"#),
             CheckAccountOutcome::Proceed {
                 server_captcha: "X".to_owned()
             }

--- a/src-tauri/src/services/beanfun/login/mod.rs
+++ b/src-tauri/src/services/beanfun/login/mod.rs
@@ -132,8 +132,13 @@ pub(crate) fn apply_json_headers(
         // POST; reqwest does not add one, and its absence is a bot tell.
         // These login steps are TW-only, so the host is fixed.
         .header(reqwest::header::ORIGIN, "https://login.beanfun.com")
-        .header(reqwest::header::CACHE_CONTROL, "no-cache")
-        .header("Pragma", "no-cache")
+        // NOTE: deliberately NOT sending `Cache-Control`/`Pragma: no-cache`.
+        // beanfun's own login page issues a plain `fetch()` for
+        // CheckAccountType / AccountLogin, and a plain fetch does NOT add
+        // those headers — so sending them makes the request look scripted
+        // rather than browser-issued, feeding the bot-risk score that pops
+        // reCAPTCHA on the app even when the same login succeeds without it
+        // in a real browser (and in the maplelink client, which omits them).
         .header(
             reqwest::header::ACCEPT_LANGUAGE,
             "zh-TW,zh;q=0.9,en-US;q=0.8,en;q=0.7",

--- a/src-tauri/tests/tw_login.rs
+++ b/src-tauri/tests/tw_login.rs
@@ -198,17 +198,19 @@ async fn tw_regular_happy_path_returns_session() {
 
 #[tokio::test]
 async fn recaptcha_required_diverts_to_webview_login() {
-    // Token-replay (#313/#315/#318): reCAPTCHA is detected empty-first
-    // from the CheckAccountType response (IsRecaptcha=true), not from a
-    // separate InitLogin probe. The single-shot `login_tw_regular` has no
-    // interactive surface, so it surfaces `RecaptchaRequired`.
-    // AccountLogin is intentionally left unmounted: escalating at the
-    // check step must NOT touch it.
+    // Token-replay (#313/#315/#318): reCAPTCHA is detected empty-first from
+    // the CheckAccountType response, gated on the server's "我不是機器人"
+    // message (the `IsRecaptcha` flag alone is not a trigger — it is set even
+    // on advance-check responses). The single-shot `login_tw_regular` has no
+    // interactive surface, so it surfaces `RecaptchaRequired`. AccountLogin
+    // is intentionally left unmounted: escalating at the check step must NOT
+    // touch it.
     let server = MockServer::start().await;
     mount_session_key(&server).await;
     mount_index_with_token(&server, FORM_TOKEN).await;
     let body = serde_json::json!({
         "ResultCode": "1",
+        "Message": "請點選「我不是機器人」",
         "ResultData": { "IsRecaptcha": true }
     });
     Mock::given(method("POST"))
@@ -251,14 +253,19 @@ async fn recaptcha_false_continues_headless_flow() {
 #[tokio::test]
 async fn recaptcha_required_at_account_login_step_diverts() {
     // reCAPTCHA can also gate the *second* POST (AccountLogin) even when
-    // CheckAccountType passed clean — empty-first must escalate there too.
+    // CheckAccountType passed clean — the "我不是機器人" message must escalate
+    // there too.
     let server = MockServer::start().await;
     mount_session_key(&server).await;
     mount_index_with_token(&server, FORM_TOKEN).await;
     mount_check_account_type(&server, "").await;
     mount_account_login_with_body(
         &server,
-        serde_json::json!({ "IsRecaptcha": true, "ResultCode": "1" }),
+        serde_json::json!({
+            "IsRecaptcha": true,
+            "ResultCode": "1",
+            "ResultMessage": "請點選「我不是機器人」"
+        }),
     )
     .await;
 
@@ -267,6 +274,34 @@ async fn recaptcha_required_at_account_login_step_diverts() {
         .await
         .expect_err("AccountLogin reCAPTCHA must divert");
     assert!(matches!(err, LoginError::RecaptchaRequired { .. }));
+}
+
+#[tokio::test]
+async fn bare_is_recaptcha_flag_does_not_divert() {
+    // Regression guard: a CheckAccountType response carrying `IsRecaptcha:true`
+    // WITHOUT a "我不是機器人" message must NOT open the widget — the flag is
+    // set even on responses that log in fine. The headless flow continues to
+    // a session.
+    let server = MockServer::start().await;
+    mount_session_key(&server).await;
+    mount_index_with_token(&server, FORM_TOKEN).await;
+    Mock::given(method("POST"))
+        .and(path("/Login/CheckAccountType"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "ResultCode": "1",
+            "ResultData": { "IsRecaptcha": true }
+        })))
+        .mount(&server)
+        .await;
+    mount_account_login_success(&server).await;
+    mount_send_login_happy(&server).await;
+    mount_return_aspx_with_token(&server, WEB_TOKEN).await;
+
+    let client = client_for(&server);
+    let session = login_tw_regular(&client, &creds())
+        .await
+        .expect("bare IsRecaptcha flag must not divert");
+    assert_eq!(session.web_token, WEB_TOKEN);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What

From live login logs:

1. `is_recaptcha_nested=true` is set by the server **even on advance-check responses** (`ResultCode=2`) that log in fine without a token — i.e. the `IsRecaptcha` flag is not a reliable "reCAPTCHA needed" signal. Gating the widget on `(flag && captcha.is_empty())` popped reCAPTCHA when it wasn't actually required.
2. The reCAPTCHA WebView logs `disabled=false` for the Tracking-Prevention COM call, and the specific failing step was only at INFO with a cryptic message — hard to diagnose. This (not the gate) is the likely reason the widget / GamePass social login gets storage-blocked.

Note: the flow already does **not** act on `InitLogin.IsRecaptcha` — `check_recaptcha_required` (init_login.rs) is re-exported but has no callers, so InitLogin's flag is effectively already treated as false. (Left as-is; candidate for a dead-code cleanup.)

## Fix

- **Message-only gate** — both `check_account_type` and `account_login` now escalate to reCAPTCHA **only** when the server message contains the `我不是機器人` prompt. The `IsRecaptcha` flag is still parsed and logged for diagnostics (added a `CheckAccountType.Verdict` log mirroring `AccountLogin.Verdict`). This stops the widget from opening on advance-check attempts that would succeed headless.
- **Diagnostics** — `disable_tracking_prevention_native` logs each COM sub-step failure at WARN with a greppable `stage=` field (`core_webview2` / `cast_v13` / `profile` / `cast_profile3` / `set_level`), so the exact step that returns `disabled=false` on a given WebView2 runtime is visible.

## Tests

Unit (account_login, check_account_type) + wiremock (`tw_login`) updated: a bare `IsRecaptcha` flag with no robot message now proceeds through the headless flow instead of diverting (new `bare_is_recaptcha_flag_does_not_divert` integration test). Rust lib 765 + integration 14 green; clippy / fmt clean.

## Next (needs your device)

Re-run a login that hits the reCAPTCHA and grep the log for `step="TrackingPrevention"` — the new `stage=` field tells us **which** COM step fails (e.g. `cast_profile3` = runtime too old for the tracking-prevention API). Paste that line and I can fix the COM path precisely.