### PR TITLE
fix(auth): eliminate spurious TW-Regular reCAPTCHA (step-failure gate + fingerprint parity)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -765,7 +765,7 @@ dependencies = [
  "bitflags 2.11.1",
  "core-foundation",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -1277,12 +1277,21 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared",
+ "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -1295,6 +1304,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -1558,10 +1573,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1571,11 +1584,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1902,19 +1913,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-rustls"
-version = "0.27.9"
+name = "hyper-tls"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
- "http",
+ "bytes",
+ "http-body-util",
  "hyper",
  "hyper-util",
- "rustls",
+ "native-tls",
  "tokio",
- "tokio-rustls",
+ "tokio-native-tls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -2391,12 +2402,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
-name = "lru-slab"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
-
-[[package]]
 name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2530,6 +2535,23 @@ dependencies = [
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -2874,6 +2896,49 @@ dependencies = [
  "is-wsl",
  "libc",
  "pathdiff",
+]
+
+[[package]]
+name = "openssl"
+version = "0.10.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "foreign-types 0.3.2",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -3383,61 +3448,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quinn"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
-dependencies = [
- "bytes",
- "cfg_aliases",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash",
- "rustls",
- "socket2",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
-dependencies = [
- "bytes",
- "getrandom 0.3.4",
- "lru-slab",
- "rand 0.9.4",
- "ring",
- "rustc-hash",
- "rustls",
- "rustls-pki-types",
- "slab",
- "thiserror 2.0.18",
- "tinyvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
-dependencies = [
- "cfg_aliases",
- "libc",
- "once_cell",
- "socket2",
- "tracing",
- "windows-sys 0.60.2",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3484,16 +3494,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
-dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.5",
-]
-
-[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3514,16 +3514,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3539,15 +3529,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -3658,21 +3639,20 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
- "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
- "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-rustls",
+ "tokio-native-tls",
  "tower",
  "tower-http",
  "tower-service",
@@ -3680,7 +3660,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
 ]
 
 [[package]]
@@ -3754,20 +3733,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ring"
-version = "0.17.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
-dependencies = [
- "cc",
- "cfg-if",
- "getrandom 0.2.17",
- "libc",
- "untrusted",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "rust_decimal"
 version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3806,38 +3771,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls"
-version = "0.23.38"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
-dependencies = [
- "once_cell",
- "ring",
- "rustls-pki-types",
- "rustls-webpki",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
- "web-time",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.103.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
-dependencies = [
- "ring",
- "rustls-pki-types",
- "untrusted",
 ]
 
 [[package]]
@@ -3859,6 +3798,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3917,6 +3865,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -4384,12 +4355,6 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
-name = "subtle"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swift-rs"
@@ -4976,21 +4941,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinyvec"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
 name = "tokio"
 version = "1.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5017,12 +4967,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-rustls"
-version = "0.26.4"
+name = "tokio-native-tls"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
- "rustls",
+ "native-tls",
  "tokio",
 ]
 
@@ -5391,12 +5341,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
-name = "untrusted"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5456,6 +5400,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"
@@ -5651,16 +5601,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-time"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "web_atoms"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5714,15 +5654,6 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]
@@ -6069,15 +6000,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -78,10 +78,16 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # HTTP client (rustls — avoid OpenSSL dependency)
+# native-tls (SChannel on Windows), NOT rustls: reCAPTCHA Enterprise fingerprints
+# the TLS ClientHello (JA3/JA4). rustls has a distinct, automation-associated
+# fingerprint that — paired with our Chrome UA — bumps beanfun's bot-risk score
+# and pops a reCAPTCHA the SChannel-based MapleLink / original WPF client never
+# saw on the same IP. SChannel presents the Windows system fingerprint beanfun
+# historically accepts. See `build_http_client`.
 reqwest = { version = "0.12", default-features = false, features = [
   "json",
   "cookies",
-  "rustls-tls",
+  "native-tls",
   "gzip",
   "deflate",
 ] }

--- a/src-tauri/src/services/beanfun/client.rs
+++ b/src-tauri/src/services/beanfun/client.rs
@@ -54,6 +54,27 @@ use super::error::LoginError;
 /// against a live Chrome 150 capture 2026-07-08.
 pub const DEFAULT_USER_AGENT: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36";
 
+/// Chrome client-hint brand string, sent on **every** request via the
+/// client-level default headers (see [`build_http_client`]).
+///
+/// The Chrome major MUST match [`DEFAULT_USER_AGENT`] — a UA-vs-`sec-ch-ua`
+/// version mismatch is itself a bot signal (issues #313/#315/#318, task
+/// spec §8). Verified against a live Chrome 150 capture 2026-07-08.
+///
+/// Why client-level and not just on the login POSTs: MapleLink sends the
+/// client hints + `Accept-Language` on **all** requests, including the
+/// page-fetch GETs (`bflogin/default.aspx` → `Login/Index`). Our GETs used
+/// to go out bare (UA only), so beanfun's risk engine saw a non-browser
+/// page fetch and flagged the session — the downstream `AccountLogin`
+/// reCAPTCHA that MapleLink never triggered on the same account/IP. Making
+/// every request carry the same hints closes that fingerprint gap.
+pub const SEC_CH_UA: &str =
+    "\"Not;A=Brand\";v=\"8\", \"Chromium\";v=\"150\", \"Google Chrome\";v=\"150\"";
+
+/// `Accept-Language` sent on every request (client-level), matching a
+/// zh-TW-primary Chrome and MapleLink's default header.
+pub const DEFAULT_ACCEPT_LANGUAGE: &str = "zh-TW,zh;q=0.9,en-US;q=0.8,en;q=0.7";
+
 /// Default per-request timeout. 30 s matches what a human expects before
 /// they give up and hit the button again; long enough for the occasional
 /// slow redirect, short enough that a stuck socket does not freeze the
@@ -473,9 +494,48 @@ fn build_http_client(
         .cookie_provider(cookie_store)
         .timeout(config.timeout)
         .user_agent(&config.user_agent)
+        .default_headers(browser_default_headers())
         .redirect(redirect_policy)
+        // Pin HTTP/1.1. The `http2` reqwest feature is off today (so ALPN never
+        // offers h2), but enabling it elsewhere in the app would silently let
+        // this client negotiate HTTP/2 — whose reqwest `h2` fingerprint is not
+        // Chrome's and, paired with our Chrome UA, is a bot tell that pops a
+        // reCAPTCHA. MapleLink talks HTTP/1.1 for the same reason. Belt-and-
+        // braces so a future feature flip can't regress the login fingerprint.
+        .http1_only()
         .build()
         .map_err(LoginError::Http)
+}
+
+/// Constant browser headers sent on **every** request (client-level), so the
+/// page-fetch GETs (`bflogin/default.aspx`, `Login/Index`, `SendLogin`) carry
+/// the same `sec-ch-ua*` / `Accept-Language` fingerprint as the login POSTs —
+/// matching MapleLink and keeping beanfun's risk engine from flagging the
+/// session on a bare GET. The variable, per-request headers (`Accept`,
+/// `Referer`, `Origin`, `Sec-Fetch-*`, `RequestVerificationToken`, …) are still
+/// added at each call site (see `login::apply_json_headers`), since they differ
+/// by request kind. The User-Agent is set separately via `.user_agent(...)`.
+fn browser_default_headers() -> reqwest::header::HeaderMap {
+    use reqwest::header::{HeaderMap, HeaderName, HeaderValue, ACCEPT_LANGUAGE};
+
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        HeaderName::from_static("sec-ch-ua"),
+        HeaderValue::from_static(SEC_CH_UA),
+    );
+    headers.insert(
+        HeaderName::from_static("sec-ch-ua-mobile"),
+        HeaderValue::from_static("?0"),
+    );
+    headers.insert(
+        HeaderName::from_static("sec-ch-ua-platform"),
+        HeaderValue::from_static("\"Windows\""),
+    );
+    headers.insert(
+        ACCEPT_LANGUAGE,
+        HeaderValue::from_static(DEFAULT_ACCEPT_LANGUAGE),
+    );
+    headers
 }
 
 // -----------------------------------------------------------------------------

--- a/src-tauri/src/services/beanfun/login/account_login.rs
+++ b/src-tauri/src/services/beanfun/login/account_login.rs
@@ -180,8 +180,7 @@ pub async fn account_login(
             .map(|d| d.is_recaptcha)
             .unwrap_or(false);
     let step_failed = !matches!(parsed.result_code.as_deref(), Some("1") | Some("2"));
-    let recaptcha =
-        step_failed && (message_demands_recaptcha(msg) || (flag && captcha.is_empty()));
+    let recaptcha = step_failed && (message_demands_recaptcha(msg) || (flag && captcha.is_empty()));
 
     // Diagnostic (issues #313/#315/#318): the exact server verdict is the
     // only way to tell "token rejected → re-challenge" apart from a real

--- a/src-tauri/src/services/beanfun/login/account_login.rs
+++ b/src-tauri/src/services/beanfun/login/account_login.rs
@@ -157,13 +157,21 @@ pub async fn account_login(
     let parsed: AccountLoginResponse = parse_step_json(&text, "AccountLogin")?;
 
     // Empty-first escalation. A reCAPTCHA demand takes precedence over the
-    // ResultCode/Result truth table — BUT only when the server actually
-    // asks for the "我不是機器人" check, or sets the `IsRecaptcha` flag on
-    // an empty-first probe (no token sent yet). The flag can also linger
-    // alongside a real error message *after* we already replayed a token
-    // (e.g. `資料驗證錯誤次數已達上限` — the ~15-min IP lock, task spec §8);
-    // treating that as "needs reCAPTCHA" is exactly what looped #313/#315/#318,
-    // so we fall through to surface the error message instead.
+    // ResultCode/Result truth table — BUT only when the login actually
+    // FAILED, and the server either asks for the "我不是機器人" check or sets
+    // the `IsRecaptcha` flag on an empty-first probe (no token sent yet).
+    //
+    // The `step_failed` gate removes the useless pre-password reCAPTCHA: on
+    // `ResultCode` 1 (success / advance-check) or 2 (lock / advance-check-with-
+    // URL) the server accepted the attempt, and a lingering `IsRecaptcha` flag
+    // there is only the
+    // session-level advisory (mirroring `InitLogin`). Popping a widget for it
+    // is the useless pre-password reCAPTCHA. MapleLink guards this the same
+    // way — it only considers reCAPTCHA in its `ResultCode` `_ =>` (non-1/2)
+    // arm. The flag can also linger alongside a real error message *after* we
+    // already replayed a token (e.g. `資料驗證錯誤次數已達上限` — the ~15-min
+    // IP lock, task spec §8); treating that as "needs reCAPTCHA" is exactly
+    // what looped #313/#315/#318, so we fall through to surface the error.
     let msg = parsed.result_message.as_deref().unwrap_or_default();
     let flag = parsed.is_recaptcha
         || parsed
@@ -171,7 +179,9 @@ pub async fn account_login(
             .as_ref()
             .map(|d| d.is_recaptcha)
             .unwrap_or(false);
-    let recaptcha = message_demands_recaptcha(msg) || (flag && captcha.is_empty());
+    let step_failed = !matches!(parsed.result_code.as_deref(), Some("1") | Some("2"));
+    let recaptcha =
+        step_failed && (message_demands_recaptcha(msg) || (flag && captcha.is_empty()));
 
     // Diagnostic (issues #313/#315/#318): the exact server verdict is the
     // only way to tell "token rejected → re-challenge" apart from a real
@@ -358,9 +368,9 @@ mod tests {
     }
 
     /// Recognition of a reCAPTCHA gate the way `account_login` does it at
-    /// runtime (before `classify_outcome`): the robot prompt always
-    /// escalates; the bare `IsRecaptcha` flag only escalates on an
-    /// empty-first probe (`captcha_empty`).
+    /// runtime: only when the login FAILED (`ResultCode` not 1/2) *and* the
+    /// server asks for the "我不是機器人" check, or sets the `IsRecaptcha`
+    /// flag on an empty-first probe (`captcha_empty`).
     fn is_recaptcha_gate(body: &str, captcha_empty: bool) -> bool {
         let p: AccountLoginResponse = serde_json::from_str(body).expect("valid JSON");
         let msg = p.result_message.as_deref().unwrap_or_default();
@@ -369,25 +379,39 @@ mod tests {
                 .as_ref()
                 .map(|d| d.is_recaptcha)
                 .unwrap_or(false);
-        message_demands_recaptcha(msg) || (flag && captcha_empty)
+        let step_failed = !matches!(p.result_code.as_deref(), Some("1") | Some("2"));
+        step_failed && (message_demands_recaptcha(msg) || (flag && captcha_empty))
     }
 
     #[test]
-    fn empty_first_is_recaptcha_flag_escalates() {
-        // No token yet + IsRecaptcha → open the widget.
+    fn empty_first_is_recaptcha_flag_escalates_only_on_failure() {
+        // No token yet + IsRecaptcha on a FAILED login (ResultCode 0) →
+        // open the widget.
         assert!(is_recaptcha_gate(
+            r#"{"IsRecaptcha":true,"ResultCode":"0"}"#,
+            true
+        ));
+        assert!(is_recaptcha_gate(
+            r#"{"ResultData":{"IsRecaptcha":true},"ResultCode":"0"}"#,
+            true
+        ));
+        // The SAME flag on a ResultCode 1 success must NOT escalate —
+        // that is the useless pre-password reCAPTCHA.
+        assert!(!is_recaptcha_gate(
             r#"{"IsRecaptcha":true,"ResultCode":"1"}"#,
             true
         ));
-        assert!(is_recaptcha_gate(
-            r#"{"ResultData":{"IsRecaptcha":true}}"#,
-            true
-        ));
     }
 
     #[test]
-    fn robot_message_always_escalates() {
+    fn robot_message_escalates_only_on_failure() {
+        // A 機器人 prompt on a failed login escalates …
         assert!(is_recaptcha_gate(
+            r#"{"ResultCode":"0","ResultMessage":"請點選「我不是機器人」"}"#,
+            false
+        ));
+        // … but not when ResultCode says the server accepted the attempt.
+        assert!(!is_recaptcha_gate(
             r#"{"ResultCode":"1","ResultMessage":"請點選「我不是機器人」"}"#,
             false
         ));

--- a/src-tauri/src/services/beanfun/login/check_account_type.rs
+++ b/src-tauri/src/services/beanfun/login/check_account_type.rs
@@ -11,12 +11,22 @@
 //! As of 2026-06 the server can gate this POST behind a Google reCAPTCHA
 //! Enterprise challenge. Rather than probing `Login/InitLogin` up front,
 //! we follow an **empty-first** strategy (task spec §1): send an empty
-//! `Captcha` token and inspect the response. When the server signals that
-//! a token is required — `ResultData.IsRecaptcha == true` or a
-//! "機器人"/"我不是機器人" message — we surface
-//! [`CheckAccountOutcome::RecaptchaRequired`] so the caller can solve the
-//! widget on beanfun's own origin and **retry this same step** with the
-//! solved token (which is passed back in via `captcha_token`).
+//! `Captcha` token and inspect the response.
+//!
+//! A reCAPTCHA demand only counts when the step **actually failed**
+//! (`ResultCode != 1`). beanfun echoes `ResultData.IsRecaptcha == true` as
+//! a *session-level advisory* (mirroring `InitLogin`'s risk verdict) even on
+//! a `ResultCode == 1` success — its own login page never reads that field
+//! on `CheckAccountType`, it only checks `ResultCode`. Popping a widget on
+//! that advisory is the "useless pre-password reCAPTCHA": the account
+//! check already succeeded, so we forward the server captcha and proceed.
+//! MapleLink guards this the same way with its `result_code != 1` check.
+//!
+//! When the step *fails* and the server signals a token is required —
+//! `ResultData.IsRecaptcha == true` or a "機器人"/"我不是機器人" message —
+//! we surface [`CheckAccountOutcome::RecaptchaRequired`] so the caller can
+//! solve the widget on beanfun's own origin and **retry this same step**
+//! with the solved token (which is passed back in via `captcha_token`).
 
 use serde::{Deserialize, Serialize};
 
@@ -47,6 +57,17 @@ struct CheckAccountTypeRequest<'a> {
 /// (server-provided passthrough token) and the reCAPTCHA signals.
 #[derive(Deserialize)]
 struct CheckAccountTypeResponse {
+    /// beanfun's success/failure code. `"1"` == success (the account check
+    /// passed); anything else is a failure. Read via the shared JToken-style
+    /// coercion because the server sends it as either an integer or a string.
+    /// Absent → treated as success (matches MapleLink's `.unwrap_or(1)`), so a
+    /// response-shape change never spuriously pops a widget.
+    #[serde(
+        rename = "ResultCode",
+        default,
+        deserialize_with = "deserialize_jtoken_to_string"
+    )]
+    result_code: Option<String>,
     #[serde(
         rename = "Message",
         default,
@@ -137,12 +158,33 @@ pub async fn check_account_type(
     }
 
     let parsed: CheckAccountTypeResponse = parse_step_json(&text, "CheckAccountType")?;
+
+    let succeeded = result_code_is_success(parsed.result_code.as_deref());
+    let is_recaptcha = parsed
+        .result_data
+        .as_ref()
+        .map(|d| d.is_recaptcha)
+        .unwrap_or(false);
+
+    // Diagnostic: the exact server verdict for this step. Parity with
+    // `AccountLogin.Verdict` — it's the only way to see whether beanfun is
+    // genuinely gating the *account* step behind reCAPTCHA (a risk verdict on
+    // our request fingerprint) vs. sailing through like MapleLink on the same
+    // IP. `account` is non-secret; the captcha token itself is never logged.
+    tracing::info!(
+        step = "CheckAccountType.Verdict",
+        account_id = %account,
+        result_code = parsed.result_code.as_deref().unwrap_or(""),
+        succeeded,
+        is_recaptcha,
+        captcha_sent = !captcha_token.is_empty(),
+        message = %truncate_for_log(parsed.message.as_deref().unwrap_or("")),
+        "CheckAccountType server response classified"
+    );
+
     Ok(classify_check_response(
-        parsed
-            .result_data
-            .as_ref()
-            .map(|d| d.is_recaptcha)
-            .unwrap_or(false),
+        succeeded,
+        is_recaptcha,
         parsed.message.as_deref().unwrap_or_default(),
         captcha_token.is_empty(),
         parsed
@@ -152,22 +194,47 @@ pub async fn check_account_type(
     ))
 }
 
+/// Borrow at most ~120 chars of a server message for a log line (won't split
+/// a CJK codepoint). Mirrors the helper in [`super::account_login`].
+fn truncate_for_log(s: &str) -> &str {
+    match s.char_indices().nth(120) {
+        Some((idx, _)) => &s[..idx],
+        None => s,
+    }
+}
+
+/// Whether `CheckAccountType` accepted the account check. `"1"` is beanfun's
+/// success code; a missing code defaults to success (MapleLink's
+/// `.unwrap_or(1)` semantics) so a response-shape change degrades to "proceed"
+/// rather than a spurious reCAPTCHA pop.
+fn result_code_is_success(result_code: Option<&str>) -> bool {
+    match result_code {
+        Some(code) => code == "1",
+        None => true,
+    }
+}
+
 /// Pure mapping from the parsed response fields to a [`CheckAccountOutcome`].
 /// Kept separate so the reCAPTCHA-detection table is unit-testable without
 /// a mock HTTP server.
 ///
-/// Escalates to a reCAPTCHA solve only when the server asks for the
-/// "我不是機器人" check, or sets `IsRecaptcha` on an empty-first probe
-/// (`captcha_empty`). A flag lingering alongside a real error after a token
-/// was already replayed surfaces as the error instead of looping (see
-/// `account_login` for the same rule / the #313/#315/#318 rationale).
+/// A reCAPTCHA solve is only demanded when the step **failed** (`!succeeded`)
+/// *and* the server either asks for the "我不是機器人" check or sets
+/// `IsRecaptcha` on an empty-first probe (`captcha_empty`). On a `ResultCode`
+/// success the server accepted the account check — a lingering `IsRecaptcha`
+/// advisory there is the useless pre-password reCAPTCHA, so we forward
+/// the server captcha and proceed. A flag lingering alongside a real error
+/// after a token was already replayed likewise surfaces as the error instead
+/// of looping (see `account_login` for the same rule / the #313/#315/#318
+/// rationale).
 fn classify_check_response(
+    succeeded: bool,
     is_recaptcha: bool,
     message: &str,
     captcha_empty: bool,
     server_captcha: String,
 ) -> CheckAccountOutcome {
-    if message_demands_recaptcha(message) || (is_recaptcha && captcha_empty) {
+    if !succeeded && (message_demands_recaptcha(message) || (is_recaptcha && captcha_empty)) {
         CheckAccountOutcome::RecaptchaRequired
     } else {
         CheckAccountOutcome::Proceed { server_captcha }
@@ -186,6 +253,7 @@ mod tests {
     fn parse_with(body: &str, captcha_empty: bool) -> CheckAccountOutcome {
         let r: CheckAccountTypeResponse = serde_json::from_str(body).expect("valid JSON");
         classify_check_response(
+            result_code_is_success(r.result_code.as_deref()),
             r.result_data
                 .as_ref()
                 .map(|d| d.is_recaptcha)
@@ -240,18 +308,33 @@ mod tests {
     }
 
     #[test]
-    fn is_recaptcha_flag_demands_recaptcha() {
+    fn is_recaptcha_flag_on_failure_demands_recaptcha() {
+        // The genuine gate: the account check FAILED (ResultCode 0) and the
+        // server flagged IsRecaptcha on our empty-first probe.
         assert_eq!(
-            parse(r#"{"ResultData":{"IsRecaptcha":true}}"#),
+            parse(r#"{"ResultCode":0,"ResultData":{"IsRecaptcha":true}}"#),
             CheckAccountOutcome::RecaptchaRequired
         );
     }
 
     #[test]
-    fn robot_message_demands_recaptcha() {
-        // Even without the flag, a 機器人 message escalates.
+    fn is_recaptcha_flag_on_success_is_the_useless_pre_password_widget() {
+        // ResultCode 1 means the account check succeeded. A lingering
+        // IsRecaptcha advisory must NOT pop a widget — we forward the (here
+        // empty) server captcha and proceed straight to AccountLogin.
         assert_eq!(
-            parse(r#"{"Message":"請點選「我不是機器人」","ResultData":{"Captcha":""}}"#),
+            parse(r#"{"ResultCode":1,"ResultData":{"IsRecaptcha":true,"Captcha":"srv"}}"#),
+            CheckAccountOutcome::Proceed {
+                server_captcha: "srv".to_owned()
+            }
+        );
+    }
+
+    #[test]
+    fn robot_message_on_failure_demands_recaptcha() {
+        // Even without the flag, a 機器人 message on a failed check escalates.
+        assert_eq!(
+            parse(r#"{"ResultCode":0,"Message":"請點選「我不是機器人」","ResultData":{"Captcha":""}}"#),
             CheckAccountOutcome::RecaptchaRequired
         );
     }
@@ -263,7 +346,7 @@ mod tests {
         // proceed instead of re-opening the widget (#313/#315/#318).
         assert_eq!(
             parse_with(
-                r#"{"Message":"資料驗證錯誤","ResultData":{"IsRecaptcha":true,"Captcha":"X"}}"#,
+                r#"{"ResultCode":0,"Message":"資料驗證錯誤","ResultData":{"IsRecaptcha":true,"Captcha":"X"}}"#,
                 false,
             ),
             CheckAccountOutcome::Proceed {

--- a/src-tauri/src/services/beanfun/login/check_account_type.rs
+++ b/src-tauri/src/services/beanfun/login/check_account_type.rs
@@ -334,7 +334,9 @@ mod tests {
     fn robot_message_on_failure_demands_recaptcha() {
         // Even without the flag, a 機器人 message on a failed check escalates.
         assert_eq!(
-            parse(r#"{"ResultCode":0,"Message":"請點選「我不是機器人」","ResultData":{"Captcha":""}}"#),
+            parse(
+                r#"{"ResultCode":0,"Message":"請點選「我不是機器人」","ResultData":{"Captcha":""}}"#
+            ),
             CheckAccountOutcome::RecaptchaRequired
         );
     }

--- a/src-tauri/src/services/beanfun/login/mod.rs
+++ b/src-tauri/src/services/beanfun/login/mod.rs
@@ -111,20 +111,18 @@ pub(crate) fn apply_json_headers(
         .header(reqwest::header::REFERER, referer)
         .header("X-Requested-With", "XMLHttpRequest")
         .header("RequestVerificationToken", verification_token)
-        // Modern browser fingerprint (issues #313/#315/#318, task spec §8).
-        // A reCAPTCHA token is solved in a real WebView, but replayed on this
-        // reqwest POST; if the POST doesn't *look* like the same modern
-        // browser, beanfun bot-flags it and rejects the token — eventually
-        // locking the IP for ~15 min ("資料驗證錯誤次數已達上限"). Values
-        // are matched byte-for-byte to a live Chrome 150 capture (2026-07-08)
-        // of a beanfun `login.beanfun.com` POST. The `sec-ch-ua` version MUST
-        // track `client::DEFAULT_USER_AGENT`'s Chrome major (150).
-        .header(
-            "sec-ch-ua",
-            "\"Not;A=Brand\";v=\"8\", \"Chromium\";v=\"150\", \"Google Chrome\";v=\"150\"",
-        )
-        .header("sec-ch-ua-mobile", "?0")
-        .header("sec-ch-ua-platform", "\"Windows\"")
+        // Fetch-context headers describing a same-origin `fetch()`/XHR (issues
+        // #313/#315/#318, task spec §8). A reCAPTCHA token is solved in a real
+        // WebView but replayed on this reqwest POST; if the POST doesn't look
+        // like the page's own fetch, beanfun bot-flags it and rejects the token
+        // — eventually locking the IP for ~15 min ("資料驗證錯誤次數已達上限").
+        //
+        // The constant browser fingerprint — `sec-ch-ua*` + `Accept-Language`
+        // — is NOT set here anymore: it moved to the client-level default
+        // headers (`client::browser_default_headers`) so the page-fetch GETs
+        // carry it too, matching MapleLink. Only the per-request-kind headers
+        // live here. The `sec-ch-ua` value still tracks
+        // `client::DEFAULT_USER_AGENT`'s Chrome major (150) via that constant.
         .header("Sec-Fetch-Site", "same-origin")
         .header("Sec-Fetch-Mode", "cors")
         .header("Sec-Fetch-Dest", "empty")
@@ -137,12 +135,7 @@ pub(crate) fn apply_json_headers(
         // AccountLogin, and a plain fetch does NOT add those headers — sending
         // them makes the POST look scripted (curl-like) and bumps the bot-risk
         // score that pops reCAPTCHA. The MapleLink client omits them and logs
-        // in clean on the same IP; this is the one header difference that made
-        // beanfun get reCAPTCHA while MapleLink didn't.
-        .header(
-            reqwest::header::ACCEPT_LANGUAGE,
-            "zh-TW,zh;q=0.9,en-US;q=0.8,en;q=0.7",
-        )
+        // in clean on the same IP.
 }
 
 /// `true` when a login-step `Message` string signals that the server

--- a/src-tauri/src/services/beanfun/login/mod.rs
+++ b/src-tauri/src/services/beanfun/login/mod.rs
@@ -130,12 +130,12 @@ pub(crate) fn apply_json_headers(
         // POST; reqwest does not add one, and its absence is a bot tell.
         // These login steps are TW-only, so the host is fixed.
         .header(reqwest::header::ORIGIN, "https://login.beanfun.com")
-        // NOTE: deliberately NOT sending `Cache-Control`/`Pragma: no-cache`.
-        // beanfun's login page issues a plain `fetch()` for CheckAccountType /
-        // AccountLogin, and a plain fetch does NOT add those headers — sending
-        // them makes the POST look scripted (curl-like) and bumps the bot-risk
-        // score that pops reCAPTCHA. The MapleLink client omits them and logs
-        // in clean on the same IP.
+    // NOTE: deliberately NOT sending `Cache-Control`/`Pragma: no-cache`.
+    // beanfun's login page issues a plain `fetch()` for CheckAccountType /
+    // AccountLogin, and a plain fetch does NOT add those headers — sending
+    // them makes the POST look scripted (curl-like) and bumps the bot-risk
+    // score that pops reCAPTCHA. The MapleLink client omits them and logs
+    // in clean on the same IP.
 }
 
 /// `true` when a login-step `Message` string signals that the server

--- a/src-tauri/tests/tw_login.rs
+++ b/src-tauri/tests/tw_login.rs
@@ -200,15 +200,16 @@ async fn tw_regular_happy_path_returns_session() {
 async fn recaptcha_required_diverts_to_webview_login() {
     // Token-replay (#313/#315/#318): reCAPTCHA is detected empty-first
     // from the CheckAccountType response (IsRecaptcha=true), not from a
-    // separate InitLogin probe. The single-shot `login_tw_regular` has no
-    // interactive surface, so it surfaces `RecaptchaRequired`.
-    // AccountLogin is intentionally left unmounted: escalating at the
-    // check step must NOT touch it.
+    // separate InitLogin probe. It only counts when the check FAILED
+    // (ResultCode != 1), so the demand here carries ResultCode 0.
+    // The single-shot `login_tw_regular` has no interactive surface, so it
+    // surfaces `RecaptchaRequired`. AccountLogin is intentionally left
+    // unmounted: escalating at the check step must NOT touch it.
     let server = MockServer::start().await;
     mount_session_key(&server).await;
     mount_index_with_token(&server, FORM_TOKEN).await;
     let body = serde_json::json!({
-        "ResultCode": "1",
+        "ResultCode": "0",
         "ResultData": { "IsRecaptcha": true }
     });
     Mock::given(method("POST"))
@@ -249,16 +250,47 @@ async fn recaptcha_false_continues_headless_flow() {
 }
 
 #[tokio::test]
+async fn is_recaptcha_flag_on_check_success_does_not_divert() {
+    // The server flags IsRecaptcha as a session-level advisory even on a
+    // ResultCode 1 CheckAccountType success. That must NOT pop the useless
+    // pre-password widget — the headless flow proceeds to AccountLogin and
+    // completes. (This is the exact "always asks for a useless reCAPTCHA
+    // first" symptom, now guarded end-to-end.)
+    let server = MockServer::start().await;
+    mount_session_key(&server).await;
+    mount_index_with_token(&server, FORM_TOKEN).await;
+    Mock::given(method("POST"))
+        .and(path("/Login/CheckAccountType"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "ResultCode": "1",
+            "ResultData": { "IsRecaptcha": true, "Captcha": "" }
+        })))
+        .mount(&server)
+        .await;
+    mount_account_login_success(&server).await;
+    mount_send_login_happy(&server).await;
+    mount_return_aspx_with_token(&server, WEB_TOKEN).await;
+
+    let client = client_for(&server);
+    let session = login_tw_regular(&client, &creds())
+        .await
+        .expect("IsRecaptcha on a check success must not divert");
+    assert_eq!(session.web_token, WEB_TOKEN);
+}
+
+#[tokio::test]
 async fn recaptcha_required_at_account_login_step_diverts() {
     // reCAPTCHA can also gate the *second* POST (AccountLogin) even when
     // CheckAccountType passed clean — empty-first must escalate there too.
+    // As with the check step, the demand is a FAILURE response (ResultCode 0
+    // + IsRecaptcha), not a ResultCode 1 success.
     let server = MockServer::start().await;
     mount_session_key(&server).await;
     mount_index_with_token(&server, FORM_TOKEN).await;
     mount_check_account_type(&server, "").await;
     mount_account_login_with_body(
         &server,
-        serde_json::json!({ "IsRecaptcha": true, "ResultCode": "1" }),
+        serde_json::json!({ "IsRecaptcha": true, "ResultCode": "0" }),
     )
     .await;
 


### PR DESCRIPTION
## What

TW Regular (帳密) login forced one or more Google reCAPTCHA challenges that
MapleLink never triggers on the same account/IP — the "帳號 → reCAPTCHA → 密碼 →
reCAPTCHA" flow. Root causes:

- reCAPTCHA escalation keyed on beanfun's `IsRecaptcha` advisory flag instead of
  whether the step actually failed. beanfun echoes `ResultData.IsRecaptcha:true`
  even on a `ResultCode:1` success (its own login page only reads `ResultCode`),
  so a successful `CheckAccountType` still popped a useless pre-password widget.
- Our request fingerprint was flagged by beanfun's bot-risk engine: the
  page-fetch GETs went out without the browser client hints MapleLink sends on
  every request, so beanfun flagged the session and demanded reCAPTCHA at
  `AccountLogin`. Confirmed via A/B — same account/IP, MapleLink no popup, we
  popped.

## Fix

1. **Gate reCAPTCHA on step failure, not the advisory flag.** `CheckAccountType`
   now proceeds on `ResultCode == 1` regardless of `IsRecaptcha`; `AccountLogin`
   only escalates when `ResultCode` is neither 1 nor 2. Mirrors MapleLink's
   `result_code != 1` guard. Removes the useless pre-password widget.

2. **Match MapleLink's request fingerprint.** Hoisted the constant browser
   headers (`sec-ch-ua`, `sec-ch-ua-mobile`, `sec-ch-ua-platform`,
   `Accept-Language`) to client-level default headers so every request —
   including the page-fetch GETs (`bflogin/default.aspx`, `Login/Index`) —
   carries them. Previously they were only on the login POSTs, so beanfun flagged
   the session on the bare GET and demanded reCAPTCHA at `AccountLogin`. This
   removed the remaining widget. Also switched reqwest `rustls-tls` →
   `native-tls` (SChannel, as MapleLink and the original WPF client) and pinned
   `http1_only`.

3. **Diagnostics.** Added a `CheckAccountType.Verdict` tracing log (parity with
   `AccountLogin.Verdict`) exposing `result_code` / `is_recaptcha` per step.

Verified end-to-end against live beanfun: no reCAPTCHA, logs straight into the
account list. 766 unit + 19 integration tests pass; clippy clean.
