### PR TITLE
fix(classic): drive the portal even when the page never finishes loading (issue #356)

### DIFF
--- a/src-tauri/src/commands/classic.rs
+++ b/src-tauri/src/commands/classic.rs
@@ -150,6 +150,14 @@ fn portal_script(region: LoginRegion) -> String {
   // considered ready to be driven — ~1.2s, enough for the client-side
   // app to bind its handlers.
   var SETTLE_TICKS = 3;
+  // …but `readyState === 'complete'` waits for EVERY subresource, and a
+  // single hung one (an analytics script an accelerator / VPN / blocker
+  // is swallowing, a slow CDN) means it never arrives — the page then
+  // sat there untouched forever, which is what "it doesn't click
+  // GamaPass by itself" looked like. After this many unchanged ticks we
+  // act anyway: the URL has been stable for ~5s, so the document we can
+  // see is the one we are going to get.
+  var SETTLE_FALLBACK_TICKS = 12;
   var MAX_SELECT_ATTEMPTS = 3;
 
   function post(msg) {{
@@ -171,16 +179,26 @@ fn portal_script(region: LoginRegion) -> String {
   }}
 
   // Per-page state. Anything that changes the URL resets it.
-  var pageUrl = '', settled = 0, phase = '', attempts = 0, chosen = '';
+  var pageUrl = '', settled = 0, stable = 0, phase = '', attempts = 0, chosen = '';
   function pageReady() {{
     if (location.href !== pageUrl) {{
       pageUrl = location.href;
       settled = 0;
+      stable = 0;
       phase = '';
       attempts = 0;
       return false;
     }}
-    if (document.readyState !== 'complete') {{ settled = 0; return false; }}
+    stable++;
+    if (document.readyState !== 'complete') {{
+      settled = 0;
+      if (stable === SETTLE_FALLBACK_TICKS) {{
+        // Say why we are proceeding without a finished load, so a stuck
+        // flow is diagnosable from the log instead of looking idle.
+        post({{ kind: 'ready-timeout', state: document.readyState, href: location.href }});
+      }}
+      return stable >= SETTLE_FALLBACK_TICKS;
+    }}
     settled++;
     return settled >= SETTLE_TICKS;
   }}
@@ -967,6 +985,19 @@ mod tests {
         let script = portal_script(LoginRegion::TW);
         assert!(script.contains(".bottom-fixed-action-area a.ui-btn"));
         assert!(!script.contains("PRIMARY"), "no label-matching heuristics");
+    }
+
+    #[test]
+    fn portal_script_acts_even_when_the_page_never_finishes_loading() {
+        // `readyState === 'complete'` waits for every subresource; one
+        // hung request (an analytics script a VPN / accelerator /
+        // blocker swallows) meant the gate never opened and NO step ever
+        // ran — reported as "it doesn't click GamaPass by itself". The
+        // script must fall back to URL stability and say why.
+        let script = portal_script(LoginRegion::TW);
+        assert!(script.contains("SETTLE_FALLBACK_TICKS"));
+        assert!(script.contains("stable >= SETTLE_FALLBACK_TICKS"));
+        assert!(script.contains("ready-timeout"));
     }
 
     #[test]


### PR DESCRIPTION
## What
Follow-up on #356. The reporter narrowed it down precisely:

> 在關閉硬體加速的情境下，不會 popup 出登入視窗，啟用後即正常運作

Two separate problems, and the first one confirms an earlier diagnosis.

## 1. No portal window with hardware acceleration off — already fixed, not yet released
This is the WebView2 environment mismatch fixed in `3e4eb44`, and the hardware-acceleration correlation is independent confirmation of it:

| Hardware acceleration | Main window args | Portal args (before the fix) | Result |
|---|---|---|---|
| **On** | wry defaults | wry defaults | identical → works |
| **Off** | defaults **+ `--disable-gpu --disable-gpu-compositing`** | wry defaults | mismatch → `ERROR_INVALID_STATE` → no webview |

Every WebView2 environment sharing a user data folder must be configured identically; the portal reused the per-instance folder but not the args, so turning hardware acceleration off was exactly what made the two diverge. The fix has the portal inherit the main window's args.

**It landed after the v6.0.10 tag**, so the reporter's build does not contain it — the next release does.

## 2. Never clicks GamaPass by itself — fixed here
Every step in the portal script waited for `document.readyState === 'complete'`, which waits for **every** subresource. One hung request — an analytics script an accelerator / VPN / content blocker swallows, or a slow CDN — and that state never arrives, so the gate never opened and **no** step ever ran: the sign-in click, the consent, the account selection, all of them. The window just sat there looking alive.

The gate now falls back to URL stability after ~5 s (the URL has been unchanged that whole time, so the document we can see is the one we are going to get) and posts a `ready-timeout` message naming the document state and href, so the same situation shows up in the log instead of looking idle.

## Checks
1025 Rust tests, 681 frontend tests, clippy clean under `-D warnings`, fmt clean.
