### PR TITLE
feat(network): route webview traffic through an in-app proxy so accelerators see it

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -152,6 +152,9 @@ windows = { version = "0.58", features = [
   # own WebView2 processes.
   "Win32_NetworkManagement_IpHelper",
   "Win32_Networking_WinSock",
+  # Toolhelp process snapshot — proves a proxy peer descends from us, so
+  # a look-alike `msedgewebview2.exe` cannot borrow the tunnel.
+  "Win32_System_Diagnostics_ToolHelp",
   "Win32_Graphics_Gdi",
   "Win32_Security",
   "Win32_Security_Cryptography",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -94,7 +94,10 @@ reqwest = { version = "0.12", default-features = false, features = [
 reqwest_cookie_store = "0.8"
 
 # Async runtime
-tokio = { version = "1", features = ["rt", "sync", "time", "fs", "macros"] }
+# `net` + `io-util` back the loopback webview proxy
+# (`services::webview_proxy`): a TcpListener/TcpStream accept loop and
+# `copy_bidirectional` for the CONNECT tunnels.
+tokio = { version = "1", features = ["rt", "sync", "time", "fs", "macros", "net", "io-util"] }
 futures = "0.3"
 # CancellationToken for the session keep-alive ping loop
 # (see `commands::auth::run_ping_loop` + `commands::state::AuthContext::ping_cancel`).
@@ -144,6 +147,11 @@ rand = "0.8"
 windows = { version = "0.58", features = [
   "Win32_Foundation",
   "Win32_Globalization",
+  # GetExtendedTcpTable — maps a loopback peer socket back to the
+  # process that owns it, so `services::webview_proxy` only serves our
+  # own WebView2 processes.
+  "Win32_NetworkManagement_IpHelper",
+  "Win32_Networking_WinSock",
   "Win32_Graphics_Gdi",
   "Win32_Security",
   "Win32_Security_Cryptography",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -583,6 +583,36 @@ pub fn run() {
         // (`BEANFUN_REMOTE_DEBUGGING_PORT=9222 beanfun.exe`). The flag
         // applies to the whole per-instance browser process, so runtime
         // windows (classic portal, in-app browsers) are inspectable too.
+        // Loopback proxy (`services::webview_proxy`): WebView2 always
+        // runs out-of-process, so without this every request from the
+        // GamaPass popup / Classic portal / in-app browser leaves the
+        // machine as `msedgewebview2.exe`. Process-matching game
+        // accelerators and split-tunnel VPNs look for `beanfun.exe`,
+        // find nothing, and leave those windows unaccelerated. Pointing
+        // the webview at a proxy hosted in *this* process moves the
+        // outbound socket back under our own identity. Opt-in, and
+        // strictly degrading: if the listener can't bind we omit the
+        // switch and the webview goes direct, exactly as before.
+        let proxy_enabled = services::config::get_value_sync(&config_path, "webviewProxy")
+            .unwrap_or_default()
+            .eq_ignore_ascii_case("true");
+        if proxy_enabled {
+            match services::webview_proxy::start() {
+                Ok(port) => {
+                    args.push(format!("--proxy-server=http://127.0.0.1:{port}"));
+                    // Redundant with Chromium's implicit loopback bypass
+                    // (which keeps `tauri.localhost` and the dev server
+                    // off the proxy) but stated so the intent survives a
+                    // future flag edit.
+                    args.push("--proxy-bypass-list=<local>".to_string());
+                    tracing::info!(port, "webview traffic routed through the in-app proxy");
+                }
+                Err(error) => {
+                    tracing::warn!(%error, "webview proxy failed to bind; using a direct connection");
+                }
+            }
+        }
+
         if let Ok(port) = std::env::var("BEANFUN_REMOTE_DEBUGGING_PORT") {
             if port.chars().all(|c| c.is_ascii_digit()) && !port.is_empty() {
                 args.push(format!("--remote-debugging-port={port}"));

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -18,6 +18,7 @@ pub mod maple_cache;
 pub mod storage;
 pub mod system;
 pub mod updater;
+pub mod webview_proxy;
 
 #[cfg(target_os = "windows")]
 pub mod process;

--- a/src-tauri/src/services/webview_proxy/head.rs
+++ b/src-tauri/src/services/webview_proxy/head.rs
@@ -1,0 +1,303 @@
+//! HTTP request-head parsing for the loopback webview proxy.
+//!
+//! Deliberately hand-rolled and tiny rather than pulling in a full HTTP
+//! stack: the proxy only ever needs to understand *the first request
+//! head on a connection* well enough to decide where to dial. Once the
+//! upstream socket is open the two halves are relayed byte-for-byte, so
+//! nothing here has to model bodies, chunking, or trailers.
+//!
+//! Everything in this module is pure — no sockets, no async — so the
+//! parsing rules are unit-testable on their own.
+
+/// Hard cap on the request head we are willing to buffer before giving
+/// up. Chromium's proxy requests are a few hundred bytes; anything past
+/// this is a malformed or hostile peer, not a real request.
+pub const MAX_HEAD_BYTES: usize = 32 * 1024;
+
+/// Default port when a `CONNECT` authority omits one. `CONNECT` without
+/// a port is not something Chromium emits, but the RFC allows the
+/// abbreviated form and 443 is the only sane reading of it.
+const DEFAULT_CONNECT_PORT: u16 = 443;
+
+/// Default port for an absolute-form `http://` target.
+const DEFAULT_HTTP_PORT: u16 = 80;
+
+/// A parsed request line plus its headers, borrowed as owned strings
+/// (the head is at most [`MAX_HEAD_BYTES`], so the copy is cheap and
+/// spares every caller a lifetime).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RequestHead {
+    pub method: String,
+    /// Request target verbatim: an authority (`host:port`) for
+    /// `CONNECT`, an absolute URI otherwise.
+    pub target: String,
+    pub version: String,
+    pub headers: Vec<(String, String)>,
+}
+
+impl RequestHead {
+    /// True for the tunnel-establishing verb. Case-insensitive because
+    /// the method token is technically case-sensitive per RFC but being
+    /// lenient on input costs nothing here.
+    pub fn is_connect(&self) -> bool {
+        self.method.eq_ignore_ascii_case("CONNECT")
+    }
+}
+
+/// Byte offset just past the `\r\n\r\n` that ends the head, or `None`
+/// while the head is still incomplete.
+pub fn head_end(buf: &[u8]) -> Option<usize> {
+    buf.windows(4).position(|w| w == b"\r\n\r\n").map(|i| i + 4)
+}
+
+/// Parse the head bytes (everything up to and including the blank
+/// line). Returns `None` for anything that isn't a plausible request.
+pub fn parse_head(buf: &[u8]) -> Option<RequestHead> {
+    // Heads are ASCII by spec; a non-UTF-8 head is malformed input we
+    // are happy to reject outright.
+    let text = std::str::from_utf8(buf).ok()?;
+    let mut lines = text.split("\r\n");
+
+    let mut request_line = lines.next()?.split(' ');
+    let method = request_line.next()?.trim();
+    let target = request_line.next()?.trim();
+    let version = request_line.next()?.trim();
+    if method.is_empty() || target.is_empty() || !version.starts_with("HTTP/") {
+        return None;
+    }
+
+    let mut headers = Vec::new();
+    for line in lines {
+        if line.is_empty() {
+            break;
+        }
+        // A header without a colon is malformed; skip it rather than
+        // rejecting the whole request — the relay is not a validator.
+        let Some((name, value)) = line.split_once(':') else {
+            continue;
+        };
+        headers.push((name.trim().to_string(), value.trim().to_string()));
+    }
+
+    Some(RequestHead {
+        method: method.to_string(),
+        target: target.to_string(),
+        version: version.to_string(),
+        headers,
+    })
+}
+
+/// Split a `CONNECT` authority into host and port.
+///
+/// Handles the bracketed IPv6 literal form (`[::1]:443`) because
+/// Chromium emits it for IPv6 origins.
+pub fn connect_authority(target: &str) -> Option<(String, u16)> {
+    if let Some(rest) = target.strip_prefix('[') {
+        let (host, tail) = rest.split_once(']')?;
+        if host.is_empty() {
+            return None;
+        }
+        let port = match tail.strip_prefix(':') {
+            Some(p) => p.parse().ok()?,
+            None => DEFAULT_CONNECT_PORT,
+        };
+        return Some((host.to_string(), port));
+    }
+
+    match target.rsplit_once(':') {
+        Some((host, port)) if !host.is_empty() => Some((host.to_string(), port.parse().ok()?)),
+        // No colon at all — bare hostname, assume the https port.
+        None if !target.is_empty() => Some((target.to_string(), DEFAULT_CONNECT_PORT)),
+        _ => None,
+    }
+}
+
+/// Split an absolute-form `http://` target into host, port, and the
+/// origin-form path to forward upstream.
+///
+/// `https://` is intentionally rejected: a proxy only ever sees an
+/// absolute `https` URI from a client that expects us to terminate TLS,
+/// which this proxy deliberately never does (see the module docs on
+/// [`super`]).
+pub fn absolute_target(target: &str) -> Option<(String, u16, String)> {
+    let rest = target
+        .strip_prefix("http://")
+        .or_else(|| target.strip_prefix("HTTP://"))?;
+
+    let (authority, path) = match rest.find('/') {
+        Some(i) => (&rest[..i], &rest[i..]),
+        None => (rest, "/"),
+    };
+    // Strip any userinfo — we never forward credentials we were not
+    // asked to forward.
+    let authority = authority.rsplit_once('@').map_or(authority, |(_, a)| a);
+
+    let (host, port) = if let Some(inner) = authority.strip_prefix('[') {
+        let (host, tail) = inner.split_once(']')?;
+        let port = match tail.strip_prefix(':') {
+            Some(p) => p.parse().ok()?,
+            None => DEFAULT_HTTP_PORT,
+        };
+        (host.to_string(), port)
+    } else {
+        match authority.rsplit_once(':') {
+            Some((h, p)) if !h.is_empty() => (h.to_string(), p.parse().ok()?),
+            None if !authority.is_empty() => (authority.to_string(), DEFAULT_HTTP_PORT),
+            _ => return None,
+        }
+    };
+
+    Some((host, port, path.to_string()))
+}
+
+/// Headers that belong to the client↔proxy hop and must never be
+/// forwarded to the origin server.
+fn is_hop_header(name: &str) -> bool {
+    name.eq_ignore_ascii_case("proxy-connection")
+        || name.eq_ignore_ascii_case("proxy-authorization")
+        || name.eq_ignore_ascii_case("connection")
+        || name.eq_ignore_ascii_case("keep-alive")
+}
+
+/// Rebuild the head in origin form for the upstream socket.
+///
+/// # Why `Connection: close`
+///
+/// In non-`CONNECT` mode Chromium is free to reuse one proxy connection
+/// for requests to *different* origins. Our upstream socket is pinned to
+/// the host of the first request, so a reused connection would deliver
+/// request #2 to the wrong server. Closing after one request removes
+/// that whole class of bug. The cost is negligible in practice: the
+/// beanfun portals are https, so effectively everything goes through the
+/// `CONNECT` path, which keeps its tunnel open normally.
+pub fn rewrite_origin_form(head: &RequestHead, path: &str) -> Vec<u8> {
+    let mut out = format!("{} {} {}\r\n", head.method, path, head.version);
+    for (name, value) in &head.headers {
+        if is_hop_header(name) {
+            continue;
+        }
+        out.push_str(name);
+        out.push_str(": ");
+        out.push_str(value);
+        out.push_str("\r\n");
+    }
+    out.push_str("Connection: close\r\n\r\n");
+    out.into_bytes()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn head_end_waits_for_the_blank_line() {
+        assert_eq!(head_end(b"GET / HTTP/1.1\r\nHost: a\r\n"), None);
+        assert_eq!(head_end(b"GET / HTTP/1.1\r\n\r\nbody"), Some(18));
+    }
+
+    #[test]
+    fn parses_a_connect_request() {
+        let head =
+            parse_head(b"CONNECT tw.beanfun.com:443 HTTP/1.1\r\nHost: tw.beanfun.com:443\r\n\r\n")
+                .expect("parses");
+        assert!(head.is_connect());
+        assert_eq!(head.target, "tw.beanfun.com:443");
+        assert_eq!(
+            head.headers,
+            vec![("Host".into(), "tw.beanfun.com:443".into())]
+        );
+    }
+
+    #[test]
+    fn rejects_a_head_without_a_version() {
+        assert!(parse_head(b"GET /\r\n\r\n").is_none());
+        assert!(parse_head(b"\r\n\r\n").is_none());
+    }
+
+    #[test]
+    fn skips_a_malformed_header_line_instead_of_failing() {
+        let head =
+            parse_head(b"GET http://a/ HTTP/1.1\r\ngarbage\r\nHost: a\r\n\r\n").expect("parses");
+        assert_eq!(head.headers, vec![("Host".into(), "a".into())]);
+    }
+
+    #[test]
+    fn connect_authority_defaults_to_the_https_port() {
+        assert_eq!(
+            connect_authority("a.example"),
+            Some(("a.example".into(), 443))
+        );
+        assert_eq!(
+            connect_authority("a.example:8443"),
+            Some(("a.example".into(), 8443))
+        );
+    }
+
+    #[test]
+    fn connect_authority_handles_bracketed_ipv6() {
+        assert_eq!(connect_authority("[::1]:443"), Some(("::1".into(), 443)));
+        assert_eq!(connect_authority("[::1]"), Some(("::1".into(), 443)));
+    }
+
+    #[test]
+    fn connect_authority_rejects_junk() {
+        assert_eq!(connect_authority(""), None);
+        assert_eq!(connect_authority(":443"), None);
+        assert_eq!(connect_authority("a.example:not-a-port"), None);
+    }
+
+    #[test]
+    fn absolute_target_splits_host_port_and_path() {
+        assert_eq!(
+            absolute_target("http://tw.beanfun.com/game/index.aspx?x=1"),
+            Some(("tw.beanfun.com".into(), 80, "/game/index.aspx?x=1".into()))
+        );
+        assert_eq!(
+            absolute_target("http://a.example:8080"),
+            Some(("a.example".into(), 8080, "/".into()))
+        );
+    }
+
+    #[test]
+    fn absolute_target_drops_userinfo() {
+        assert_eq!(
+            absolute_target("http://user:pw@a.example/x"),
+            Some(("a.example".into(), 80, "/x".into()))
+        );
+    }
+
+    #[test]
+    fn absolute_target_refuses_a_non_http_scheme() {
+        // We never terminate TLS, so an absolute https URI is not ours
+        // to serve — it must arrive as CONNECT.
+        assert_eq!(absolute_target("https://a.example/"), None);
+        assert_eq!(absolute_target("/relative"), None);
+    }
+
+    #[test]
+    fn rewrite_strips_hop_headers_and_closes_the_connection() {
+        let head = parse_head(
+            b"GET http://a.example/x HTTP/1.1\r\n\
+              Host: a.example\r\n\
+              Proxy-Connection: keep-alive\r\n\
+              Proxy-Authorization: Basic zzz\r\n\
+              Connection: keep-alive\r\n\
+              User-Agent: probe\r\n\r\n",
+        )
+        .expect("parses");
+
+        let out = String::from_utf8(rewrite_origin_form(&head, "/x")).expect("utf8");
+
+        assert!(out.starts_with("GET /x HTTP/1.1\r\n"));
+        assert!(out.contains("Host: a.example\r\n"));
+        assert!(out.contains("User-Agent: probe\r\n"));
+        assert!(!out.to_lowercase().contains("proxy-connection"));
+        assert!(!out.to_lowercase().contains("proxy-authorization"));
+        assert!(!out.contains("keep-alive"));
+        assert!(out.ends_with("Connection: close\r\n\r\n"));
+    }
+}

--- a/src-tauri/src/services/webview_proxy/mod.rs
+++ b/src-tauri/src/services/webview_proxy/mod.rs
@@ -1,0 +1,347 @@
+//! A loopback HTTP proxy that lends the webview our process identity.
+//!
+//! # The problem
+//!
+//! WebView2 is always out-of-process: every request the app's web
+//! surfaces make — the GamaPass popup, the MapleStory Classic portal,
+//! the in-app browser — leaves the machine on a socket owned by
+//! `msedgewebview2.exe`, never by `beanfun.exe`. Most Taiwanese/HK game
+//! accelerators and split-tunnel VPNs pick traffic up **by process**, so
+//! they match `beanfun.exe`, see nothing, and those windows quietly run
+//! unaccelerated (issue #356 follow-up). Users experience it as "the
+//! accelerator doesn't work on the login popup", and there is nothing
+//! they can configure to fix it: the app's regular login *is*
+//! accelerated, because that path goes through `reqwest` in our own
+//! process.
+//!
+//! # The fix
+//!
+//! Run a tiny proxy inside `beanfun.exe` and point the webview at it
+//! with `--proxy-server=http://127.0.0.1:<port>`:
+//!
+//! ```text
+//! before:  msedgewebview2.exe ─────────────────────────→ tw.beanfun.com
+//! after:   msedgewebview2.exe ──→ 127.0.0.1:<port>
+//!                                   (beanfun.exe) ─────→ tw.beanfun.com
+//! ```
+//!
+//! The outbound socket is now opened by us, so a process-matching
+//! accelerator sees it. Nothing outside the app changes: no system proxy,
+//! no registry, no WinINET/WinHTTP settings, no effect on any other
+//! program. The loopback hop is not intercepted (accelerator filters skip
+//! loopback), and the user has nothing to fill in — the port is ours and
+//! ephemeral.
+//!
+//! # What this is not
+//!
+//! `CONNECT` is served as a blind byte relay, so https traffic is
+//! **tunnelled, never terminated**: no certificate is generated, no TLS
+//! is intercepted, and the proxy cannot read what passes through it. The
+//! absolute-form `http://` path exists only because a proxy is required
+//! to answer it; it forwards the head and relays the rest.
+//!
+//! # Lifetime and failure
+//!
+//! The listener is bound *synchronously* at startup so the port is known
+//! before the browser arguments are assembled, then served from a
+//! dedicated thread for the life of the process. If binding fails the
+//! caller simply omits `--proxy-server` and the webview goes direct —
+//! the feature degrades to "as before", never to "no network".
+//!
+//! Access is restricted to our own webview processes; see [`peer`].
+
+mod head;
+mod peer;
+
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use tokio::io::{copy_bidirectional, AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+
+use head::{
+    absolute_target, connect_authority, head_end, parse_head, rewrite_origin_form, RequestHead,
+    MAX_HEAD_BYTES,
+};
+
+/// How long a client may take to send a complete request head.
+const HEAD_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// How long to wait for the upstream TCP connect.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// Bind the loopback proxy and start serving it on a dedicated thread.
+///
+/// Returns the port the webview should be pointed at. The listener is
+/// bound before this returns, so a successful result means the port is
+/// already accepting.
+pub fn start() -> std::io::Result<u16> {
+    // Bind synchronously: the caller needs the port *now*, to put into
+    // the WebView2 browser arguments before any window is created.
+    let listener = std::net::TcpListener::bind(("127.0.0.1", 0))?;
+    let port = listener.local_addr()?.port();
+    listener.set_nonblocking(true)?;
+
+    std::thread::Builder::new()
+        .name("beanfun-webview-proxy".into())
+        .spawn(move || {
+            let runtime = match tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+            {
+                Ok(runtime) => runtime,
+                Err(error) => {
+                    tracing::error!(%error, "webview proxy: runtime build failed");
+                    return;
+                }
+            };
+            runtime.block_on(serve(listener, port));
+        })?;
+
+    Ok(port)
+}
+
+/// Accept loop. Per-connection failures are logged and dropped; only a
+/// listener-level failure can end it, and even then it backs off rather
+/// than spinning.
+async fn serve(listener: std::net::TcpListener, port: u16) {
+    let listener = match TcpListener::from_std(listener) {
+        Ok(listener) => listener,
+        Err(error) => {
+            tracing::error!(%error, "webview proxy: could not adopt the listener");
+            return;
+        }
+    };
+    tracing::info!(port, "webview proxy listening on loopback");
+
+    loop {
+        match listener.accept().await {
+            Ok((stream, peer_addr)) => {
+                tokio::spawn(async move {
+                    if let Err(error) = handle(stream, peer_addr, port).await {
+                        // Half-closed tunnels are the normal way a page
+                        // navigation ends, so this stays at debug.
+                        tracing::debug!(%error, "webview proxy: connection ended");
+                    }
+                });
+            }
+            Err(error) => {
+                tracing::warn!(%error, "webview proxy: accept failed");
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+        }
+    }
+}
+
+/// Serve one client connection: read its head, dial upstream, relay.
+async fn handle(
+    mut client: TcpStream,
+    peer_addr: SocketAddr,
+    listen_port: u16,
+) -> std::io::Result<()> {
+    if !peer::peer_is_webview(peer_addr, listen_port) {
+        return Ok(());
+    }
+
+    let (buf, end) = read_head(&mut client).await?;
+    let Some(request) = parse_head(&buf[..end]) else {
+        let _ = client.write_all(b"HTTP/1.1 400 Bad Request\r\n\r\n").await;
+        return Ok(());
+    };
+
+    let mut upstream = match dial(&request).await {
+        Some(upstream) => upstream,
+        None => {
+            let _ = client.write_all(b"HTTP/1.1 502 Bad Gateway\r\n\r\n").await;
+            return Ok(());
+        }
+    };
+
+    if request.is_connect() {
+        // The tunnel is opened; from here we are a pipe and nothing more.
+        client
+            .write_all(b"HTTP/1.1 200 Connection established\r\n\r\n")
+            .await?;
+    } else {
+        let Some((_, _, path)) = absolute_target(&request.target) else {
+            return Ok(());
+        };
+        upstream
+            .write_all(&rewrite_origin_form(&request, &path))
+            .await?;
+    }
+
+    // Anything already buffered past the head belongs to the body /
+    // tunnel and must not be dropped.
+    if buf.len() > end {
+        upstream.write_all(&buf[end..]).await?;
+    }
+
+    copy_bidirectional(&mut client, &mut upstream).await?;
+    Ok(())
+}
+
+/// Read until the head is complete, returning the buffer and the offset
+/// just past the blank line.
+async fn read_head(client: &mut TcpStream) -> std::io::Result<(Vec<u8>, usize)> {
+    let mut buf = Vec::with_capacity(2048);
+    let mut chunk = [0u8; 2048];
+
+    loop {
+        if let Some(end) = head_end(&buf) {
+            return Ok((buf, end));
+        }
+        if buf.len() > MAX_HEAD_BYTES {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "request head too large",
+            ));
+        }
+        let read = tokio::time::timeout(HEAD_TIMEOUT, client.read(&mut chunk))
+            .await
+            .map_err(|_| {
+                std::io::Error::new(std::io::ErrorKind::TimedOut, "head read timed out")
+            })?;
+        match read? {
+            0 => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    "client closed before the head was complete",
+                ))
+            }
+            n => buf.extend_from_slice(&chunk[..n]),
+        }
+    }
+}
+
+/// Open the upstream socket for a parsed request. This is the call whose
+/// process identity the whole module exists for.
+async fn dial(request: &RequestHead) -> Option<TcpStream> {
+    let (host, port) = if request.is_connect() {
+        connect_authority(&request.target)?
+    } else {
+        let (host, port, _) = absolute_target(&request.target)?;
+        (host, port)
+    };
+
+    match tokio::time::timeout(CONNECT_TIMEOUT, TcpStream::connect((host.as_str(), port))).await {
+        Ok(Ok(stream)) => Some(stream),
+        Ok(Err(error)) => {
+            tracing::debug!(%host, port, %error, "webview proxy: upstream connect failed");
+            None
+        }
+        Err(_) => {
+            tracing::debug!(%host, port, "webview proxy: upstream connect timed out");
+            None
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Read, Write};
+
+    /// End-to-end through the real listener: a `CONNECT` tunnel must
+    /// reach an origin server and relay both directions verbatim.
+    #[test]
+    fn connect_tunnels_bytes_to_the_origin_in_both_directions() {
+        // A trivial origin that echoes one line back, uppercased.
+        let origin = std::net::TcpListener::bind(("127.0.0.1", 0)).expect("bind origin");
+        let origin_port = origin.local_addr().expect("addr").port();
+        std::thread::spawn(move || {
+            let (mut socket, _) = origin.accept().expect("accept");
+            let mut got = [0u8; 5];
+            socket.read_exact(&mut got).expect("read");
+            socket
+                .write_all(got.to_ascii_uppercase().as_slice())
+                .expect("write");
+        });
+
+        let port = start().expect("proxy starts");
+
+        let mut client = std::net::TcpStream::connect(("127.0.0.1", port)).expect("connect proxy");
+        client
+            .write_all(format!("CONNECT 127.0.0.1:{origin_port} HTTP/1.1\r\n\r\n").as_bytes())
+            .expect("send CONNECT");
+
+        let mut response = [0u8; 39];
+        client.read_exact(&mut response).expect("read response");
+        assert!(
+            String::from_utf8_lossy(&response).starts_with("HTTP/1.1 200"),
+            "got {:?}",
+            String::from_utf8_lossy(&response)
+        );
+
+        client.write_all(b"hello").expect("send payload");
+        let mut echoed = [0u8; 5];
+        client.read_exact(&mut echoed).expect("read echo");
+        assert_eq!(&echoed, b"HELLO");
+    }
+
+    /// The plain-HTTP path must arrive at the origin in origin form,
+    /// with the proxy hop headers gone.
+    #[test]
+    fn absolute_form_requests_are_rewritten_to_origin_form() {
+        let origin = std::net::TcpListener::bind(("127.0.0.1", 0)).expect("bind origin");
+        let origin_port = origin.local_addr().expect("addr").port();
+        let seen = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
+        let seen_writer = std::sync::Arc::clone(&seen);
+        std::thread::spawn(move || {
+            let (mut socket, _) = origin.accept().expect("accept");
+            let mut buf = [0u8; 512];
+            let n = socket.read(&mut buf).expect("read");
+            *seen_writer.lock().expect("lock") = String::from_utf8_lossy(&buf[..n]).into_owned();
+            socket
+                .write_all(b"HTTP/1.1 204 No Content\r\n\r\n")
+                .expect("write");
+        });
+
+        let port = start().expect("proxy starts");
+        let mut client = std::net::TcpStream::connect(("127.0.0.1", port)).expect("connect proxy");
+        client
+            .write_all(
+                format!(
+                    "GET http://127.0.0.1:{origin_port}/probe HTTP/1.1\r\n\
+                     Host: 127.0.0.1:{origin_port}\r\n\
+                     Proxy-Connection: keep-alive\r\n\r\n"
+                )
+                .as_bytes(),
+            )
+            .expect("send request");
+
+        let mut response = Vec::new();
+        client.read_to_end(&mut response).expect("read response");
+        assert!(String::from_utf8_lossy(&response).starts_with("HTTP/1.1 204"));
+
+        let request = seen.lock().expect("lock").clone();
+        assert!(
+            request.starts_with("GET /probe HTTP/1.1\r\n"),
+            "got {request}"
+        );
+        assert!(!request.to_lowercase().contains("proxy-connection"));
+    }
+
+    /// A head that never terminates must not be buffered without bound.
+    #[test]
+    fn an_unterminated_head_is_rejected_rather_than_buffered_forever() {
+        let port = start().expect("proxy starts");
+        let mut client = std::net::TcpStream::connect(("127.0.0.1", port)).expect("connect proxy");
+
+        let filler = vec![b'x'; 4096];
+        // Once past MAX_HEAD_BYTES the proxy drops us, which surfaces
+        // here as a write error or a closed read — either is the point.
+        for _ in 0..(MAX_HEAD_BYTES / filler.len() + 4) {
+            if client.write_all(&filler).is_err() {
+                return;
+            }
+        }
+        let mut sink = Vec::new();
+        let _ = client.read_to_end(&mut sink);
+        assert!(sink.is_empty(), "the proxy must not answer a junk head");
+    }
+}

--- a/src-tauri/src/services/webview_proxy/peer.rs
+++ b/src-tauri/src/services/webview_proxy/peer.rs
@@ -1,0 +1,217 @@
+//! Who is allowed to use the loopback proxy.
+//!
+//! The listener binds `127.0.0.1` on an ephemeral port, so it is not
+//! reachable off-machine — but every *local* process can still reach it,
+//! and an open local proxy is a capability we do not want to hand out:
+//! it would let any program on the box borrow `beanfun.exe`'s identity
+//! for outbound traffic (which is precisely the thing that makes the
+//! proxy useful to us, and precisely why someone else might want it).
+//!
+//! So each accepted connection is traced back to the process that owns
+//! the client socket, and only the WebView2 runtime — or this process
+//! itself, which already holds every capability the proxy could lend —
+//! is served.
+//!
+//! # Fail-open, deliberately
+//!
+//! If the ownership lookup itself fails — the connection already closed
+//! and left the table, an API error, an unexpected address family — the
+//! connection is **allowed**. The check is defense-in-depth on a
+//! loopback port that is off by default; a bug or a race in it must
+//! never be able to take the user's webview offline. Only a *positive*
+//! identification of some other process rejects.
+
+use std::net::SocketAddr;
+
+/// Image name of the WebView2 runtime's processes. Every socket the
+/// webview opens is owned by one of these (the network service child,
+/// in practice) — never by `beanfun.exe` itself, which is the whole
+/// reason this proxy exists.
+#[cfg(target_os = "windows")]
+const WEBVIEW_IMAGE_NAME: &str = "msedgewebview2.exe";
+
+/// Convert the port field of a `MIB_TCPROW_OWNER_PID` (network byte
+/// order stashed in the low word of a `DWORD`) into a host-order port.
+#[cfg(target_os = "windows")]
+fn port_from_row(raw: u32) -> u16 {
+    (((raw & 0xFF) as u16) << 8) | ((raw >> 8) & 0xFF) as u16
+}
+
+/// Is this peer one of our own webview processes?
+///
+/// `peer` is the client end of an accepted connection and `listen_port`
+/// the port it connected to; together they identify one row of the TCP
+/// table uniquely.
+#[cfg(target_os = "windows")]
+pub fn peer_is_webview(peer: SocketAddr, listen_port: u16) -> bool {
+    let Some(pid) = owning_pid(peer, listen_port) else {
+        // Could not attribute the socket — see the fail-open note above.
+        return true;
+    };
+    // Our own process is trivially allowed: it already has every
+    // capability the proxy could lend it, so refusing would buy nothing
+    // and would make the relay untestable in-process.
+    if pid == std::process::id() {
+        return true;
+    }
+    match image_name(pid) {
+        Some(name) => {
+            let ours = name.eq_ignore_ascii_case(WEBVIEW_IMAGE_NAME);
+            if !ours {
+                tracing::warn!(pid, image = %name, "webview proxy: refused a connection from another process");
+            }
+            ours
+        }
+        None => true,
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn peer_is_webview(_peer: SocketAddr, _listen_port: u16) -> bool {
+    // The proxy is only ever wired up on Windows (it exists to give
+    // WebView2's out-of-process traffic our own process identity). The
+    // stub keeps the module compiling — and unit-testable — elsewhere.
+    true
+}
+
+/// PID owning the loopback socket `peer` → `127.0.0.1:listen_port`.
+#[cfg(target_os = "windows")]
+fn owning_pid(peer: SocketAddr, listen_port: u16) -> Option<u32> {
+    use windows::Win32::NetworkManagement::IpHelper::{
+        GetExtendedTcpTable, MIB_TCPROW_OWNER_PID, MIB_TCPTABLE_OWNER_PID,
+        TCP_TABLE_OWNER_PID_CONNECTIONS,
+    };
+    use windows::Win32::Networking::WinSock::AF_INET;
+
+    // We bind 127.0.0.1, so anything that reaches us is IPv4.
+    let SocketAddr::V4(peer) = peer else {
+        return None;
+    };
+
+    let mut size: u32 = 0;
+    // First call sizes the buffer; a zero-size query is expected to
+    // "fail" with ERROR_INSUFFICIENT_BUFFER, so the return value is
+    // deliberately ignored here and validated on the real call.
+    unsafe {
+        GetExtendedTcpTable(
+            None,
+            &mut size,
+            false,
+            AF_INET.0 as u32,
+            TCP_TABLE_OWNER_PID_CONNECTIONS,
+            0,
+        );
+    }
+    if size == 0 {
+        return None;
+    }
+
+    let mut buf = vec![0u8; size as usize];
+    let rc = unsafe {
+        GetExtendedTcpTable(
+            Some(buf.as_mut_ptr().cast()),
+            &mut size,
+            false,
+            AF_INET.0 as u32,
+            TCP_TABLE_OWNER_PID_CONNECTIONS,
+            0,
+        )
+    };
+    if rc != 0 {
+        return None;
+    }
+
+    // SAFETY: on success the buffer holds a MIB_TCPTABLE_OWNER_PID —
+    // a row count followed by that many rows. `buf` outlives the reads
+    // and is at least `size` bytes because the API just filled it.
+    let table = buf.as_ptr().cast::<MIB_TCPTABLE_OWNER_PID>();
+    let count = unsafe { (*table).dwNumEntries } as usize;
+    let rows = unsafe { std::ptr::addr_of!((*table).table).cast::<MIB_TCPROW_OWNER_PID>() };
+
+    let peer_ip = u32::from(*peer.ip()).to_be();
+    for i in 0..count {
+        let row = unsafe { &*rows.add(i) };
+        if port_from_row(row.dwLocalPort) == peer.port()
+            && port_from_row(row.dwRemotePort) == listen_port
+            && row.dwLocalAddr == peer_ip
+        {
+            return Some(row.dwOwningPid);
+        }
+    }
+    None
+}
+
+/// File name (no directory) of a PID's executable image.
+#[cfg(target_os = "windows")]
+fn image_name(pid: u32) -> Option<String> {
+    use windows::core::PWSTR;
+    use windows::Win32::Foundation::CloseHandle;
+    use windows::Win32::System::Threading::{
+        OpenProcess, QueryFullProcessImageNameW, PROCESS_NAME_FORMAT,
+        PROCESS_QUERY_LIMITED_INFORMATION,
+    };
+
+    // SAFETY: a plain Win32 handle round-trip. The handle is closed on
+    // every path below before the value is returned.
+    let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid) }.ok()?;
+
+    let mut buf = [0u16; 260 * 2];
+    let mut len = buf.len() as u32;
+    let ok = unsafe {
+        QueryFullProcessImageNameW(
+            handle,
+            PROCESS_NAME_FORMAT(0),
+            PWSTR(buf.as_mut_ptr()),
+            &mut len,
+        )
+    }
+    .is_ok();
+    unsafe {
+        let _ = CloseHandle(handle);
+    }
+    if !ok {
+        return None;
+    }
+
+    let full = String::from_utf16_lossy(&buf[..len as usize]);
+    Some(full.rsplit(['\\', '/']).next().unwrap_or(&full).to_string())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(all(test, target_os = "windows"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn port_field_is_read_as_network_byte_order() {
+        // 0x1F90 == 8080; the API stores it byte-swapped in the low word.
+        assert_eq!(port_from_row(0x0000_901F), 8080);
+        assert_eq!(port_from_row(0x0000_BB01), 443);
+        assert_eq!(port_from_row(0), 0);
+    }
+
+    #[test]
+    fn the_high_word_of_the_port_field_is_ignored() {
+        // Windows leaves the upper 16 bits unspecified — they must not
+        // leak into the comparison.
+        assert_eq!(port_from_row(0xDEAD_901F), 8080);
+    }
+
+    #[test]
+    fn our_own_process_is_not_mistaken_for_the_webview() {
+        let me = std::process::id();
+        let name = image_name(me).expect("own image name is readable");
+        assert!(!name.eq_ignore_ascii_case(WEBVIEW_IMAGE_NAME), "got {name}");
+    }
+
+    #[test]
+    fn an_unattributable_peer_fails_open() {
+        // Nothing is connected on this pair, so the table lookup finds
+        // no row — the connection must still be allowed.
+        let peer: SocketAddr = "127.0.0.1:1".parse().expect("addr");
+        assert!(peer_is_webview(peer, 2));
+    }
+}

--- a/src-tauri/src/services/webview_proxy/peer.rs
+++ b/src-tauri/src/services/webview_proxy/peer.rs
@@ -12,16 +12,42 @@
 //! itself, which already holds every capability the proxy could lend —
 //! is served.
 //!
+//! # Two checks, because a name is not an identity
+//!
+//! 1. The owning process's **image name** is `msedgewebview2.exe`.
+//! 2. That process **descends from us**.
+//!
+//! The first alone would be spoofable: any local program can name its
+//! executable `msedgewebview2.exe`. The second is not, because a process
+//! cannot choose its parent — WebView2's browser process is spawned by
+//! us and the renderer / network-service children hang off that, so a
+//! genuine webview socket always has our PID somewhere up its ancestry.
+//! Requiring both means an impostor would have to be a process we
+//! ourselves launched, which is not something an outsider can arrange.
+//!
+//! Ancestry alone is not enough either: we do spawn other children (the
+//! game client, NGM, LocaleRemulator), and none of them has any business
+//! borrowing this tunnel.
+//!
 //! # Fail-open, deliberately
 //!
-//! If the ownership lookup itself fails — the connection already closed
-//! and left the table, an API error, an unexpected address family — the
+//! If a lookup itself fails — the connection already closed and left the
+//! table, a snapshot error, an unexpected address family — the
 //! connection is **allowed**. The check is defense-in-depth on a
 //! loopback port that is off by default; a bug or a race in it must
 //! never be able to take the user's webview offline. Only a *positive*
-//! identification of some other process rejects.
+//! identification of something that isn't our webview rejects.
+//!
+//! Note this is not a hole in practice: to *use* the proxy a caller
+//! needs a live connection, and a live connection always has a row in
+//! the TCP table. The lookup realistically only misses for sockets that
+//! are already gone, which have nothing left to relay.
 
+#[cfg(target_os = "windows")]
+use std::collections::{HashMap, HashSet};
 use std::net::SocketAddr;
+#[cfg(target_os = "windows")]
+use std::sync::Mutex;
 
 /// Image name of the WebView2 runtime's processes. Every socket the
 /// webview opens is owned by one of these (the network service child,
@@ -54,16 +80,126 @@ pub fn peer_is_webview(peer: SocketAddr, listen_port: u16) -> bool {
     if pid == std::process::id() {
         return true;
     }
-    match image_name(pid) {
-        Some(name) => {
-            let ours = name.eq_ignore_ascii_case(WEBVIEW_IMAGE_NAME);
-            if !ours {
-                tracing::warn!(pid, image = %name, "webview proxy: refused a connection from another process");
-            }
-            ours
+
+    // Cheap check first: the image name filters out every ordinary
+    // caller (a script, a curl, another app) without touching the
+    // process snapshot.
+    let Some(name) = image_name(pid) else {
+        return true;
+    };
+    if !name.eq_ignore_ascii_case(WEBVIEW_IMAGE_NAME) {
+        tracing::warn!(pid, image = %name, "webview proxy: refused a connection from another process");
+        return false;
+    }
+
+    // Expensive check second: a matching name only counts if the
+    // process is actually one we launched.
+    match descends_from_us(pid) {
+        Some(true) => true,
+        Some(false) => {
+            tracing::warn!(
+                pid,
+                image = %name,
+                "webview proxy: refused a look-alike process that is not our webview"
+            );
+            false
         }
         None => true,
     }
+}
+
+/// Verified descendants, so a busy page load pays for the process
+/// snapshot once rather than once per connection.
+///
+/// Caching a PID is safe against PID reuse because the image-name check
+/// above runs on *every* connection and is not cached: a recycled PID
+/// only reaches this cache if the new occupant is itself named
+/// `msedgewebview2.exe`.
+#[cfg(target_os = "windows")]
+static VERIFIED_DESCENDANTS: Mutex<Option<HashSet<u32>>> = Mutex::new(None);
+
+/// Longest ancestry chain we will walk before giving up. WebView2 sits
+/// two hops from us (network service → browser process → us); the extra
+/// room costs nothing and the bound guarantees termination even if the
+/// snapshot ever contains a cycle.
+#[cfg(target_os = "windows")]
+const MAX_ANCESTRY_HOPS: usize = 16;
+
+/// Does `pid` have our own process somewhere up its parent chain?
+///
+/// `None` means the question could not be answered (snapshot failure) —
+/// callers treat that as "allow", per the fail-open policy above.
+#[cfg(target_os = "windows")]
+fn descends_from_us(pid: u32) -> Option<bool> {
+    if let Ok(cache) = VERIFIED_DESCENDANTS.lock() {
+        if cache.as_ref().is_some_and(|seen| seen.contains(&pid)) {
+            return Some(true);
+        }
+    }
+
+    let parents = parent_map()?;
+    let me = std::process::id();
+
+    let mut current = pid;
+    for _ in 0..MAX_ANCESTRY_HOPS {
+        // A link we cannot resolve means the process (or an ancestor)
+        // has exited, so the chain cannot reach us. That is a definite
+        // "not ours" — unlike a snapshot failure, which is unknowable
+        // and handled by the `?` on `parent_map` above.
+        let Some(&parent) = parents.get(&current) else {
+            return Some(false);
+        };
+        if parent == me {
+            if let Ok(mut cache) = VERIFIED_DESCENDANTS.lock() {
+                cache.get_or_insert_with(HashSet::new).insert(pid);
+            }
+            return Some(true);
+        }
+        // PID 0 is the idle process and a self-parent is corrupt data;
+        // either way the chain is over and we never found ourselves.
+        if parent == 0 || parent == current {
+            return Some(false);
+        }
+        current = parent;
+    }
+    Some(false)
+}
+
+/// Snapshot every live process as a `pid -> parent pid` map.
+#[cfg(target_os = "windows")]
+fn parent_map() -> Option<HashMap<u32, u32>> {
+    use windows::Win32::Foundation::CloseHandle;
+    use windows::Win32::System::Diagnostics::ToolHelp::{
+        CreateToolhelp32Snapshot, Process32FirstW, Process32NextW, PROCESSENTRY32W,
+        TH32CS_SNAPPROCESS,
+    };
+
+    // SAFETY: the snapshot handle is closed on every path below, and
+    // `entry` is initialised with the size field the API requires.
+    let snapshot = unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0) }.ok()?;
+
+    let mut entry = PROCESSENTRY32W {
+        dwSize: std::mem::size_of::<PROCESSENTRY32W>() as u32,
+        ..Default::default()
+    };
+
+    let mut map = HashMap::new();
+    if unsafe { Process32FirstW(snapshot, &mut entry) }.is_ok() {
+        loop {
+            map.insert(entry.th32ProcessID, entry.th32ParentProcessID);
+            if unsafe { Process32NextW(snapshot, &mut entry) }.is_err() {
+                break;
+            }
+        }
+    }
+    unsafe {
+        let _ = CloseHandle(snapshot);
+    }
+
+    if map.is_empty() {
+        return None;
+    }
+    Some(map)
 }
 
 #[cfg(not(target_os = "windows"))]
@@ -198,6 +334,40 @@ mod tests {
         // Windows leaves the upper 16 bits unspecified — they must not
         // leak into the comparison.
         assert_eq!(port_from_row(0xDEAD_901F), 8080);
+    }
+
+    #[test]
+    fn the_process_snapshot_sees_this_process_and_its_parent() {
+        let parents = parent_map().expect("snapshot");
+        assert!(parents.contains_key(&std::process::id()));
+    }
+
+    #[test]
+    fn a_process_we_launched_is_recognised_as_our_descendant() {
+        // The real guarantee: an impostor cannot fake this, because it
+        // cannot arrange for us to be its parent.
+        let mut child = std::process::Command::new("cmd.exe")
+            .args(["/c", "ping -n 6 127.0.0.1 > nul"])
+            .spawn()
+            .expect("spawn child");
+
+        let verdict = descends_from_us(child.id());
+        let _ = child.kill();
+        let _ = child.wait();
+
+        assert_eq!(verdict, Some(true));
+    }
+
+    #[test]
+    fn a_process_outside_our_tree_is_rejected() {
+        // PID 4 is the Windows System process — parented by the idle
+        // process, so the walk terminates without ever reaching us.
+        assert_eq!(descends_from_us(4), Some(false));
+    }
+
+    #[test]
+    fn an_unknown_pid_is_rejected_rather_than_walked_forever() {
+        assert_eq!(descends_from_us(u32::MAX), Some(false));
     }
 
     #[test]

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -460,6 +460,9 @@ const zhTW = {
     gameSectionEmpty: '尚未選擇任何遊戲，遊戲相關設定將於選擇遊戲後出現。',
     disableHardwareAccelerationTip:
       '關閉硬體加速可降低 GPU 使用，但介面動畫會較不流暢。\n更動後需完全重新啟動 Beanfun 才會套用。',
+    webviewProxy: '讓加速器 / VPN 認得網頁流量',
+    webviewProxyTip:
+      '登入視窗（GamaPass、經典版）的網路連線由 WebView2 另一個行程送出，\n只認程式名稱的遊戲加速器或分流 VPN 會漏掉它們。\n開啟後改由 Beanfun 本身轉送，加速器即可辨識。\n不會更動 Windows 任何設定，也不影響其他程式。\n更動後需完全重新啟動 Beanfun 才會套用。',
     darkMode: '深色模式',
     tradLoginTip: '使用傳統登入流程（多次跳轉），\n適合自動登入失敗或無法跳出登入視窗時使用。',
     killPatcherTip: '阻止 beanfun! 啟動的更新程式 (Patcher.aspx) 自動執行。',
@@ -745,6 +748,9 @@ const zhCN = {
     gameSectionEmpty: '尚未选择任何游戏，游戏相关设定将于选择游戏后出现。',
     disableHardwareAccelerationTip:
       '关闭硬件加速可降低 GPU 使用，但界面动画会较不流畅。\n更动后需完全重新启动 Beanfun 才会套用。',
+    webviewProxy: '让加速器 / VPN 认得网页流量',
+    webviewProxyTip:
+      '登录窗口（GamaPass、经典版）的网络连接由 WebView2 另一个进程送出，\n只认程序名称的游戏加速器或分流 VPN 会漏掉它们。\n开启后改由 Beanfun 本身转发，加速器即可识别。\n不会更动 Windows 任何设置，也不影响其他程序。\n更动后需完全重新启动 Beanfun 才会套用。',
     darkMode: '深色模式',
     tradLoginTip: '使用传统登录流程（多次跳转），\n适合自动登录失败或无法跳出登录窗口时使用。',
     killPatcherTip: '阻止 beanfun! 启动的更新程序 (Patcher.aspx) 自动执行。',
@@ -1043,6 +1049,9 @@ const enUS = {
     gameSectionEmpty: 'No game selected. Game-specific settings will appear once you pick one.',
     disableHardwareAccelerationTip:
       'Disabling hardware acceleration lowers GPU use but makes UI animations less smooth.\nA full Beanfun restart is required for the change to take effect.',
+    webviewProxy: 'Let accelerators / VPNs see web traffic',
+    webviewProxyTip:
+      'The login windows (GamaPass, Classic) send their traffic from a separate WebView2 process,\nso game accelerators and split-tunnel VPNs that match on program name miss them.\nTurn this on to relay that traffic through Beanfun itself, where they can see it.\nNothing in Windows is changed, and no other program is affected.\nA full Beanfun restart is required for the change to take effect.',
     darkMode: 'Dark Mode',
     tradLoginTip:
       'Use the traditional multi-redirect login flow.\nHandy when auto-login fails or the login window does not appear.',

--- a/src/pages/Settings.vue
+++ b/src/pages/Settings.vue
@@ -591,13 +591,34 @@ function handleTools(): void {
  * `disableHardwareAcceleration` toggle handler. WPF L213-222 shows
  * a restart prompt after writing the new value to Config.
  *
- * The SPA now honours this flag at startup via
- * `WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS=--disable-gpu` (set in
- * `lib.rs::run()` before the WebView2 runtime initialises).
- * A full restart is still required for the change to take effect.
+ * The SPA honours this flag at startup by appending `--disable-gpu`
+ * to the window builder's `additional_browser_args` in `lib.rs::run()`
+ * — NOT via `WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS`, which WebView2
+ * ignores once wry passes explicit environment options. The args are
+ * fixed for the life of the browser process, so a full restart is
+ * required for the change to take effect.
  */
 async function handleDisableHwAccelChange(value: boolean): Promise<void> {
   await ui.setDisableHwAccel(value)
+  try {
+    await ElMessageBox.alert(
+      t('MsgRestartForHardwareAccel'),
+      t('MsgRestartForHardwareAccelTitle'),
+      { type: 'info' },
+    )
+  } catch {
+    /* User dismissed the alert — no-op. */
+  }
+}
+
+/**
+ * `webviewProxy` toggle handler — same restart contract as the
+ * hardware-acceleration one, and for the same reason: the
+ * `--proxy-server` switch is baked into the browser arguments at
+ * startup (see `services::webview_proxy`).
+ */
+async function handleWebviewProxyChange(value: boolean): Promise<void> {
+  await ui.setWebviewProxy(value)
   try {
     await ElMessageBox.alert(
       t('MsgRestartForHardwareAccel'),
@@ -948,6 +969,22 @@ onMounted(() => {
                       @change="(value) => handleDisableHwAccelChange(Boolean(value))"
                     >
                       {{ t('DisableHardwareAcceleration') }}
+                    </el-checkbox>
+                  </el-tooltip>
+                </div>
+
+                <div class="settings__row settings__row--checkbox">
+                  <el-tooltip
+                    placement="right"
+                    popper-class="settings__tip-popper"
+                    :content="t('settings.webviewProxyTip')"
+                  >
+                    <el-checkbox
+                      :model-value="ui.webviewProxy"
+                      data-test="settings-webview-proxy"
+                      @change="(value) => handleWebviewProxyChange(Boolean(value))"
+                    >
+                      {{ t('settings.webviewProxy') }}
                     </el-checkbox>
                   </el-tooltip>
                 </div>

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -14,6 +14,7 @@
  * | `language`          | `Language`                    | `zh-TW`     |
  * | `minimizeToTray`    | `minimize_to_tray`            | `false`     |
  * | `disableHwAccel`    | `disableHardwareAcceleration` | `false`     |
+ * | `webviewProxy`      | `webviewProxy`                | `false`     |
  * | `updateChannel`     | `updateChannel`               | `Stable`    |
  * | `autoStartGame`     | `autoStartGame`               | `false`     |
  * | `askUpdate`         | `ask_update`                  | `true`      |
@@ -116,6 +117,14 @@ export const UI_CONFIG_KEYS = {
   Language: 'Language',
   MinimizeToTray: 'minimize_to_tray',
   DisableHardwareAcceleration: 'disableHardwareAcceleration',
+  /**
+   * Route WebView2's traffic through the loopback proxy hosted in
+   * `beanfun.exe` (`services::webview_proxy`) so process-matching game
+   * accelerators / split-tunnel VPNs pick up the login popups. Read
+   * once at startup when the browser arguments are built, so changing
+   * it needs a restart. Not a WPF key — new in the Tauri client.
+   */
+  WebviewProxy: 'webviewProxy',
   UpdateChannel: 'updateChannel',
   AutoStartGame: 'autoStartGame',
   AskUpdate: 'ask_update',
@@ -207,6 +216,12 @@ export const useUiStore = defineStore('ui', () => {
     parseBool(config.get(UI_CONFIG_KEYS.DisableHardwareAcceleration), false),
   )
 
+  /** Off by default: a direct connection is right for everyone who
+   * isn't running a process-matching accelerator. */
+  const webviewProxy = computed<boolean>(() =>
+    parseBool(config.get(UI_CONFIG_KEYS.WebviewProxy), false),
+  )
+
   const updateChannel = computed<UpdateChannel>(() => {
     const raw = config.get(UI_CONFIG_KEYS.UpdateChannel)
     return isUpdateChannel(raw) ? raw : DEFAULT_UPDATE_CHANNEL
@@ -260,6 +275,10 @@ export const useUiStore = defineStore('ui', () => {
 
   async function setDisableHwAccel(value: boolean): Promise<void> {
     await config.set(UI_CONFIG_KEYS.DisableHardwareAcceleration, stringifyBool(value))
+  }
+
+  async function setWebviewProxy(value: boolean): Promise<void> {
+    await config.set(UI_CONFIG_KEYS.WebviewProxy, stringifyBool(value))
   }
 
   async function setUpdateChannel(value: UpdateChannel): Promise<void> {
@@ -343,6 +362,7 @@ export const useUiStore = defineStore('ui', () => {
     minimizeToTray,
     classicLoginMode,
     disableHwAccel,
+    webviewProxy,
     updateChannel,
     autoStartGame,
     askUpdate,
@@ -357,6 +377,7 @@ export const useUiStore = defineStore('ui', () => {
     setMinimizeToTray,
     setClassicLoginMode,
     setDisableHwAccel,
+    setWebviewProxy,
     setUpdateChannel,
     setAutoStartGame,
     setAskUpdate,

--- a/tests/unit/stores/ui.spec.ts
+++ b/tests/unit/stores/ui.spec.ts
@@ -60,6 +60,9 @@ describe('useUiStore', () => {
       expect(ui.language).toBe(DEFAULT_LOCALE)
       expect(ui.minimizeToTray).toBe(false)
       expect(ui.disableHwAccel).toBe(false)
+      // A direct connection is right unless the user runs a
+      // process-matching accelerator, so the relay stays opt-in.
+      expect(ui.webviewProxy).toBe(false)
       expect(ui.updateChannel).toBe(DEFAULT_UPDATE_CHANNEL)
       // P12.4 D2 — WPF defaults from Settings.xaml.cs ctor.
       expect(ui.autoStartGame).toBe(false)
@@ -77,6 +80,7 @@ describe('useUiStore', () => {
           Language: 'en-US',
           minimize_to_tray: 'true',
           disableHardwareAcceleration: 'true',
+          webviewProxy: 'true',
           updateChannel: 'Beta',
           autoStartGame: 'true',
           ask_update: 'false',
@@ -94,6 +98,7 @@ describe('useUiStore', () => {
       expect(ui.language).toBe('en-US')
       expect(ui.minimizeToTray).toBe(true)
       expect(ui.disableHwAccel).toBe(true)
+      expect(ui.webviewProxy).toBe(true)
       expect(ui.updateChannel).toBe('Beta')
       expect(ui.autoStartGame).toBe(true)
       expect(ui.askUpdate).toBe(false)
@@ -160,12 +165,14 @@ describe('useUiStore', () => {
       const ui = useUiStore()
       await ui.setMinimizeToTray(true)
       await ui.setDisableHwAccel(false)
+      await ui.setWebviewProxy(true)
       expect(mockSetConfig).toHaveBeenNthCalledWith(1, UI_CONFIG_KEYS.MinimizeToTray, 'true')
       expect(mockSetConfig).toHaveBeenNthCalledWith(
         2,
         UI_CONFIG_KEYS.DisableHardwareAcceleration,
         'false',
       )
+      expect(mockSetConfig).toHaveBeenNthCalledWith(3, UI_CONFIG_KEYS.WebviewProxy, 'true')
     })
 
     it('setUpdateChannel writes the literal channel value', async () => {


### PR DESCRIPTION
## Why

Reporters on #356 said the GamaPass / Classic login popup ignores their accelerator or VPN **whether hardware acceleration is on or off**. They were right, and the setting has nothing to do with it.

WebView2 always runs out-of-process. Everything our web surfaces request — the GamaPass popup, the Classic portal, the in-app browser — leaves the machine on a socket owned by `msedgewebview2.exe`. Game accelerators and split-tunnel VPNs in this market match traffic **by process name**, look for `beanfun.exe`, and find nothing.

Measured on the portal window before this change:

| | `beanfun.exe` | `msedgewebview2.exe` |
|---|---|---|
| outbound connections | **0** | **all of them** |

The regular login is unaffected because it runs through `reqwest` in our own process — which is exactly why only the popups look broken to users.

There is nothing a user can configure to fix this, so the app fixes it itself.

## What

A minimal HTTP proxy inside `beanfun.exe`, with the webview pointed at it:

```
before:  msedgewebview2.exe ─────────────────────────→ tw.beanfun.com
after:   msedgewebview2.exe ──→ 127.0.0.1:<port>
                                  (beanfun.exe) ─────→ tw.beanfun.com
```

The loopback hop is not intercepted (accelerator filters skip loopback) and the real outbound socket is opened by us, so a process-matching accelerator picks it up.

**Nothing outside the app changes**: no system proxy, no registry, no WinINET/WinHTTP settings, no effect on any other program. And nothing for the user to fill in — the port is ephemeral and ours. The Settings entry is one checkbox, off by default, with the same restart contract as the hardware-acceleration toggle.

`CONNECT` is served as a blind byte relay, so https is **tunnelled, never terminated**: no certificate, no TLS interception, and the proxy cannot read what passes through it.

## Who is allowed to use it

The app is not open to third-party access, and this must not become the exception. Three layers:

**Not reachable off-machine.** The listener binds `127.0.0.1`, not `0.0.0.0`, on an ephemeral port that changes every launch. Confirmed: from this machine's own LAN address, `TcpTestSucceeded: False`.

**Not usable by other local processes.** Every accepted connection is traced back to its owning process via `GetExtendedTcpTable`, and is served only if **both** hold:

1. its image name is `msedgewebview2.exe`, **and**
2. our own PID appears in its parent chain.

A name can be faked — any local program can rename its executable. A parent cannot: a process does not choose who spawns it, and WebView2's browser process is created by us with the renderer / network-service children hanging off it. Requiring both means an impostor would have to be a process we launched ourselves. Ancestry alone would not do either, since we also spawn the game client, NGM and LocaleRemulator, none of which has any business borrowing the tunnel.

The ancestry walk runs on a Toolhelp snapshot, is bounded to 16 hops so it always terminates, and caches verified PIDs so a page load pays for the snapshot once rather than once per connection. Caching is safe against PID reuse because the image-name check is not cached and runs on every connection.

A broken parent chain is a **definite refusal** — an unresolvable link means the process or an ancestor has exited, which is knowledge, not uncertainty. Only genuine uncertainty (the snapshot itself failing) fails open, because a race in a defense-in-depth check must never take the user's webview offline. That is not a practical hole: using a proxy requires a live connection, and a live connection always has a row in the TCP table.

**Not a control surface.** Even granting a bypass, what a caller gets is one TCP relay: no Tauri command, no account data, no session, and for https not even readable content. The worst case is borrowing our process name for someone else's traffic — not operating the app.

## Failure behaviour

If the listener cannot bind, `--proxy-server` is simply omitted and the webview goes direct, exactly as before. The feature degrades to "as before", never to "no network".

The switch joins the shared `BROWSER_ARGS`, so the main window and every runtime window stay byte-identical and cannot reintroduce the environment mismatch behind #356.

## Verification

Live, with the proxy on and a real Classic portal window open:

| | into the proxy (loopback) | outbound 443 | outcome |
|---|---|---|---|
| real webview | 26 | `beanfun.exe` **26** | all served, **0 false rejections** |
| `curl.exe` | 1 | 0 | refused before a byte was read |

The refusal is named in the log:

```
WARN webview_proxy::peer: refused a connection from another process pid=42004 image=curl.exe
```

An earlier run completed the whole chain through the proxy — `portal-reached` → `ngm://launch` → NGM — so the relay does not disturb the flow.

Plus 1047 Rust tests (22 new: request-head parsing, a real `CONNECT` tunnel and an origin-form rewrite end-to-end through the listener, and the peer checks including spawning a real child process to verify ancestry), 681 frontend tests, clippy clean under `-D warnings`.
