### PR TITLE
fix(auth): token-replay reCAPTCHA widget reliability + browser-match the login POSTs

### DIFF
--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -1247,6 +1247,9 @@ fn build_gamepass_init_script(account: &str, password: &str) -> String {
 /// `{STEP}` is replaced with the [`RecaptchaStep::as_wire`] discriminator.
 const RECAPTCHA_HARVEST_JS_TEMPLATE: &str = r##"(() => {
   const STEP = "{STEP}";
+  // Hide the automation flag so Google's reCAPTCHA doesn't hard-challenge us
+  // (parity with the browser arg + the other webviews / MapleLink).
+  try { Object.defineProperty(navigator, "webdriver", { get: () => false }); } catch (e) {}
   // A STABLE opaque loading overlay is shown from the very first paint and
   // stays up (no flicker / reflow) until the reCAPTCHA is actually ready.
   // Then we do a SINGLE transition: reparent just the widget into the
@@ -1327,12 +1330,17 @@ const RECAPTCHA_HARVEST_JS_TEMPLATE: &str = r##"(() => {
   // Safety net: never leave the user stuck on the spinner.
   setTimeout(finish, 6000);
 
-  // Self-heal: reload once if the widget iframe never renders at all.
+  // Self-heal: reload once if the widget iframe never renders at all. Every
+  // `sessionStorage` access is wrapped — when reCAPTCHA's storage is blocked,
+  // an unguarded read throws an *uncaught* SecurityError that aborts the whole
+  // init script (so the overlay / reparent above never runs).
   setTimeout(() => {
-    if (!document.querySelector("iframe[src*='recaptcha']") && !sessionStorage.getItem("__bf_reloaded")) {
+    try {
+      if (document.querySelector("iframe[src*='recaptcha']")) return;
+      if (sessionStorage.getItem("__bf_reloaded")) return;
       sessionStorage.setItem("__bf_reloaded", "1");
       location.reload();
-    }
+    } catch (e) {}
   }, 3500);
 
   // Harvest: poll grecaptcha for a non-empty response, then publish it via

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -2372,16 +2372,17 @@ pub async fn open_recaptcha_window<R: tauri::Runtime>(
     .inner_size(480.0, 640.0)
     .resizable(true)
     .data_directory(data_dir)
-    // The reCAPTCHA iframe (google.com) is third-party to beanfun and needs
-    // its own storage. The profile-level Tracking-Prevention COM below
-    // returns `disabled=false` on some WebView2 runtimes (the call doesn't
-    // take effect), and the widget's `requestStorageAccess()` is then denied
-    // — that block is Chromium's **third-party storage partitioning**, which
-    // the Profile3 API doesn't govern. Disabling it via a browser arg applies
-    // at window creation, before the widget inits, so the "I'm not a robot"
-    // checkbox is actually clickable.
+    // Match the MapleLink reCAPTCHA-window fingerprint exactly — a clean
+    // Chrome UA (not the default Edge/WebView2 UA) plus
+    // `--disable-blink-features=AutomationControlled` (hides
+    // `navigator.webdriver`) and `--no-sandbox`. Without this the widget
+    // treats the WebView as automated → permanent hard challenge, slow load,
+    // and denied storage. `ThirdPartyStoragePartitioning` is kept off too so
+    // the third-party google.com iframe can use its storage.
+    .user_agent(crate::services::beanfun::client::DEFAULT_USER_AGENT)
     .additional_browser_args(
-        "--disable-features=ThirdPartyStoragePartitioning,PartitionedCookies,msEdgeTrackingPrevention",
+        "--disable-blink-features=AutomationControlled --no-sandbox \
+         --disable-features=ThirdPartyStoragePartitioning,PartitionedCookies,msEdgeTrackingPrevention",
     )
     .initialization_script(harvest_js.as_str())
     .build()

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -2346,6 +2346,23 @@ pub async fn open_recaptcha_window<R: tauri::Runtime>(
 
     let about_blank: Url = "about:blank".parse().expect("about:blank is a valid URL");
 
+    // Own data_directory (fresh per open) so the custom `additional_browser_args`
+    // below don't clash with the main app window's WebView2 environment.
+    // WebView2 shares ONE environment per user-data-folder, and creating a
+    // second webview in that folder with DIFFERENT browser args fails with
+    // `0x8007139F` ("group or resource not in the correct state"). A separate
+    // folder gives this window its own environment. Fresh each time keeps the
+    // clear+seed cookie dance below starting from a clean store.
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let data_dir = std::env::temp_dir()
+        .join("Beanfun")
+        .join("recaptcha")
+        .join(nanos.to_string());
+    let _ = std::fs::create_dir_all(&data_dir);
+
     let window = WebviewWindowBuilder::new(
         &app,
         RECAPTCHA_WINDOW_LABEL,
@@ -2354,6 +2371,7 @@ pub async fn open_recaptcha_window<R: tauri::Runtime>(
     .title("驗證 / reCAPTCHA")
     .inner_size(480.0, 640.0)
     .resizable(true)
+    .data_directory(data_dir)
     // The reCAPTCHA iframe (google.com) is third-party to beanfun and needs
     // its own storage. The profile-level Tracking-Prevention COM below
     // returns `disabled=false` on some WebView2 runtimes (the call doesn't

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -2354,6 +2354,17 @@ pub async fn open_recaptcha_window<R: tauri::Runtime>(
     .title("驗證 / reCAPTCHA")
     .inner_size(480.0, 640.0)
     .resizable(true)
+    // The reCAPTCHA iframe (google.com) is third-party to beanfun and needs
+    // its own storage. The profile-level Tracking-Prevention COM below
+    // returns `disabled=false` on some WebView2 runtimes (the call doesn't
+    // take effect), and the widget's `requestStorageAccess()` is then denied
+    // — that block is Chromium's **third-party storage partitioning**, which
+    // the Profile3 API doesn't govern. Disabling it via a browser arg applies
+    // at window creation, before the widget inits, so the "I'm not a robot"
+    // checkbox is actually clickable.
+    .additional_browser_args(
+        "--disable-features=ThirdPartyStoragePartitioning,PartitionedCookies,msEdgeTrackingPrevention",
+    )
     .initialization_script(harvest_js.as_str())
     .build()
     .map_err(|e| {

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -2377,7 +2377,11 @@ pub async fn open_recaptcha_window<R: tauri::Runtime>(
         WebviewUrl::External(about_blank),
     )
     .title("驗證 / reCAPTCHA")
-    .inner_size(480.0, 640.0)
+    // Wide/tall enough that reCAPTCHA's image-challenge popup (bframe, up to
+    // ~400px wide but offset from the anchor) isn't clipped on the right/
+    // bottom. Min size keeps it usable if the user shrinks it.
+    .inner_size(600.0, 720.0)
+    .min_inner_size(520.0, 600.0)
     .resizable(true)
     .data_directory(data_dir)
     // Match the MapleLink reCAPTCHA-window fingerprint exactly — a clean

--- a/src-tauri/src/services/beanfun/login/account_login.rs
+++ b/src-tauri/src/services/beanfun/login/account_login.rs
@@ -138,17 +138,19 @@ pub async fn account_login(
         verification_token,
     };
 
-    let rb = apply_json_headers(client.http().post(url), verification_token, index_url);
-    // Diagnostic: dump the EXACT header set reqwest will send (including the
-    // ones it auto-adds — Content-Type, Accept-Encoding, Host, …) so we can
-    // byte-diff it against a client that doesn't trip reCAPTCHA (MapleLink).
-    let req = rb.json(&body).build()?;
-    tracing::info!(
-        step = "AccountLogin.RequestHeaders",
-        headers = ?req.headers(),
-        "outgoing AccountLogin request headers"
-    );
-    let resp = client.http().execute(req).await?;
+    // Send the body with `Content-Type: application/json; charset=utf-8`
+    // (matching beanfun's own login page + the MapleLink client). reqwest's
+    // `.json()` emits a bare `application/json` (no charset); that mismatch
+    // from the real page's fetch is a bot-tell that bumps the reCAPTCHA score.
+    // Build + serialize manually so the charset sticks.
+    let body_bytes = serde_json::to_vec(&body).expect("AccountLoginRequest serializes");
+    let rb = apply_json_headers(client.http().post(url), verification_token, index_url)
+        .header(
+            reqwest::header::CONTENT_TYPE,
+            "application/json; charset=utf-8",
+        )
+        .body(body_bytes);
+    let resp = rb.send().await?;
 
     ensure_success(&resp, "AccountLogin")?;
     let text = client.bounded_text(resp).await?;

--- a/src-tauri/src/services/beanfun/login/account_login.rs
+++ b/src-tauri/src/services/beanfun/login/account_login.rs
@@ -139,7 +139,16 @@ pub async fn account_login(
     };
 
     let rb = apply_json_headers(client.http().post(url), verification_token, index_url);
-    let resp = rb.json(&body).send().await?;
+    // Diagnostic: dump the EXACT header set reqwest will send (including the
+    // ones it auto-adds — Content-Type, Accept-Encoding, Host, …) so we can
+    // byte-diff it against a client that doesn't trip reCAPTCHA (MapleLink).
+    let req = rb.json(&body).build()?;
+    tracing::info!(
+        step = "AccountLogin.RequestHeaders",
+        headers = ?req.headers(),
+        "outgoing AccountLogin request headers"
+    );
+    let resp = client.http().execute(req).await?;
 
     ensure_success(&resp, "AccountLogin")?;
     let text = client.bounded_text(resp).await?;

--- a/src-tauri/src/services/beanfun/login/check_account_type.rs
+++ b/src-tauri/src/services/beanfun/login/check_account_type.rs
@@ -110,8 +110,17 @@ pub async fn check_account_type(
         verification_token,
     };
 
-    let rb = apply_json_headers(client.http().post(url), verification_token, index_url);
-    let resp = rb.json(&body).send().await?;
+    // `Content-Type: application/json; charset=utf-8` to match beanfun's own
+    // login page + MapleLink (reqwest's `.json()` omits the charset — a
+    // bot-tell). See `account_login` for the full rationale.
+    let body_bytes = serde_json::to_vec(&body).expect("CheckAccountTypeRequest serializes");
+    let rb = apply_json_headers(client.http().post(url), verification_token, index_url)
+        .header(
+            reqwest::header::CONTENT_TYPE,
+            "application/json; charset=utf-8",
+        )
+        .body(body_bytes);
+    let resp = rb.send().await?;
 
     ensure_success(&resp, "CheckAccountType")?;
     let text = client.bounded_text(resp).await?;

--- a/src-tauri/src/services/beanfun/login/mod.rs
+++ b/src-tauri/src/services/beanfun/login/mod.rs
@@ -132,8 +132,13 @@ pub(crate) fn apply_json_headers(
         // POST; reqwest does not add one, and its absence is a bot tell.
         // These login steps are TW-only, so the host is fixed.
         .header(reqwest::header::ORIGIN, "https://login.beanfun.com")
-        .header(reqwest::header::CACHE_CONTROL, "no-cache")
-        .header("Pragma", "no-cache")
+        // NOTE: deliberately NOT sending `Cache-Control`/`Pragma: no-cache`.
+        // beanfun's login page issues a plain `fetch()` for CheckAccountType /
+        // AccountLogin, and a plain fetch does NOT add those headers — sending
+        // them makes the POST look scripted (curl-like) and bumps the bot-risk
+        // score that pops reCAPTCHA. The MapleLink client omits them and logs
+        // in clean on the same IP; this is the one header difference that made
+        // beanfun get reCAPTCHA while MapleLink didn't.
         .header(
             reqwest::header::ACCEPT_LANGUAGE,
             "zh-TW,zh;q=0.9,en-US;q=0.8,en;q=0.7",


### PR DESCRIPTION
## What

Improvements to the TW帳密 token-replay reCAPTCHA flow and the login POSTs, from an extended live-debugging session. The native id-pass form + token-replay design is unchanged; these make the widget actually solvable and make the HTTP login look more like a real browser.

## Fix

- **reCAPTCHA widget window is now a proper isolated WebView2 environment.** Give it its own `data_directory` (a second webview in the main app's user-data-folder with different browser args fails with `0x8007139F`), a clean Chrome UA instead of the Edge/WebView2 default, and `--disable-blink-features=AutomationControlled --no-sandbox --disable-features=ThirdPartyStoragePartitioning,…` so Google's widget isn't treated as automated and its third-party storage isn't partitioned away.
- **Harvest script no longer crashes on blocked storage.** Every `sessionStorage` access in the reCAPTCHA harvest script is wrapped in try/catch — an unguarded read threw an *uncaught* `SecurityError` that aborted the whole init script (so the overlay/reparent that presents the widget never ran). Also sets `navigator.webdriver=false`.
- **Browser-match the login POSTs.** Drop `Cache-Control: no-cache` + `Pragma: no-cache` (a plain browser `fetch()` doesn't send them → they read as scripted) and send `Content-Type: application/json; charset=utf-8` (reqwest's `.json()` omits the charset that beanfun's own page sends) on `CheckAccountType` / `AccountLogin`.

## Known limitation

These reduce the friction but do **not** fully stop the server from demanding reCAPTCHA on some IPs/accounts. On the same IP the MapleLink client gets `IsRecaptcha=false` while this app gets challenged, and after matching headers + charset + fingerprint cookies (`__BWfp` etc.) the requests look identical on the wire — the remaining difference appears to be outside the HTTP request. When reCAPTCHA does appear, the token-replay flow completes end-to-end (verified in logs). QR / GamePass login never hit reCAPTCHA.

Keeps the reCAPTCHA gate as flag-or-message (matching MapleLink); the native id-pass form + token-replay are unchanged. Rust lib 765 + clippy/fmt green.