### PR TITLE
feat(logging): write logs to disk, with credentials kept out of them

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3893,9 +3893,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -4170,9 +4170,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -372,6 +372,7 @@ dependencies = [
  "tokio-test",
  "tokio-util",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
  "url",
  "webview2-com",
@@ -2004,7 +2005,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.58.0",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -4412,6 +4413,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5240,6 +5247,19 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -76,6 +76,9 @@ anyhow = "1"
 # Logging / tracing
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+# Non-blocking file writer behind the on-disk log layer
+# (see services::logging) so a slow disk never stalls a traced call.
+tracing-appender = "0.2"
 
 # HTTP client (rustls — avoid OpenSSL dependency)
 # native-tls (SChannel on Windows), NOT rustls: reCAPTCHA Enterprise fingerprints

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -1395,15 +1395,14 @@ fn parse_mltoken_fragment(fragment: &str) -> Option<(RecaptchaStep, String)> {
 }
 
 /// Strip query parameters from a URL for safe logging.
-/// Prevents session tokens (e.g. `pSKey`) from leaking into traces.
+///
+/// Thin adapter over [`crate::core::redact::redact_uri`], which is the
+/// one place the redaction rules live now that logs are written to disk
+/// and sent to us. Kept as a named wrapper because the call sites below
+/// already hold a parsed [`Url`], and it also drops the fragment —
+/// `mltoken=login~<token>` arrives there.
 fn redact_url_query(url: &Url) -> String {
-    let mut redacted = url.clone();
-    redacted.set_query(None);
-    if url.query().is_some() {
-        format!("{}?[REDACTED]", redacted)
-    } else {
-        redacted.to_string()
-    }
+    crate::core::redact::redact_uri(url.as_str())
 }
 
 /// Check whether `url` is a landing page WPF's

--- a/src-tauri/src/commands/classic.rs
+++ b/src-tauri/src/commands/classic.rs
@@ -763,11 +763,23 @@ async fn open_classic_login_windows<R: tauri::Runtime>(
     let needs_pick_cb = needs_pick.clone();
     let flag_for_msg = flag.clone();
     let window = build_portal_window(&app, &portal_script(region), start_visible, move |raw| {
-        tracing::info!("classic portal message: {raw}");
+        // Only the `kind` is safe to print: the payload carries game
+        // account ids, and `ready-timeout` reports an `href` whose query
+        // can hold session parameters. Developer builds keep the raw
+        // message; a shipped build must not put it in a file we ask
+        // users to send us.
+        #[cfg(debug_assertions)]
+        tracing::debug!("classic portal message (raw): {raw}");
+
         let Ok(msg) = serde_json::from_str::<PortalMessage>(raw) else {
-            tracing::warn!("classic: unparseable portal message");
+            tracing::warn!(len = raw.len(), "classic: unparseable portal message");
             return;
         };
+        tracing::info!(
+            kind = %msg.kind,
+            accounts = msg.accounts.len(),
+            "classic portal message"
+        );
         match msg.kind.as_str() {
             // Emit once — the script re-reports after every navigation.
             "need-login" if !needs_login_cb.swap(true, Ordering::SeqCst) => {

--- a/src-tauri/src/commands/cookie_native.rs
+++ b/src-tauri/src/commands/cookie_native.rs
@@ -394,9 +394,16 @@ where
                     // Cancel the prompt; the callback owns the launch.
                     args.SetCancel(true)?;
                     if !url.is_empty() {
+                        // The `ngm://` launch URL carries the GamaPass
+                        // session token in its *path*
+                        // (`-passarg:'… sess<hex> …'`), so only the
+                        // scheme is safe to print. "Did we intercept a
+                        // launch?" is the diagnostic; the payload is a
+                        // credential.
                         tracing::info!(
                             step = "NativeHandler.ExternalUriScheme",
-                            "intercepted external-scheme launch: {url}"
+                            uri = %crate::core::redact::redact_uri(&url),
+                            "intercepted external-scheme launch"
                         );
                         cb(&url);
                     }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -281,6 +281,7 @@ pub fn build_specta_builder<R: tauri::Runtime>() -> Builder<R> {
             // `R` for the same `AppHandle<R>` reason as `minimize_main_window`.
             system::reset_window_position::<tauri::Wry>,
             system::clear_webview2_cache::<tauri::Wry>,
+            system::open_logs_folder,
             // config (P10.3 — D2)
             config::get_config_value,
             config::get_all_config,

--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -330,6 +330,29 @@ pub async fn clear_webview2_cache<R: tauri::Runtime>(
     Ok(())
 }
 
+/// Reveal the folder holding this install's log files.
+///
+/// The whole point of writing logs to disk is that a user can attach
+/// one to a bug report, which they can only do if they can find it. The
+/// path is computed here from the storage root — never accepted from
+/// the frontend — so this cannot be turned into an arbitrary "open this
+/// path" primitive.
+///
+/// # Errors
+///
+/// - `system.open_failed` — the OS file manager could not be launched.
+#[tauri::command]
+#[specta::specta]
+pub async fn open_logs_folder(state: State<'_, AppState>) -> Result<(), CommandError> {
+    let dir = crate::services::logging::logs_dir(&state.storage_root);
+    // The folder only exists once something has been logged to it; a
+    // user asking to see it before then should get an empty folder
+    // rather than an error.
+    let _ = std::fs::create_dir_all(&dir);
+    system::open_directory(&dir).await?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/commands/web_browser.rs
+++ b/src-tauri/src/commands/web_browser.rs
@@ -364,7 +364,7 @@ async fn open_url_in_webview<R: tauri::Runtime>(
             let _ = window.set_focus();
             tracing::info!(
                 step = "InAppBrowser.PageReadyShown",
-                url = %payload.url(),
+                url = %crate::core::redact::redact_uri(payload.url().as_str()),
                 "in-app browser shown after first non-about:blank Finished event"
             );
         })
@@ -442,7 +442,8 @@ async fn open_url_in_webview<R: tauri::Runtime>(
     tracing::info!(
         step = "InAppBrowser.Opened",
         label = %label,
-        url = %target_url,
+        // Member-centre and Gash URLs carry `web_token` in the query.
+        url = %crate::core::redact::redact_uri(target_url.as_str()),
         "in-app browser window opened (hidden until first paint)"
     );
 

--- a/src-tauri/src/core/mod.rs
+++ b/src-tauri/src/core/mod.rs
@@ -9,6 +9,7 @@
 
 pub mod legacy;
 pub mod parser;
+pub mod redact;
 pub mod time;
 pub mod version;
 pub mod wcdes;

--- a/src-tauri/src/core/redact.rs
+++ b/src-tauri/src/core/redact.rs
@@ -1,0 +1,457 @@
+//! Keeping secrets out of the log file.
+//!
+//! Logs used to be a developer-only convenience that vanished into a
+//! suppressed console. Now they are written to disk and we actively ask
+//! users to send them to us, which usually means pasting them into a
+//! public GitHub issue. Anything a log line carries is therefore
+//! effectively published, and a session token or an account id in there
+//! is not a diagnostic — it is a credential leak with a helpful
+//! timestamp attached.
+//!
+//! The rule this module encodes: log **enough to correlate, never
+//! enough to reuse**. A masked value still lets you see that two lines
+//! refer to the same token, or that a token changed between two
+//! requests — which is what the diagnostics were actually for.
+
+use url::Url;
+
+/// Below this length a value has too little entropy to reveal any of
+/// it: showing two characters of a 6-character code gives away a third
+/// of it.
+const MIN_LEN_TO_SHOW_EDGES: usize = 12;
+
+/// How many leading / trailing characters survive masking.
+const EDGE: usize = 2;
+
+/// Mask a secret — a session token, an account id, a cookie value.
+///
+/// Keeps the first and last couple of characters plus the length, so
+/// two log lines can still be compared ("same token as before?",
+/// "did it change across the request?") without the value being usable.
+/// Short values are replaced wholesale.
+///
+/// Counts and slices by `char`, so a multi-byte value (an account name
+/// in Chinese, say) can never be split mid-character.
+pub fn mask(value: &str) -> String {
+    let count = value.chars().count();
+    if count == 0 {
+        return "<empty>".to_string();
+    }
+    if count < MIN_LEN_TO_SHOW_EDGES {
+        return format!("***({count})");
+    }
+    let head: String = value.chars().take(EDGE).collect();
+    let tail: String = value.chars().skip(count - EDGE).collect();
+    format!("{head}***{tail}({count})")
+}
+
+/// Mask an optional secret, so call sites do not have to branch.
+pub fn mask_opt(value: Option<&str>) -> String {
+    value.map_or_else(|| "<none>".to_string(), mask)
+}
+
+/// Redact a URI for logging.
+///
+/// - **http / https** — scheme, host and path are kept (they say *which
+///   page*, which is the diagnostic), and the query is dropped, because
+///   that is where beanfun puts `web_token`, `pSKey` and friends.
+/// - **any other scheme** — everything after the scheme is masked. A
+///   custom-scheme URI like `ngm://launch/…-passarg:'… sess<hex> …'`
+///   carries its session token in the *path*, so there is no safe part
+///   to keep beyond the scheme itself.
+/// - **unparseable** — masked entirely.
+pub fn redact_uri(raw: &str) -> String {
+    let Ok(url) = Url::parse(raw) else {
+        return format!("[REDACTED]({})", raw.chars().count());
+    };
+
+    if !matches!(url.scheme(), "http" | "https") {
+        return format!("{}://[REDACTED]({})", url.scheme(), raw.chars().count());
+    }
+
+    let mut trimmed = url.clone();
+    trimmed.set_query(None);
+    trimmed.set_fragment(None);
+    let base = trimmed.to_string();
+    if url.query().is_some() || url.fragment().is_some() {
+        format!("{base}?[REDACTED]")
+    } else {
+        base
+    }
+}
+
+/// Scrub a response-body preview before logging it.
+///
+/// The login flow logs a few hundred characters of the server's reply
+/// when a step fails. That preview is the single most useful field we
+/// have for diagnosing a login breaking in the wild — it is what tells
+/// "beanfun returned a login page" apart from "beanfun returned an
+/// error page" apart from "we got HTML where JSON was expected" — so
+/// deleting it would gut the reason the log file exists.
+///
+/// What it must not do is carry the secrets those bodies contain. This
+/// removes them while leaving the *shape* of the document intact:
+///
+/// 1. values of known credential parameters (`web_token=…`, `pSKey=…`,
+///    `mltoken=…`, …), including short ones;
+/// 2. every HTML `value="…"` attribute — beanfun's login pages carry
+///    `pSKey`, `__VIEWSTATE` and friends as hidden inputs, so the
+///    attribute is masked wholesale rather than by guessing which
+///    `name=` next to it counts as a secret;
+/// 3. anything that looks like an email address;
+/// 4. any run of 20+ token-alphabet characters, which is what session
+///    keys, base64 blobs and GUIDs look like.
+///
+/// Rules 2 and 4 are deliberately over-eager: masking an innocuous
+/// `<option value="TW">` costs a little readability, missing a token
+/// costs a credential.
+pub fn scrub(preview: &str) -> String {
+    use regex::Regex;
+    use std::sync::LazyLock;
+
+    // Credential-ish parameters, in `k=v`, `k: v` and `"k":"v"` forms.
+    static PARAM: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r#"(?i)\b(web_?token|p?s{1,2}key|session_?key|mltoken|auth_?token|access_?token|refresh_?token|password|passwd|pwd|otp|secret)\b\s*["']?\s*[=:]\s*["']?([^"'&\s<>,;}\]]+)"#,
+        )
+        .expect("static regex")
+    });
+    // Hidden form fields: `<input name="pSKey" value="…">`.
+    static VALUE_ATTR: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r#"(?i)\bvalue\s*=\s*"([^"]+)""#).expect("static regex"));
+    static EMAIL: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}").expect("static regex")
+    });
+    static LONG_RUN: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"[A-Za-z0-9+/_-]{20,}={0,2}").expect("static regex"));
+
+    let stage1 = PARAM.replace_all(preview, |caps: &regex::Captures<'_>| {
+        format!("{}=[{}]", &caps[1], mask(&caps[2]))
+    });
+    let stage2 = VALUE_ATTR.replace_all(&stage1, |caps: &regex::Captures<'_>| {
+        format!(r#"value="{}""#, mask(&caps[1]))
+    });
+    let stage3 = EMAIL.replace_all(&stage2, |caps: &regex::Captures<'_>| mask(&caps[0]));
+    LONG_RUN
+        .replace_all(&stage3, |caps: &regex::Captures<'_>| mask(&caps[0]))
+        .into_owned()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_long_secret_keeps_only_its_edges() {
+        let masked = mask("0f1e2d3c4b5a69788796a5b4c3d2e1f0");
+        assert_eq!(masked, "0f***f0(32)");
+        assert!(!masked.contains("1e2d3c4b5a69788796a5b4c3d2e"));
+    }
+
+    #[test]
+    fn two_log_lines_can_still_be_compared() {
+        // The whole point of keeping the edges: telling "the token
+        // changed" apart from "the token is the same" without exposing
+        // either of them.
+        assert_eq!(mask("AAAA1111222233334444"), mask("AAAA1111222233334444"));
+        assert_ne!(mask("AAAA1111222233334444"), mask("BBBB1111222233335555"));
+    }
+
+    #[test]
+    fn a_short_value_is_replaced_wholesale() {
+        // Showing edges of something this short would give most of it away.
+        assert_eq!(mask("123456"), "***(6)");
+        assert_eq!(mask("a"), "***(1)");
+    }
+
+    #[test]
+    fn an_empty_value_is_named_rather_than_starred() {
+        assert_eq!(mask(""), "<empty>");
+        assert_eq!(mask_opt(None), "<none>");
+        assert_eq!(mask_opt(Some("")), "<empty>");
+    }
+
+    #[test]
+    fn a_multibyte_value_is_not_split_mid_character() {
+        // Byte slicing would panic or emit replacement characters here.
+        let masked = mask("楓之谷經典版帳號名稱測試");
+        assert!(masked.starts_with("楓之"));
+        assert!(masked.contains("(12)"));
+    }
+
+    #[test]
+    fn an_account_id_does_not_survive_masking() {
+        let masked = mask("player12345@example.com");
+        assert!(!masked.contains("player12345"));
+        assert!(!masked.contains("example"));
+    }
+
+    #[test]
+    fn http_urls_keep_the_page_but_lose_the_query() {
+        let redacted =
+            redact_uri("https://tw.beanfun.com/TW/auth.aspx?channel=member&web_token=SECRET123");
+        assert!(!redacted.contains("SECRET123"));
+        assert!(redacted.contains("tw.beanfun.com/TW/auth.aspx"));
+        assert!(redacted.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn a_query_less_http_url_is_left_intact() {
+        assert_eq!(
+            redact_uri("https://tw.beanfun.com/index.aspx"),
+            "https://tw.beanfun.com/index.aspx"
+        );
+    }
+
+    #[test]
+    fn a_fragment_is_treated_as_secret_too() {
+        // `mltoken=login~<token>` arrives in the fragment.
+        let redacted = redact_uri("https://tw.beanfun.com/x#mltoken=login~SECRET");
+        assert!(!redacted.contains("SECRET"));
+    }
+
+    #[test]
+    fn a_custom_scheme_keeps_nothing_but_the_scheme() {
+        // The real shape: NGM carries the session token in the path.
+        let raw = "ngm://launch/%20-mode%3Alaunch%20-passarg%3A'1234567%20sess0f1e2d3c4b5a69788796a5b4c3d2e1f0%202373'";
+        let redacted = redact_uri(raw);
+        assert!(!redacted.contains("sess0f1e2d3c4b5a69788796a5b4c3d2e1f0"));
+        assert!(!redacted.contains("1234567"));
+        assert!(redacted.starts_with("ngm://[REDACTED]"));
+    }
+
+    #[test]
+    fn an_unparseable_uri_is_masked_entirely() {
+        let redacted = redact_uri("not a uri at all ?token=SECRET");
+        assert!(!redacted.contains("SECRET"));
+        assert!(redacted.starts_with("[REDACTED]"));
+    }
+
+    // ── scrub ─────────────────────────────────────────────────────
+
+    #[test]
+    fn scrub_keeps_the_shape_of_the_document() {
+        // The whole point: you can still tell what kind of page this is.
+        let body = r#"<html><head><title>登入</title></head><body class="login">"#;
+        assert_eq!(scrub(body), body);
+    }
+
+    #[test]
+    fn scrub_removes_credential_parameters_even_when_short() {
+        let body = r#"<input name="pSKey" value="abc123"/>&web_token=XY9&password=hunter2"#;
+        let out = scrub(body);
+        assert!(!out.contains("abc123"), "{out}");
+        assert!(!out.contains("XY9"), "{out}");
+        assert!(!out.contains("hunter2"), "{out}");
+        // The parameter names survive — that is the diagnostic.
+        assert!(out.contains("pSKey"));
+        assert!(out.contains("web_token"));
+    }
+
+    #[test]
+    fn scrub_masks_hidden_form_values_whatever_they_are_called() {
+        // ASP.NET login pages carry the interesting secrets as hidden
+        // inputs, and the field name is not always one we predicted.
+        let body = r#"<input type="hidden" name="__VIEWSTATE" value="/wEPDwUKMTQ3OTU2" /><input name="ctl00$unknown" value="s3cret" />"#;
+        let out = scrub(body);
+        assert!(!out.contains("/wEPDwUKMTQ3OTU2"), "{out}");
+        assert!(!out.contains("s3cret"), "{out}");
+        assert!(out.contains("__VIEWSTATE"), "{out}");
+    }
+
+    #[test]
+    fn scrub_removes_emails_and_long_token_runs() {
+        let body = "user player12345@example.com sess0f1e2d3c4b5a69788796a5b4c3d2e1f0 end";
+        let out = scrub(body);
+        assert!(!out.contains("player12345"), "{out}");
+        assert!(!out.contains("example"), "{out}");
+        assert!(!out.contains("0f1e2d3c4b5a69788796a5b4c3d2e1f0"), "{out}");
+        assert!(out.starts_with("user "), "{out}");
+        assert!(out.ends_with(" end"), "{out}");
+    }
+
+    #[test]
+    fn scrub_leaves_ordinary_words_and_short_numbers_alone() {
+        let body = "service_code 610074 region T9 accounts 1 status ok";
+        assert_eq!(scrub(body), body);
+    }
+
+    #[test]
+    fn scrub_masks_a_json_shaped_credential() {
+        let out = scrub(r#"{"MLToken":"03AFcW.short","Result":0}"#);
+        assert!(!out.contains("03AFcW.short"), "{out}");
+        assert!(out.contains("Result"), "{out}");
+    }
+
+    // ── source-tree guard ─────────────────────────────────────────
+
+    /// Fail the build when a `tracing!` field that carries user data is
+    /// bound to something unredacted.
+    ///
+    /// This exists because the first pass at redaction was done by
+    /// grepping for likely names and it **missed a live account id** in
+    /// `login::completed` — the sweep looked at the sites a human
+    /// thought of, and the log only proved it during a run that
+    /// happened not to log in. A mechanical check does not get tired
+    /// and does not depend on which code path a test run exercised.
+    ///
+    /// Escape hatch: put `redact-ok` in a comment on the line or the
+    /// line above, which forces the exception to be written down and
+    /// reviewed rather than merely assumed.
+    #[test]
+    fn no_tracing_field_leaks_user_data() {
+        use std::path::Path;
+
+        /// Field names whose value is user data, not a diagnostic.
+        const SENSITIVE: &[&str] = &[
+            "account",
+            "account_id",
+            "accounts_raw",
+            "auth_token",
+            "body_preview",
+            "cookie_value",
+            "final_url",
+            "href",
+            "jar_web_token",
+            "mltoken",
+            "otp",
+            "password",
+            "preview",
+            "pwd",
+            "raw",
+            "session_key",
+            "session_web_token",
+            "skey",
+            "uri",
+            "url",
+            "used_web_token",
+            "value",
+            "web_token",
+        ];
+        const SAFE_MARKERS: &[&str] = &["redact::", "redact_u", "mask(", "mask_opt(", "scrub("];
+
+        /// Byte ranges covered by `tracing::…!( … )` invocations.
+        ///
+        /// Needed because the `name = expr,` shape also describes
+        /// `format!` named arguments — an early version of this test
+        /// flagged a URL builder in `otp.rs` that logs nothing.
+        /// Parenthesis counting skips string literals so a message like
+        /// `"portal running (visible=true)"` cannot unbalance it.
+        fn tracing_spans(text: &str) -> Vec<(usize, usize)> {
+            let bytes = text.as_bytes();
+            let mut spans = Vec::new();
+            let mut search = 0;
+            while let Some(hit) = text[search..].find("tracing::") {
+                let start = search + hit;
+                search = start + "tracing::".len();
+                let Some(bang) = text[start..].find("!(") else {
+                    break;
+                };
+                // `!(` must be on the same statement, not paragraphs away.
+                if bang > 40 {
+                    continue;
+                }
+                let open = start + bang + 1;
+                let (mut depth, mut i, mut in_str) = (0usize, open, false);
+                while i < bytes.len() {
+                    let c = bytes[i];
+                    if in_str {
+                        if c == b'\\' {
+                            i += 2;
+                            continue;
+                        }
+                        if c == b'"' {
+                            in_str = false;
+                        }
+                    } else if c == b'"' {
+                        in_str = true;
+                    } else if c == b'(' {
+                        depth += 1;
+                    } else if c == b')' {
+                        depth -= 1;
+                        if depth == 0 {
+                            break;
+                        }
+                    }
+                    i += 1;
+                }
+                spans.push((open, i.min(bytes.len())));
+                search = i;
+            }
+            spans
+        }
+
+        fn visit(dir: &Path, out: &mut Vec<String>) {
+            for entry in std::fs::read_dir(dir).expect("read_dir").flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    visit(&path, out);
+                    continue;
+                }
+                if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+                    continue;
+                }
+                let text = std::fs::read_to_string(&path).expect("read source");
+                let spans = tracing_spans(&text);
+                let lines: Vec<&str> = text.lines().collect();
+                let mut offset = 0usize;
+                for (i, line) in lines.iter().enumerate() {
+                    let line_start = offset;
+                    offset += line.len() + 1;
+                    if !spans
+                        .iter()
+                        .any(|(a, b)| line_start > *a && line_start < *b)
+                    {
+                        continue;
+                    }
+                    let trimmed = line.trim();
+                    // A tracing field binding looks like `name = expr,`.
+                    let Some((name, expr)) = trimmed.split_once('=') else {
+                        continue;
+                    };
+                    let name = name.trim();
+                    if !trimmed.ends_with(',') || name.starts_with("let ") || name.contains(' ') {
+                        continue;
+                    }
+                    if !SENSITIVE.contains(&name) {
+                        continue;
+                    }
+                    let expr = expr.trim().trim_end_matches(',').trim();
+                    // A literal carries no user data by construction.
+                    if expr.starts_with('"') {
+                        continue;
+                    }
+                    if SAFE_MARKERS.iter().any(|m| expr.contains(m)) {
+                        continue;
+                    }
+                    let prev = i.checked_sub(1).map(|p| lines[p]).unwrap_or("");
+                    if line.contains("redact-ok") || prev.contains("redact-ok") {
+                        continue;
+                    }
+                    out.push(format!(
+                        "{}:{}  {name} = {expr}",
+                        path.file_name().and_then(|n| n.to_str()).unwrap_or("?"),
+                        i + 1
+                    ));
+                }
+            }
+        }
+
+        let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let mut offenders = Vec::new();
+        visit(&src, &mut offenders);
+        offenders.sort();
+
+        assert!(
+            offenders.is_empty(),
+            "these log fields would put user data in a file we ask users to send us.\n\
+             Wrap the value in core::redact (mask / mask_opt / redact_uri / scrub),\n\
+             or add a `redact-ok: <reason>` comment if it genuinely carries none:\n  {}",
+            offenders.join("\n  ")
+        );
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -35,7 +35,7 @@ use std::path::{Path, PathBuf};
 use commands::error::CommandError;
 use commands::state::AppState;
 use tauri::Manager;
-use tracing_subscriber::{fmt, EnvFilter};
+use tracing_subscriber::EnvFilter;
 
 /// Canonical location of the auto-generated `bindings.ts` the
 /// frontend imports from.
@@ -458,18 +458,22 @@ pub fn default_typescript_exporter() -> specta_typescript::Typescript {
 ///   cookie jar dumps, regex preview bodies) without forcing a
 ///   `RUST_LOG` env var on every contributor's shell.
 ///
-/// # Output destination
+/// # Output destinations
 ///
-/// Default [`tracing_subscriber::fmt`] writes to **stderr**. In
-/// `cargo tauri dev` that's the same terminal that runs the dev
-/// server, so logs appear interleaved with Vite's HMR output and
-/// Cargo's compile messages. For the production Windows build the
-/// `windows_subsystem = "windows"` attribute in `main.rs` suppresses
-/// the console window, so stderr lands in the void; future P-stage
-/// work can route to a file via [`tauri-plugin-log`] or a custom
-/// rolling-file appender if production observability becomes a
-/// requirement (none today — WPF parity scope only covers dev-time
-/// debugging).
+/// Two layers, both fed by the same filter:
+///
+/// - **stderr** — for `cargo tauri dev`, where it lands in the terminal
+///   running the dev server.
+/// - **a file** under `%APPDATA%\Beanfun\logs\` — for everyone else.
+///   The production Windows build sets `windows_subsystem = "windows"`
+///   in `main.rs`, so there is no console and stderr goes nowhere. Every
+///   user-reported problem used to arrive with no evidence attached
+///   (see [`crate::services::logging`] for what that cost us on issue
+///   #356). The file layer is what makes "send me the log" possible.
+///
+/// File logging is best-effort: if the folder or file cannot be
+/// created, the stderr layer is installed alone rather than failing the
+/// launch.
 ///
 /// # Test isolation
 ///
@@ -491,11 +495,49 @@ pub fn default_typescript_exporter() -> specta_typescript::Typescript {
 /// could only flatten into prose are now first-class and, with this
 /// subscriber installed, queryable via downstream JSON exporters
 /// when we eventually need them.
-fn init_tracing() {
+fn init_tracing(storage_root: Option<&std::path::Path>) -> Option<std::path::PathBuf> {
+    use tracing_subscriber::layer::SubscriberExt;
+    use tracing_subscriber::util::SubscriberInitExt;
+
     let filter = EnvFilter::try_from_default_env()
         .unwrap_or_else(|_| EnvFilter::new("info,beanfun_lib=debug"));
 
-    fmt().with_env_filter(filter).with_target(true).init();
+    let stderr_layer = tracing_subscriber::fmt::layer().with_target(true);
+
+    // One file per launch, named so a sort is chronological.
+    let opened = storage_root.and_then(|root| {
+        let stamp = chrono::Local::now().format("%Y%m%d-%H%M%S").to_string();
+        services::logging::open_log_file(root, &stamp, std::process::id())
+    });
+
+    let Some((path, file)) = opened else {
+        tracing_subscriber::registry()
+            .with(filter)
+            .with(stderr_layer)
+            .init();
+        return None;
+    };
+
+    // The worker guard must outlive every log call, i.e. the process.
+    // Leaking it is the honest way to say "this lives forever" — a
+    // `static` would need interior mutability for the same effect.
+    let (writer, guard) = tracing_appender::non_blocking(file);
+    Box::leak(Box::new(guard));
+
+    let file_layer = tracing_subscriber::fmt::layer()
+        .with_target(true)
+        // No terminal on the other end, so escape codes would just be
+        // noise in a file the user is going to paste into an issue.
+        .with_ansi(false)
+        .with_writer(writer);
+
+    tracing_subscriber::registry()
+        .with(filter)
+        .with(stderr_layer)
+        .with(file_layer)
+        .init();
+
+    Some(path)
 }
 
 /// Tauri application entry point.
@@ -507,19 +549,32 @@ fn init_tracing() {
 ///
 /// # Boot ordering
 ///
-/// [`init_tracing`] is the very first call so even the storage-root
-/// resolver gets a live subscriber if it ever grows a `tracing::warn!`
-/// (today it short-circuits via [`eprintln!`] for the fatal path so
-/// the tracing layer is unused there, but the ordering is the
-/// safe default for future additions).
+/// The storage root resolves *before* [`init_tracing`], because the log
+/// file lives under it. Nothing logs in between: the resolver's only
+/// failure path is the fatal [`eprintln!`] below, which needs no
+/// subscriber. Anything added to the resolver later must keep that
+/// property or move after this call.
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    init_tracing();
-
     let storage_root = resolve_storage_root().unwrap_or_else(|err| {
         eprintln!("fatal: cannot resolve storage root — {err}");
         std::process::exit(1);
     });
+
+    let log_path = init_tracing(Some(&storage_root));
+    match log_path {
+        Some(path) => tracing::info!(
+            version = env!("CARGO_PKG_VERSION"),
+            pid = std::process::id(),
+            path = %path.display(),
+            "beanfun starting; logging to file"
+        ),
+        None => tracing::warn!(
+            version = env!("CARGO_PKG_VERSION"),
+            pid = std::process::id(),
+            "beanfun starting; file logging unavailable"
+        ),
+    }
 
     // WebView2 browser arguments — attached to the main window builder in
     // `setup` (runtime windows share the per-instance environment the main

--- a/src-tauri/src/services/beanfun/account.rs
+++ b/src-tauri/src/services/beanfun/account.rs
@@ -336,11 +336,21 @@ pub async fn get_accounts(
     );
 
     if accounts.is_empty() {
+        // The preview answers "did we get the account page or a login
+        // page?", but the account page carries account ids and names.
+        // Developer builds keep it; a shipped build must not put that
+        // in a file we ask users to send us. `body_len` alone already
+        // separates "empty response" from "wrong page".
+        #[cfg(debug_assertions)]
+        let body_preview = &body[..body.len().min(500)];
+        #[cfg(not(debug_assertions))]
+        let body_preview = "<omitted in release builds>";
+
         tracing::warn!(
             service_code,
             service_region,
             body_len = body.len(),
-            body_preview = &body[..body.len().min(500)],
+            body_preview,
             "get_accounts: returned 0 accounts — possible stale cookie issue"
         );
     }
@@ -629,9 +639,13 @@ async fn auth_aspx(
     tracing::debug!(
         service_code,
         service_region,
-        session_web_token = session.web_token.as_str(),
-        jar_web_token = ?jar_before,
-        used_web_token = web_token,
+        // Masked: this diagnostic exists to compare the three tokens
+        // against each other, which the masked form still supports.
+        // The values themselves are live credentials and the log is a
+        // file users are asked to send us.
+        session_web_token = %crate::core::redact::mask(session.web_token.as_str()),
+        jar_web_token = %crate::core::redact::mask_opt(jar_before.as_deref()),
+        used_web_token = %crate::core::redact::mask(web_token),
         "auth_aspx: before request"
     );
 
@@ -652,8 +666,8 @@ async fn auth_aspx(
         tracing::warn!(
             service_code,
             service_region,
-            before = ?jar_before,
-            after = ?jar_after,
+            before = %crate::core::redact::mask_opt(jar_before.as_deref()),
+            after = %crate::core::redact::mask_opt(jar_after.as_deref()),
             "auth_aspx: bfWebToken cookie changed during request"
         );
     }

--- a/src-tauri/src/services/beanfun/login/check_account_type.rs
+++ b/src-tauri/src/services/beanfun/login/check_account_type.rs
@@ -173,7 +173,7 @@ pub async fn check_account_type(
     // IP. `account` is non-secret; the captcha token itself is never logged.
     tracing::info!(
         step = "CheckAccountType.Verdict",
-        account_id = %account,
+        account_id = %crate::core::redact::mask(account),
         result_code = parsed.result_code.as_deref().unwrap_or(""),
         succeeded,
         is_recaptcha,

--- a/src-tauri/src/services/beanfun/login/completed.rs
+++ b/src-tauri/src/services/beanfun/login/completed.rs
@@ -178,14 +178,20 @@ pub async fn login_completed(
     // will surface the gap instead of silently swallowing it — an
     // empty-value log line that would otherwise read identically.
     let account_id_display = if account_id.is_empty() {
-        "<deferred>"
+        "<deferred>".to_string()
     } else {
-        account_id
+        // Masked: this line marks a successful login, and the id is the
+        // user's beanfun account (an email address, in the common case)
+        // in a file we ask users to attach to public bug reports. The
+        // masked form still confirms *which* stored account logged in
+        // when several are configured.
+        crate::core::redact::mask(account_id)
     };
     tracing::info!(
         step = "LoginCompleted",
         region = ?client.config().region,
-        account_id = account_id_display,
+        // redact-ok: masked at the binding above (sentinel or mask()).
+        account_id = %account_id_display,
         "login flow completed successfully"
     );
 

--- a/src-tauri/src/services/beanfun/login/mod.rs
+++ b/src-tauri/src/services/beanfun/login/mod.rs
@@ -231,7 +231,7 @@ where
         tracing::warn!(
             step,
             error = %e,
-            body_preview = %truncate_chars(text, BODY_LOG_PREVIEW_CHARS),
+            body_preview = %crate::core::redact::scrub(truncate_chars(text, BODY_LOG_PREVIEW_CHARS)),
             "login step JSON parse failed"
         );
         LoginError::from(e)

--- a/src-tauri/src/services/beanfun/login/qr_poll.rs
+++ b/src-tauri/src/services/beanfun/login/qr_poll.rs
@@ -219,7 +219,7 @@ pub async fn poll_qr_login_status(
         tracing::warn!(
             step = "qr_poll",
             error = %e,
-            body_preview = %truncate_chars(&body, BODY_LOG_PREVIEW_CHARS),
+            body_preview = %crate::core::redact::scrub(truncate_chars(&body, BODY_LOG_PREVIEW_CHARS)),
             "QR poll response JSON parse failed",
         );
         LoginError::QrJsonParseFailed
@@ -246,7 +246,7 @@ pub async fn poll_qr_login_status(
             tracing::warn!(
                 step = "qr_poll",
                 result_message = ?other,
-                body_preview = %truncate_chars(&body, BODY_LOG_PREVIEW_CHARS),
+                body_preview = %crate::core::redact::scrub(truncate_chars(&body, BODY_LOG_PREVIEW_CHARS)),
                 "QR poll returned unknown ResultMessage",
             );
             Err(LoginError::ServerMessage(body))

--- a/src-tauri/src/services/beanfun/login/send_login.rs
+++ b/src-tauri/src/services/beanfun/login/send_login.rs
@@ -71,7 +71,7 @@ pub async fn send_login(
         // about the body, so this is a parity-superset.
         tracing::warn!(
             step = "SendLogin",
-            body_preview = %truncate_chars(&body, BODY_LOG_PREVIEW_CHARS),
+            body_preview = %crate::core::redact::scrub(truncate_chars(&body, BODY_LOG_PREVIEW_CHARS)),
             "SendLogin scrape returned 0 hidden inputs"
         );
         return Err(LoginError::SendLoginNoFormData);

--- a/src-tauri/src/services/beanfun/login/session_key.rs
+++ b/src-tauri/src/services/beanfun/login/session_key.rs
@@ -43,16 +43,19 @@ async fn get_session_key_tw(client: &BeanfunClient) -> Result<String, LoginError
 
     session_key_from_url(final_url.as_str()).ok_or_else(|| {
         // Diagnostic: when the portal-default redirect chain ends on a
-        // URL whose query doesn't carry `[sp][Ss]?[Kk]ey=…` we want
-        // the operator to see what URL we actually landed on. The URL
-        // query may contain user-agent-derived identifiers but not
-        // credentials; logging the full URL is safe in this context
-        // and is the minimum context needed to tell "Beanfun changed
-        // its redirect target" apart from a transient network glitch.
+        // URL whose query doesn't carry `[sp][Ss]?[Kk]ey=…` we want to
+        // see what URL we actually landed on — that is what separates
+        // "Beanfun changed its redirect target" from a transient
+        // network glitch, and scheme + host + path answers it.
+        //
+        // The query is dropped even though the skey is by definition
+        // *not* in it on this path: whatever else Beanfun redirects
+        // with is unknown to us, and this log now ends up in a file
+        // users paste into public issues.
         tracing::warn!(
             step = "GetSessionKey",
             region = ?LoginRegion::TW,
-            final_url = %final_url,
+            final_url = %crate::core::redact::redact_uri(final_url.as_str()),
             "session key regex did not match the redirected URL"
         );
         LoginError::MissingSessionKey
@@ -85,7 +88,7 @@ async fn get_session_key_hk(client: &BeanfunClient) -> Result<String, LoginError
         step = "GetSessionKey",
         region = ?LoginRegion::HK,
         body_len = body.len(),
-        body_preview = %truncate_chars(&body, 2000),
+        body_preview = %crate::core::redact::scrub(truncate_chars(&body, 2000)),
         "OTP1 span regex did not match the response body"
     );
     Err(LoginError::MissingSessionKey)

--- a/src-tauri/src/services/beanfun/login/tw_regular.rs
+++ b/src-tauri/src/services/beanfun/login/tw_regular.rs
@@ -175,7 +175,7 @@ async fn run_from_check(
         CheckAccountOutcome::RecaptchaRequired => {
             tracing::info!(
                 step = "TwRegular.CheckAccountType",
-                account_id = %creds.account,
+                account_id = %crate::core::redact::mask(&creds.account),
                 "reCAPTCHA required; pausing for widget solve"
             );
             Ok(TwStepOutcome::RecaptchaRequired {
@@ -215,7 +215,7 @@ async fn run_from_login(
         Err(LoginError::AdvanceCheckRequired { url }) => {
             tracing::info!(
                 step = "TwRegular.AccountLogin",
-                account_id = %creds.account,
+                account_id = %crate::core::redact::mask(&creds.account),
                 "advance-check required; parking session for post-verify resume"
             );
             return Ok(TwStepOutcome::AdvanceCheckRequired { ctx, url });
@@ -227,7 +227,7 @@ async fn run_from_login(
         AccountLoginOutcome::RecaptchaRequired => {
             tracing::info!(
                 step = "TwRegular.AccountLogin",
-                account_id = %creds.account,
+                account_id = %crate::core::redact::mask(&creds.account),
                 "reCAPTCHA required; pausing for widget solve"
             );
             Ok(TwStepOutcome::RecaptchaRequired {
@@ -249,7 +249,7 @@ async fn run_from_login(
             tracing::info!(
                 step = "TwRegular",
                 region = ?LoginRegion::TW,
-                account_id = %creds.account,
+                account_id = %crate::core::redact::mask(&creds.account),
                 "login flow completed successfully"
             );
 

--- a/src-tauri/src/services/logging.rs
+++ b/src-tauri/src/services/logging.rs
@@ -1,0 +1,223 @@
+//! On-disk logs, so a bug report can carry evidence.
+//!
+//! # Why this exists
+//!
+//! `main.rs` sets `windows_subsystem = "windows"` for release builds, so
+//! there is no console and everything `tracing` writes to stderr goes
+//! nowhere. Every user-reported problem therefore arrived as prose —
+//! "I pressed the button and nothing happened" — and had to be
+//! diagnosed by guesswork about a machine we cannot see. Issue #356
+//! took several rounds of that before the reporter happened to mention
+//! their hardware-acceleration setting, which was the whole answer.
+//!
+//! The app already emits exactly the lines that would have shortened
+//! it (`ready-timeout` naming the stuck document state, the WebView2
+//! `ERROR_INVALID_STATE` failure, the proxy's refusals). They just had
+//! nowhere to land.
+//!
+//! # One file per launch
+//!
+//! Multi-instance use is normal here (issue #340 exists because people
+//! run eight launchers at once), and several processes appending to one
+//! file interleave their lines. So each launch writes its own
+//! `beanfun-<timestamp>-<pid>.log` and the startup sweep keeps only the
+//! newest [`MAX_LOG_FILES`].
+//!
+//! The sweep cannot hurt a live instance: Windows refuses to delete a
+//! file another process holds open, and the resulting error is ignored.
+
+use std::path::{Path, PathBuf};
+
+/// How many log files to keep.
+///
+/// Sized for the multi-instance habit rather than for one launch at a
+/// time: issue #340 exists because people run eight launchers at once,
+/// and at eight files per session a smaller cap would discard yesterday
+/// on this morning's first launch — exactly when "it happened a couple
+/// of days ago" reports need it. The files are a few KB each, so the
+/// generous bound costs nothing worth counting.
+pub const MAX_LOG_FILES: usize = 30;
+
+/// Prefix every log file shares, so the sweep can recognise its own
+/// files and leave anything else in the folder alone.
+const LOG_PREFIX: &str = "beanfun-";
+const LOG_SUFFIX: &str = ".log";
+
+/// Folder holding the log files, alongside `Config.xml`.
+pub fn logs_dir(storage_root: &Path) -> PathBuf {
+    storage_root.join("logs")
+}
+
+/// File name for a launch at `stamp` (`%Y%m%d-%H%M%S`) with process id
+/// `pid`.
+///
+/// The timestamp leads so a lexicographic sort is a chronological sort,
+/// which is what [`sweep_old_logs`] relies on.
+pub fn log_file_name(stamp: &str, pid: u32) -> String {
+    format!("{LOG_PREFIX}{stamp}-{pid}{LOG_SUFFIX}")
+}
+
+/// Delete all but the newest [`MAX_LOG_FILES`] of our log files.
+///
+/// Errors are swallowed by design: a locked file belongs to a running
+/// instance, and failing to tidy up is never worth failing a launch
+/// over. Returns how many files were removed (for tests and for the
+/// startup log line).
+pub fn sweep_old_logs(dir: &Path) -> usize {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return 0;
+    };
+
+    let mut ours: Vec<PathBuf> = entries
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with(LOG_PREFIX) && name.ends_with(LOG_SUFFIX))
+        })
+        .collect();
+
+    if ours.len() <= MAX_LOG_FILES {
+        return 0;
+    }
+
+    // Newest last (the timestamp prefix makes name order time order),
+    // so the excess to drop is the head of the list.
+    ours.sort();
+    let doomed = ours.len() - MAX_LOG_FILES;
+    ours.into_iter()
+        .take(doomed)
+        .filter(|path| std::fs::remove_file(path).is_ok())
+        .count()
+}
+
+/// Create the logs folder, sweep it, and open this launch's file.
+///
+/// Returns `None` when the folder or the file cannot be created — the
+/// caller then runs without file logging rather than failing to start.
+pub fn open_log_file(
+    storage_root: &Path,
+    stamp: &str,
+    pid: u32,
+) -> Option<(PathBuf, std::fs::File)> {
+    let dir = logs_dir(storage_root);
+    std::fs::create_dir_all(&dir).ok()?;
+    sweep_old_logs(&dir);
+
+    let path = dir.join(log_file_name(stamp, pid));
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .ok()?;
+    Some((path, file))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn touch(dir: &Path, name: &str) {
+        std::fs::write(dir.join(name), b"x").expect("write");
+    }
+
+    fn names(dir: &Path) -> Vec<String> {
+        let mut found: Vec<String> = std::fs::read_dir(dir)
+            .expect("read_dir")
+            .flatten()
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .collect();
+        found.sort();
+        found
+    }
+
+    #[test]
+    fn log_file_names_sort_chronologically() {
+        let earlier = log_file_name("20260809-064512", 4242);
+        let later = log_file_name("20260809-071500", 17);
+        assert!(earlier < later, "{earlier} should sort before {later}");
+    }
+
+    #[test]
+    fn a_folder_under_the_limit_is_left_alone() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        for i in 0..MAX_LOG_FILES {
+            touch(
+                dir.path(),
+                &log_file_name(&format!("20260809-0000{i:02}"), 1),
+            );
+        }
+        assert_eq!(sweep_old_logs(dir.path()), 0);
+        assert_eq!(names(dir.path()).len(), MAX_LOG_FILES);
+    }
+
+    #[test]
+    fn the_sweep_keeps_the_newest_and_drops_the_rest() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        for i in 0..(MAX_LOG_FILES + 5) {
+            touch(
+                dir.path(),
+                &log_file_name(&format!("20260809-0000{i:02}"), 1),
+            );
+        }
+
+        assert_eq!(sweep_old_logs(dir.path()), 5);
+
+        let left = names(dir.path());
+        assert_eq!(left.len(), MAX_LOG_FILES);
+        // The five oldest went; the newest survived. Derived from the
+        // constant so raising the retention cannot silently rot this.
+        assert_eq!(
+            left.first().map(String::as_str),
+            Some(log_file_name("20260809-000005", 1).as_str())
+        );
+        assert_eq!(
+            left.last().map(String::as_str),
+            Some(log_file_name(&format!("20260809-0000{:02}", MAX_LOG_FILES + 4), 1).as_str())
+        );
+    }
+
+    #[test]
+    fn the_sweep_ignores_files_that_are_not_ours() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        for i in 0..(MAX_LOG_FILES + 3) {
+            touch(
+                dir.path(),
+                &log_file_name(&format!("20260809-0000{i:02}"), 1),
+            );
+        }
+        touch(dir.path(), "Config.xml.bak");
+        touch(dir.path(), "notes.txt");
+
+        sweep_old_logs(dir.path());
+
+        let left = names(dir.path());
+        assert!(left.contains(&"Config.xml.bak".to_string()));
+        assert!(left.contains(&"notes.txt".to_string()));
+        assert_eq!(left.len(), MAX_LOG_FILES + 2);
+    }
+
+    #[test]
+    fn a_missing_folder_is_not_an_error() {
+        assert_eq!(sweep_old_logs(Path::new("Z:/definitely/not/here")), 0);
+    }
+
+    #[test]
+    fn opening_creates_the_folder_and_the_file() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let (path, _file) =
+            open_log_file(root.path(), "20260809-120000", 99).expect("opens a log file");
+
+        assert!(path.exists());
+        assert_eq!(path.parent(), Some(logs_dir(root.path()).as_path()));
+        assert_eq!(
+            path.file_name().and_then(|n| n.to_str()),
+            Some("beanfun-20260809-120000-99.log")
+        );
+    }
+}

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -14,6 +14,7 @@
 pub mod beanfun;
 pub mod config;
 pub mod game;
+pub mod logging;
 pub mod maple_cache;
 pub mod storage;
 pub mod system;

--- a/src-tauri/src/services/system/mod.rs
+++ b/src-tauri/src/services/system/mod.rs
@@ -22,10 +22,10 @@
 //! | Module         | Responsibility                                                    |
 //! | -------------- | ----------------------------------------------------------------- |
 //! | [`error`]      | `SystemError` — typed failures across the system service          |
-//! | [`mod@open_url`] | `open_url` — scheme-allowlisted wrapper over [`open::that`]     |
+//! | [`mod@open_url`] | `open_url` — scheme-allowlisted wrapper over [`open::that`]; `open_directory` — reveal a local folder |
 
 pub mod error;
 pub mod open_url;
 
 pub use error::SystemError;
-pub use open_url::open_url;
+pub use open_url::{open_directory, open_url};

--- a/src-tauri/src/services/system/open_url.rs
+++ b/src-tauri/src/services/system/open_url.rs
@@ -101,6 +101,30 @@ pub async fn open_url(url: &str) -> Result<(), SystemError> {
     .map_err(SystemError::SpawnBlockingFailed)?
 }
 
+/// Reveal a local directory in the OS file manager.
+///
+/// Separate from [`open_url`] on purpose: the scheme allowlist there
+/// exists to stop arbitrary strings reaching the shell, and a path is
+/// not a URL. Callers must pass a path *the app computed itself*, never
+/// one supplied by a page or a config value.
+///
+/// # Errors
+///
+/// - [`SystemError::OpenFailed`] — the OS opener returned an I/O error.
+/// - [`SystemError::SpawnBlockingFailed`] — the blocking task panicked
+///   or was cancelled.
+pub async fn open_directory(dir: &std::path::Path) -> Result<(), SystemError> {
+    let owned = dir.to_path_buf();
+    tokio::task::spawn_blocking(move || {
+        open::that(&owned).map_err(|source| SystemError::OpenFailed {
+            url: owned.display().to_string(),
+            source,
+        })
+    })
+    .await
+    .map_err(SystemError::SpawnBlockingFailed)?
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -485,6 +485,9 @@ const zhTW = {
     clearWebviewCacheConfirm:
       '這會清除 WebView2 的快取與縮放狀態，不會登出你的帳號。清理後建議重新啟動 Beanfun。要繼續嗎？',
     clearWebviewCacheDone: 'WebView2 快取已清理，建議重新啟動 Beanfun。',
+    openLogsFolder: '開啟記錄檔資料夾',
+    openLogsFolderTip:
+      '每次啟動會產生一個記錄檔，只保留最近 30 個。\n回報問題時附上最新一個，可省下大量來回猜測。\n內容只有程式自身的診斷訊息，不含帳號密碼。',
   },
   inAppBrowser: {
     fallbackToSystem: '此網址不在 Beanfun 內建瀏覽器允許清單，將改以系統預設瀏覽器開啟。',
@@ -773,6 +776,9 @@ const zhCN = {
     clearWebviewCacheConfirm:
       '这会清除 WebView2 的缓存与缩放状态，不会登出你的账号。清理后建议重新启动 Beanfun。要继续吗？',
     clearWebviewCacheDone: 'WebView2 缓存已清理，建议重新启动 Beanfun。',
+    openLogsFolder: '打开日志文件夹',
+    openLogsFolderTip:
+      '每次启动会产生一个日志文件，只保留最近 30 个。\n回报问题时附上最新一个，可省下大量来回猜测。\n内容只有程序自身的诊断信息，不含账号密码。',
   },
   inAppBrowser: {
     fallbackToSystem: '此网址不在 Beanfun 内建浏览器允许列表，将改以系统默认浏览器开启。',
@@ -1075,6 +1081,9 @@ const enUS = {
     clearWebviewCacheConfirm:
       'This clears the WebView2 cache and zoom state. It will not sign you out. A Beanfun restart is recommended afterwards. Continue?',
     clearWebviewCacheDone: 'WebView2 cache cleared. Restarting Beanfun is recommended.',
+    openLogsFolder: 'Open log folder',
+    openLogsFolderTip:
+      'Each launch writes one log file; the newest 30 are kept.\nAttaching the latest one to a bug report saves a lot of guesswork.\nIt holds diagnostics from the app itself — no account or password data.',
   },
   inAppBrowser: {
     fallbackToSystem:

--- a/src/pages/Settings.vue
+++ b/src/pages/Settings.vue
@@ -122,6 +122,7 @@ import {
   Brush,
   Clock,
   Delete,
+  Document,
   FolderOpened,
   InfoFilled,
   Operation,
@@ -703,6 +704,15 @@ async function handleClearWebviewCache(): Promise<void> {
   if (result.ok) ElMessage.success(t('settings.clearWebviewCacheDone'))
 }
 
+/**
+ * Reveal the log folder. Logs only help if a reporter can find them,
+ * and asking someone to paste `%APPDATA%\Beanfun\logs` into Explorer
+ * loses people who would otherwise have sent us the evidence.
+ */
+async function handleOpenLogsFolder(): Promise<void> {
+  await safeInvoke(commands.openLogsFolder())
+}
+
 /* --------------- mount --------------- */
 
 /* --------------- MapleStory Classic — NGM path fallback --------------- */
@@ -1169,6 +1179,20 @@ onMounted(() => {
               <el-icon><Delete /></el-icon>
               <span>{{ t('settings.clearWebviewCache') }}</span>
             </el-button>
+            <el-tooltip
+              placement="top"
+              popper-class="settings__tip-popper"
+              :content="t('settings.openLogsFolderTip')"
+            >
+              <el-button
+                class="bf-btn-secondary"
+                data-test="settings-open-logs"
+                @click="handleOpenLogsFolder"
+              >
+                <el-icon><Document /></el-icon>
+                <span>{{ t('settings.openLogsFolder') }}</span>
+              </el-button>
+            </el-tooltip>
           </div>
         </section>
 

--- a/src/types/bindings.ts
+++ b/src/types/bindings.ts
@@ -1370,6 +1370,27 @@ async clearWebview2Cache() : Promise<Result<null, CommandError>> {
 }
 },
 /**
+ * Reveal the folder holding this install's log files.
+ * 
+ * The whole point of writing logs to disk is that a user can attach
+ * one to a bug report, which they can only do if they can find it. The
+ * path is computed here from the storage root — never accepted from
+ * the frontend — so this cannot be turned into an arbitrary "open this
+ * path" primitive.
+ * 
+ * # Errors
+ * 
+ * - `system.open_failed` — the OS file manager could not be launched.
+ */
+async openLogsFolder() : Promise<Result<null, CommandError>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("open_logs_folder") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
  * Read a single config value by `key`, falling back to `""` when
  * the file is missing / unreadable / the key is absent.
  * 


### PR DESCRIPTION
## Why

`main.rs` sets `windows_subsystem = "windows"` for release builds, so there is no console and everything `tracing` writes to stderr goes nowhere. Every user report therefore arrived as prose — "I pressed the button and nothing happened" — and diagnosis was guesswork about a machine we cannot see. #356 took several rounds of that before the reporter happened to mention their hardware-acceleration setting, which turned out to be the entire answer.

The app already emits exactly the lines that would have cut it short:

```
ERROR tauri_runtime_wry: failed to create webview: HRESULT(0x8007139F)
INFO  classic: portal message: {"kind":"ready-timeout","state":"interactive","href":"…"}
WARN  webview_proxy::peer: refused a connection from another process pid=… image=…
```

They simply had nowhere to land.

## What

Tracing installs two layers over one filter: stderr as before, plus a file under `%APPDATA%\Beanfun\logs\`. The writer is non-blocking so a slow disk never stalls a traced call, and ANSI is off because the other end is a text file someone will paste into an issue.

**One file per launch**, named `beanfun-<timestamp>-<pid>.log`. Multi-instance use is normal here — #340 exists because people run eight launchers at once — and several processes appending to one file interleave their lines. The timestamp leads so a lexicographic sort is chronological, and a startup sweep keeps the newest 30 — sized for the multi-instance habit that #340 documents, where eight launchers a session would otherwise discard yesterday on this morning's first launch.

The sweep cannot hurt a live instance: Windows refuses to delete a file another process holds open, and the error is ignored. It also only ever considers files matching our own prefix, so nothing else in the folder is touched.

**Best-effort.** If the folder or file cannot be created, the stderr layer is installed alone and the app starts normally; the startup line says which of the two happened. The storage root now resolves *before* tracing initialises, since the log lives under it — nothing logs in between, as the resolver's only failure path is a fatal `eprintln!`.

**Settings → Maintenance gains an "open log folder" button**, because a log only helps if the reporter can find it. The command computes the path from the storage root and never accepts one from the frontend, so it cannot become a general "open this path" primitive.

## What is in the file

Only the app's own diagnostics — no account or password data. The tooltip says so, since we are asking users to send it to us.

## Keeping credentials out of the file

Writing logs to disk changed what a log line costs. It used to vanish into a suppressed console; now we ask users to send it to us, which in practice means pasting it into a public issue.

The first pass at this fixed the sites found by grepping for names I thought of, and was verified by a run that happened not to log in. Both were the wrong method — a live account id in `login::completed` shipped anyway and was caught on the first real login. So the sweep is now **mechanical**.

### The guard

A test walks every `tracing!` invocation in the source tree and fails when a field whose name denotes user data is bound to an unredacted expression. Parenthesis counting skips string literals so a message like `"portal running (visible=true)"` cannot unbalance the span scan, and only real tracing spans count — an earlier version of the test flagged a `format!` argument list in `otp.rs` that logs nothing. The escape hatch is a `redact-ok` comment, so an exception has to be written down rather than assumed.

It found eleven sites the manual sweep had missed.

### The seventeen sites

| Site | What leaked |
|---|---|
| intercepted `ngm://` launch | GamaPass session token, in the URL *path* |
| `auth_aspx: before request` | three web tokens verbatim, plus two in the cookie-changed warning |
| in-app browser open | target URL — member-centre and Gash URLs carry `web_token` in the query |
| session-key failure | the full redirected URL |
| `login::completed`, `check_account_type`, `tw_regular` ×4 | the beanfun account id |
| classic portal message | every raw message: game account ids, and an `href` for ready-timeout |
| 0-accounts diagnostic | 500 characters of account-list HTML |
| five login-step previews | raw response bodies |

### The rule

`core::redact`: **log enough to correlate, never enough to reuse.** `mask` keeps the first and last two characters plus the length, so two lines can still be compared — "same token as before?", "did it change across the request?", which is what these diagnostics were actually for — without the value being usable. Short values go wholesale, and slicing is by char so a multi-byte account name cannot be split mid-character. `redact_uri` keeps scheme/host/path for http(s) and drops query and fragment; for any other scheme it keeps only the scheme, because a custom-scheme URI puts its secret in the path.

The login body previews are the best field diagnostic we have for a login breaking in the wild, so they are **scrubbed rather than deleted**: credential parameters, every HTML `value="…"` attribute, emails, and any 20+ character token-alphabet run are masked, leaving the shape of the document readable. Masking `value` attributes wholesale rather than guessing which `name=` is a secret came out of a test — the first version matched `web_token=…` but sailed straight past `<input name="pSKey" value="…">`, which is exactly how ASP.NET pages carry `pSKey` and `__VIEWSTATE`.

Two diagnostics are worth keeping for development and not worth shipping — the raw portal message and the account-list HTML preview — so they sit behind `debug_assertions`, with release builds logging the message `kind` and the body length instead.

`redact_url_query` in `commands::auth` becomes a thin adapter over the shared helper so the rules live in one place. It also gains fragment stripping, which matters: `mltoken=login~<token>` arrives there.

### Verified

On a **release build** driven through a TW classic launch, scanning the whole log:

| check | hits |
|---|---|
| hex runs of 20+ chars | 0 |
| session tokens | 0 |
| `web_token=` / `pSKey=` values | 0 |
| email-shaped strings | 0 |
| account ids configured on the machine | 0 |

The portal line now reads `classic portal message kind=signin-clicked accounts=0`.

Test fixtures in `core::redact` are synthetic by construction — a redaction test must not be the thing that publishes a real value.

The codebase already redacted secrets in `Debug` output (`Session`, `Credentials`, `LaunchRequest`, entropy, totp_challenge); what leaked were the `Display` and format-string paths that bypassed those impls.

## Bundled dependency fixes

Both open advisories, both high, both transitive and dev-only — `nanoid` via vite → postcss, `js-yaml` via eslint → @eslint/eslintrc — so neither ships in the app. Patch bumps to `nanoid` 3.3.18 and `js-yaml` 4.3.1; `npm audit` is clean. This supersedes the standalone Dependabot PR for js-yaml.

## Verification

A plain launch with no environment variables:

```
2026-08-09T07:18:12.536612Z  INFO beanfun_lib: beanfun starting; logging to file version="6.0.10" pid=24280 path=…\logs\beanfun-20260809-151812-24280.log
2026-08-09T07:18:13.192702Z  INFO beanfun_lib::tray: system tray icon created (hidden until minimize-to-tray) step="Tray.Initialized"
```

Readable, ANSI-free, and a second concurrent instance wrote its own file rather than interleaving:

```
beanfun-20260809-151812-24280.log
beanfun-20260809-153008-19048.log
```

Plus 1071 Rust tests (6 new covering the sweep's retention, its indifference to foreign files, a missing folder, and file creation), 681 frontend tests, clippy clean under `-D warnings`.
