### PR TITLE
fix(classic): give the portal window the main window's browser args (issue #356)

### DIFF
--- a/src-tauri/src/commands/classic.rs
+++ b/src-tauri/src/commands/classic.rs
@@ -91,6 +91,9 @@ pub const CLASSIC_SLOW_EVENT: &str = "classic-launch-slow";
 /// Emitted when the portal needs an interactive sign-in (always the case
 /// for TW, whose classic login is separate from the regular service).
 pub const CLASSIC_NEEDS_LOGIN_EVENT: &str = "classic-needs-login";
+/// Emitted when the user closed the portal without a launch, so the
+/// frontend can release its re-entry guard.
+pub const CLASSIC_CLOSED_EVENT: &str = "classic-portal-closed";
 /// Emitted with the GamaPass game accounts when the portal offers more
 /// than one — the frontend shows a native picker and answers with
 /// [`classic_select_account`].
@@ -585,9 +588,16 @@ fn spawn_portal_window<R: tauri::Runtime>(
     .user_agent(CLASSIC_PORTAL_USER_AGENT)
     .initialization_script(script);
     // Share the per-instance WebView2 profile (issue #340) so this window
-    // can't hit the cross-instance ERROR_INVALID_STATE either.
+    // can't hit the cross-instance ERROR_INVALID_STATE either — and with
+    // it the SAME browser args, because every environment on one user
+    // data folder must be configured identically. Passing the folder
+    // alone is what made this window fail with ERROR_INVALID_STATE and
+    // the launch button do nothing (issue #356).
     if let Some(dir) = crate::current_instance_webview_dir() {
         builder = builder.data_directory(dir);
+        if let Some(args) = crate::current_browser_args() {
+            builder = builder.additional_browser_args(args);
+        }
     }
     builder.build().map_err(|e| {
         CommandError::new(
@@ -827,7 +837,12 @@ async fn open_classic_login_windows<R: tauri::Runtime>(
         for tick in 0..HARD_DEADLINE_TICKS {
             tokio::time::sleep(std::time::Duration::from_millis(500)).await;
             if app.get_webview_window(CLASSIC_WINDOW_LABEL).is_none() {
-                return; // user closed the portal
+                // The user closed the portal. Say so: the frontend arms a
+                // re-entry guard when the launch starts, and leaving
+                // silently here left it armed forever — every later press
+                // of the launch button then did nothing at all.
+                let _ = app.emit(CLASSIC_CLOSED_EVENT, ());
+                return;
             }
 
             match flag.load(Ordering::SeqCst) {
@@ -902,6 +917,26 @@ mod tests {
     fn rejects_empty_handler_commands() {
         assert!(parse_handler_command("", "ngm://x").is_none());
         assert!(parse_handler_command(r#""""#, "ngm://x").is_none());
+    }
+
+    #[test]
+    fn portal_window_matches_the_main_environment() {
+        // Every WebView2 environment on one user data folder must be
+        // configured identically; passing the folder without the args
+        // is refused with ERROR_INVALID_STATE (0x8007139F) and the
+        // launch button then did nothing at all (issue #356, measured).
+        let src = include_str!("classic.rs");
+        let dir_at = src
+            .find("current_instance_webview_dir")
+            .expect("dir accessor used");
+        let args_at = src
+            .find("current_browser_args")
+            .expect("args accessor used");
+        let build_end = src.find("builder.build()").expect("builder is built");
+        assert!(
+            dir_at < build_end && args_at < build_end,
+            "the portal must take BOTH the per-instance folder and its args"
+        );
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -189,6 +189,36 @@ fn webview_instance_base_dir() -> Option<PathBuf> {
 /// Returns `None` when boot fell back to the shared default (the
 /// window builder then simply omits `data_directory`, matching the
 /// main window's fallback).
+/// Browser arguments the main window's WebView2 environment was built
+/// with, for runtime-created windows to reuse.
+///
+/// # Why this must be shared (issue #356)
+///
+/// Every WebView2 environment sharing a user data folder must be
+/// configured **identically**; a second environment with different
+/// options is refused with `ERROR_INVALID_STATE` (0x8007139F). The
+/// MapleStory Classic portal reused the per-instance folder (#340) but
+/// not the args, so its webview failed to create and the launch button
+/// did nothing — measured, not theorised:
+///
+/// ```text
+/// ERROR tauri_runtime_wry: failed to create webview:
+///   WebView2 error: WindowsError(HRESULT(0x8007139F))
+/// WARN  classic: portal webview not usable … rebuilding once
+/// ```
+///
+/// Any window that passes [`current_instance_webview_dir`] must pass
+/// these too — they are two halves of one environment identity.
+#[cfg(target_os = "windows")]
+static BROWSER_ARGS: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+
+/// The main window's browser arguments; `None` before boot has set them
+/// (and on non-Windows, where the concept doesn't apply).
+#[cfg(target_os = "windows")]
+pub(crate) fn current_browser_args() -> Option<&'static str> {
+    BROWSER_ARGS.get().map(String::as_str)
+}
+
 #[cfg(target_os = "windows")]
 pub(crate) fn current_instance_webview_dir() -> Option<PathBuf> {
     let dir = webview_instance_base_dir()?.join(std::process::id().to_string());
@@ -560,7 +590,12 @@ pub fn run() {
             }
         }
 
-        args.join(" ")
+        let joined = args.join(" ");
+        // Runtime windows sharing the per-instance user data folder must
+        // build their environment with exactly these args — see
+        // `current_browser_args`.
+        let _ = BROWSER_ARGS.set(joined.clone());
+        joined
     };
 
     // Per-instance WebView2 profile (issue #340) — see

--- a/src/composables/useClassicLaunch.ts
+++ b/src/composables/useClassicLaunch.ts
@@ -30,6 +30,7 @@ import {
   CLASSIC_LAUNCHED_EVENT,
   CLASSIC_NEEDS_LOGIN_EVENT,
   CLASSIC_SLOW_EVENT,
+  CLASSIC_CLOSED_EVENT,
 } from '../constants/classic'
 
 export interface ClassicLaunch {
@@ -64,6 +65,12 @@ export function useClassicLaunch(): ClassicLaunch {
         }),
         await listen(CLASSIC_NEEDS_LOGIN_EVENT, () => {
           ElMessage.info(t('classic.needsLogin'))
+        }),
+        // Closing the portal is a deliberate cancel — release the guard
+        // quietly so the button works again (it used to stay armed and
+        // every later press did nothing).
+        await listen(CLASSIC_CLOSED_EVENT, () => {
+          launching.value = false
         }),
       )
     } catch (e) {

--- a/src/constants/classic.ts
+++ b/src/constants/classic.ts
@@ -35,6 +35,12 @@ export const CLASSIC_SLOW_EVENT = 'classic-launch-slow'
 /** Emitted when the portal needs an interactive sign-in (always TW). */
 export const CLASSIC_NEEDS_LOGIN_EVENT = 'classic-needs-login'
 /**
+ * Emitted when the user closed the portal without launching. Releases
+ * the re-entry guard: without it the guard stayed armed and every later
+ * press of the launch button did nothing (issue #356).
+ */
+export const CLASSIC_CLOSED_EVENT = 'classic-portal-closed'
+/**
  * Emitted with the GamaPass game accounts when the portal offers more
  * than one; `ClassicAccountPicker` answers with `classicSelectAccount`.
  * A single account never reaches the frontend — the portal script

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -373,7 +373,7 @@ const zhTW = {
     button: '經典版',
     modeToggle: '懷舊服',
     modeToggleTitle:
-      '切換懷舊服登入模式：登入後先啟動新楓之谷經典版，再進入帳號清單（限 HK 帳號或 TW GamaPass 登入）',
+      '懷舊服模式：香港帳號登入後會自動啟動新楓之谷經典版；台灣帳號請按「啟動經典版」另行登入（台服經典版與正式服帳號分開）。',
     needGamapass:
       '台服經典版與正式服為獨立登入，無法沿用正式服的登入狀態。點擊下方按鈕開啟經典版視窗並於視窗內登入，登入後將自動啟動遊戲。',
     launchButton: '啟動經典版',
@@ -658,7 +658,7 @@ const zhCN = {
     button: '经典版',
     modeToggle: '怀旧服',
     modeToggleTitle:
-      '切换怀旧服登录模式：登录后先启动新枫之谷经典版，再进入账号列表（限 HK 账号或 TW GamaPass 登录）',
+      '怀旧服模式：香港账号登录后会自动启动新枫之谷经典版；台湾账号请按「启动经典版」另行登录（台服经典版与正式服账号分开）。',
     needGamapass:
       '台服经典版与正式服为独立登录，无法沿用正式服的登录状态。点击下方按钮开启经典版窗口并在窗口内登录，登录后将自动启动游戏。',
     launchButton: '启动经典版',
@@ -949,7 +949,7 @@ const enUS = {
     button: 'Classic',
     modeToggle: 'Classic',
     modeToggleTitle:
-      'Toggle Classic login mode: after sign-in, MapleStory Classic launches first, then the account list opens (HK accounts or TW GamaPass only)',
+      'Classic mode: an HK account launches MapleStory Classic right after signing in; a Taiwan account uses "Launch Classic" to sign in separately — TW Classic has its own account, apart from the regular service.',
     needGamapass:
       'Taiwan Classic uses a separate login from the regular service — an existing sign-in does not carry over. Open the Classic window below and sign in there; the game launches automatically afterwards.',
     launchButton: 'Launch Classic',


### PR DESCRIPTION
## What
Reported in #356: with the 懷舊服 toggle on, pressing 啟動經典版 did **nothing at all**. Reproduced locally with tracing — the portal's webview never came up:

```
ERROR tauri_runtime_wry: failed to create webview:
  WebView2 error: WindowsError(HRESULT(0x8007139F))
WARN  classic: portal webview not usable (WebMessageReceived registration timed out); rebuilding once
```

`0x8007139F` is **ERROR_INVALID_STATE**. Every WebView2 environment sharing a user data folder must be configured **identically** — and the portal took the per-instance folder (#340) *without* the browser args the main window builds its environment with (those moved onto the builder in #346). The mismatch made the second environment illegal: the window opened with a dead webview, every handler timed out, and ~11 s later the command failed. From the user's seat: nothing happened.

## Fix
- `lib.rs` publishes the boot-time args (`BROWSER_ARGS` / `current_browser_args`) right next to `current_instance_webview_dir` — they are two halves of one environment identity, and the doc comment says so, so the next window can't take one without the other.
- `classic.rs` passes both. **Verified in the running app**: the portal now opens and the injected script reports `signin-clicked`.
- A regression test pins that the portal builder reads both accessors.

## Two more things from the same report
- **Closing the portal emitted nothing**, so the frontend's re-entry guard stayed armed and *every later press* of the launch button silently did nothing — a second, independent "no response" path. The poll now emits `classic-portal-closed` and the composable releases the guard.
- **The tooltip was wrong for TW.** It claimed the launch "then opens the account list", which only happens for HK; TW Classic is a separate login that the button opens directly. Reworded in all three locales.

## Answering the reporter's questions (for the issue thread)
- **HK**: the beanfun sign-in covers both services, so Classic starts silently right after login.
- **TW**: Classic is a **separate** login from the regular service — the button opens the official portal window, you sign in there (account/password → GamaPass consent → game-account selection, all driven automatically), then NGM launches the game. Same order as the official site.
- The portal is the official page, so it offers exactly what the official launch link offers — account/password, not QR.

## Checks
681 frontend tests, 1024 Rust tests across 28 binaries, clippy clean under `-D warnings`, typecheck / eslint / prettier pass.