### PR TITLE
fix(login): cap the account dropdown to the space below the field

### DIFF
--- a/src/pages/IdPassForm.vue
+++ b/src/pages/IdPassForm.vue
@@ -265,6 +265,38 @@ const savedAccountsForRegion = computed(() => {
 
 const showAccountDropdown = ref(false)
 
+/* --------------- issue #344 — dropdown double-scrollbar --------------- */
+
+/**
+ * The account dropdown used to be a fixed `max-height: 200px`. The
+ * window is content-fit and often shorter than "field bottom + 200px",
+ * so with 11+ saved accounts the absolutely-positioned list poked past
+ * the window bottom — `login-shell__body` (overflow auto) then grew a
+ * SECOND scrollbar, and the inner list's own scrollbar could never
+ * reach the last account (issue #344). Fix: measure the space actually
+ * available below the field when the dropdown opens and cap the list
+ * to it, so the list always ends inside the window and only ONE
+ * scrollbar (its own) exists.
+ */
+const accountWrapRef = ref<HTMLElement | null>(null)
+const dropdownMaxHeight = ref(200)
+
+/** Bottom margin (px) kept between the dropdown and the window edge. */
+const DROPDOWN_VIEWPORT_MARGIN = 12
+/** Never cap below ~3 rows — a sliver of a list is unusable. */
+const DROPDOWN_MIN_HEIGHT = 96
+
+function toggleAccountDropdown(): void {
+  if (!showAccountDropdown.value && typeof window !== 'undefined') {
+    const rect = accountWrapRef.value?.getBoundingClientRect()
+    if (rect) {
+      const available = Math.floor(window.innerHeight - rect.bottom - DROPDOWN_VIEWPORT_MARGIN)
+      dropdownMaxHeight.value = Math.max(DROPDOWN_MIN_HEIGHT, Math.min(200, available))
+    }
+  }
+  showAccountDropdown.value = !showAccountDropdown.value
+}
+
 /** Reactive current region for template bindings. */
 const currentRegion = computed(() => readRegion())
 
@@ -634,7 +666,7 @@ async function persistAfterFullSuccess(intent: LoginIntent): Promise<void> {
     <template v-else>
       <div class="id-pass-form__field">
         <label class="id-pass-form__label">{{ t('AcountOrEmail') }}</label>
-        <div class="id-pass-form__account-wrap">
+        <div ref="accountWrapRef" class="id-pass-form__account-wrap">
           <el-input
             v-model="account"
             size="default"
@@ -647,11 +679,16 @@ async function persistAfterFullSuccess(intent: LoginIntent): Promise<void> {
             v-if="savedAccountsForRegion.length > 0"
             type="button"
             class="id-pass-form__dropdown-btn"
-            @click="showAccountDropdown = !showAccountDropdown"
+            @click="toggleAccountDropdown"
           >
             <span class="material-symbols-outlined">expand_more</span>
           </button>
-          <ul v-if="showAccountDropdown" class="id-pass-form__dropdown">
+          <ul
+            v-if="showAccountDropdown"
+            class="id-pass-form__dropdown"
+            :style="{ maxHeight: dropdownMaxHeight + 'px' }"
+            data-test="id-pass-account-dropdown"
+          >
             <li
               v-for="sa in savedAccountsForRegion"
               :key="sa.account_id"
@@ -843,6 +880,7 @@ async function persistAfterFullSuccess(intent: LoginIntent): Promise<void> {
   border: 1px solid rgba(0, 0, 0, 0.08);
   border-radius: 8px;
   box-shadow: 0 6px 16px rgba(0, 0, 0, 0.08);
+  /* Capped inline per open (issue #344) — 200px is only the ceiling. */
   max-height: 200px;
   overflow-y: auto;
 }

--- a/tests/unit/pages/IdPassForm.spec.ts
+++ b/tests/unit/pages/IdPassForm.spec.ts
@@ -651,6 +651,34 @@ describe('IdPassForm — P12.2 D2 credential persistence', () => {
     expect((checkboxes[1].element as HTMLInputElement).checked).toBe(true)
   })
 
+  it('issue #344: dropdown max-height is capped to the space below the field', async () => {
+    // 11+ saved accounts used to overflow the content-fit window: the
+    // fixed 200px list poked past the window bottom, the outer body
+    // grew a second scrollbar, and the inner one couldn't reach the
+    // last account. The cap must follow the actual viewport space.
+    const ctx = mountForm()
+    const account = useAccountStore()
+    account.accounts = Array.from({ length: 12 }, (_, i) => ({
+      ...STORED_ALICE,
+      account_id: `acct-${i}`,
+    }))
+    const wrapper = await ctx.mountIt()
+
+    // Small window: 150px viewport − field bottom (0 in jsdom) − 12px
+    // margin = 138px available.
+    Object.defineProperty(window, 'innerHeight', { value: 150, configurable: true })
+    await wrapper.get('.id-pass-form__dropdown-btn').trigger('click')
+    const dropdown = wrapper.get('[data-test="id-pass-account-dropdown"]')
+    expect((dropdown.element as HTMLElement).style.maxHeight).toBe('138px')
+
+    // Roomy window: capped at the 200px design ceiling, never more.
+    await wrapper.get('.id-pass-form__dropdown-btn').trigger('click') // close
+    Object.defineProperty(window, 'innerHeight', { value: 900, configurable: true })
+    await wrapper.get('.id-pass-form__dropdown-btn').trigger('click') // reopen
+    const reopened = wrapper.get('[data-test="id-pass-account-dropdown"]')
+    expect((reopened.element as HTMLElement).style.maxHeight).toBe('200px')
+  })
+
   it('mount with no Config.AccountID falls back to first stored account for the region', async () => {
     const ctx = mountForm()
     const account = useAccountStore()


### PR DESCRIPTION
## What
With 11+ saved accounts, opening the login account dropdown produced BOTH an inner scrollbar (the list's own) and an outer one, the inner scroll jammed before the end, and the last account was unreachable without hovering a row first (#344).

Root cause: the dropdown had a fixed `max-height: 200px`, but the window is content-fit and usually shorter than "field bottom + 200px" — the absolutely-positioned list poked past the window bottom, so `login-shell__body` (overflow auto) grew a second scrollbar, and the list's own scrollbar could never reach its final rows.

## Fix
Exactly what the reporter suggested — bound the dropdown's height so the outer scrollbar can't appear: on open, measure the space actually available below the account field (`viewport height − field bottom − 12px margin`, clamped to [96px, 200px]) and apply it as the list's max-height. The list always ends inside the window; its own scrollbar is the only one and reaches the last account.

## Tests
New spec: small viewport → capped to the available space (138px); roomy viewport → keeps the 200px design ceiling. 666 frontend tests, typecheck, eslint, prettier all pass. Frontend-only.

Closes #344