### PR TITLE
fix(ui): announcement re-pops every launch (seen-check races config load)

### DIFF
--- a/src/components/AnnouncementModal.vue
+++ b/src/components/AnnouncementModal.vue
@@ -178,6 +178,37 @@ async function close(): Promise<void> {
   if (!isSeen()) await markSeen()
 }
 
+/**
+ * Resolve once the config store has finished loading Config.xml into its
+ * cache (or after a safety timeout). Checking {@link isSeen} before this
+ * reads an *empty* cache — so a previously-acknowledged version looks
+ * unseen and the forced read re-fires on every launch. The localStorage
+ * fallback in {@link isSeen} isn't enough: some WebView2 profiles don't
+ * persist it across restarts, so Config.xml is the store that actually
+ * survives and it must be loaded first. Mirrors the `watch(config.loaded)`
+ * idiom already used in `LoginRegionSelection.vue`.
+ */
+function waitForConfigLoaded(timeoutMs = 5000): Promise<void> {
+  if (config.loaded) return Promise.resolve()
+  return new Promise((resolve) => {
+    let stop = () => {}
+    const timer = setTimeout(() => {
+      stop()
+      resolve()
+    }, timeoutMs)
+    stop = watch(
+      () => config.loaded,
+      (isLoaded) => {
+        if (isLoaded) {
+          stop()
+          clearTimeout(timer)
+          resolve()
+        }
+      },
+    )
+  })
+}
+
 onMounted(async () => {
   // `commands.version` never returns a Result — a throw is an IPC-bridge
   // failure, in which case we simply don't show anything (non-critical).
@@ -188,6 +219,10 @@ onMounted(async () => {
     return
   }
   if (!appVersion) return
+  // Wait for Config.xml before the seen-check, or a still-empty cache
+  // makes an already-acknowledged version look unseen and re-forces the
+  // 30-second read every launch. See {@link waitForConfigLoaded}.
+  await waitForConfigLoaded()
   ready.value = true
   if (!isSeen()) await openForced()
 })

--- a/tests/unit/components/AnnouncementModal.spec.ts
+++ b/tests/unit/components/AnnouncementModal.spec.ts
@@ -42,6 +42,11 @@ describe('AnnouncementModal', () => {
   beforeEach(() => {
     pinia = createPinia()
     setActivePinia(pinia)
+    // The modal defers its seen-check until the config store has loaded
+    // Config.xml (see `waitForConfigLoaded`). Boot has completed by the
+    // time it mounts in the app, so model that here; the dedicated race
+    // test below flips this back to `false`.
+    useConfigStore().loaded = true
     vi.useFakeTimers()
     // The "seen" flag is now also mirrored into localStorage, which is a
     // shared global across tests in this file — wipe it so each test
@@ -163,6 +168,27 @@ describe('AnnouncementModal', () => {
 
     expect(commands.setConfig).not.toHaveBeenCalled()
     expect(wrapper.find('[data-testid="announcement"]').exists()).toBe(true)
+  })
+
+  it('waits for Config.xml to load before the seen-check (no premature forced read)', async () => {
+    // Regression: the seen-check used to run on mount before the config
+    // cache was populated, so an already-acknowledged version read as
+    // unseen and re-forced the 30s read on every launch.
+    const config = useConfigStore()
+    config.loaded = false // still booting; cache is empty
+    const wrapper = mountModal()
+    await flushPromises()
+    // Must not force the read while the cache is still loading.
+    expect(wrapper.find('[data-testid="announcement"]').exists()).toBe(false)
+
+    // loadAll() resolves — the acknowledged version lands in the cache.
+    config.entries[SEEN_KEY] = VERSION.app
+    config.loaded = true
+    await flushPromises()
+
+    // Seen → stays closed (and the re-open banner is available).
+    expect(wrapper.find('[data-testid="announcement"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="announcement-banner"]').exists()).toBe(true)
   })
 
   it('opens external links via openUrl', async () => {


### PR DESCRIPTION
## What

The development-notice modal (#323) forced the 30-second read on **every** app launch, even after the user had already acknowledged it. The acknowledgement was in fact saved — `Config.xml` held `announcementSeenVersion="6.0.3"` — so the notice should have stayed closed.

## Fix

The bug was a boot-order race on the **read** side. `App.vue` populates the config cache with `await config.loadAll()` in its own `onMounted`, but `AnnouncementModal` mounts as a child and its `onMounted` runs first — before the cache is loaded. `isSeen()` therefore read an empty cache (`config.get(SEEN_KEY)` → `undefined`) and fell through to the `localStorage` fallback, which some WebView2 profiles don't persist across restarts. Result: an already-seen version looked unseen and the forced countdown re-fired.

`onMounted` now awaits a small `waitForConfigLoaded()` helper (watches `config.loaded`, with a 5-second safety timeout) before the seen-check, so `config.get()` sees the persisted version. Mirrors the existing `watch(config.loaded)` idiom in `LoginRegionSelection.vue`.