### PR TITLE
fix(window): stop the content-fit resizer re-applying what is already applied (#367)

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -574,6 +574,21 @@ export function installRouterGuards(router: Router, deps: RouterGuardDeps): void
   let currentWidth = 560
   let observer: ResizeObserver | null = null
 
+  /**
+   * Smallest zoom difference worth re-applying. Zoom is a ratio of
+   * measured pixel counts, so it carries float noise that must not read
+   * as a change.
+   */
+  const ZOOM_EPSILON = 0.001
+
+  /**
+   * The last size/zoom this resizer actually pushed to the OS window, or
+   * `null` when that is unknown (first fit, or an overlay resized the
+   * window itself). Guards `fitWindow` against re-applying what is
+   * already on screen — see the note where it is read.
+   */
+  let lastApplied: { w: number; h: number; zoom: number } | null = null
+
   /*
    * Track the OS window scale factor so `textScaleFactor()` can split
    * `devicePixelRatio` (= DPI scale × text scale × zoom) into its parts.
@@ -638,7 +653,14 @@ export function installRouterGuards(router: Router, deps: RouterGuardDeps): void
   function fitWindow(): void {
     // A full-window overlay (AnnouncementModal) may be holding the window
     // at a fixed larger size; don't snap it back to content height.
-    if (isWindowFitSuspended()) return
+    if (isWindowFitSuspended()) {
+      // The overlay resizes the window behind our back, so what we last
+      // applied is no longer what is on screen. Forget it, or the
+      // idempotence guard below would mistake the overlay's size for
+      // ours and skip the restoring fit.
+      lastApplied = null
+      return
+    }
     const root = document.querySelector('[data-window-root]') as HTMLElement | null
     if (!root) return
     // Temporarily disable overflow clipping so scrollHeight reflects
@@ -677,9 +699,41 @@ export function installRouterGuards(router: Router, deps: RouterGuardDeps): void
     const wLogical = Math.max(320, Math.round(naturalW * zoom * cssToLogical))
     const hLogical = Math.max(160, Math.round(naturalH * zoom * cssToLogical))
     root.style.height = '100vh'
-    void getCurrentWebview().setZoom(zoom)
-    setAppliedWebviewZoom(zoom)
-    void appWindow.setSize(new LogicalSize(wLogical, hLogical))
+
+    /*
+     * Apply nothing that is already applied.
+     *
+     * Every `setSize` / `setZoom` changes the viewport, which fires the
+     * ResizeObserver, which fits again. That is fine while the result
+     * converges — but the pipeline measures in CSS px and applies in
+     * rounded logical px, so a fixed point does not have to exist: a
+     * height that rounds to H can measure back as H±1, which re-applies,
+     * which measures back as H, forever. The window then jitters by a
+     * pixel several times a second for as long as the page is open,
+     * which is what issue #367 reports on the Settings page (its content
+     * only gets tall enough to land on such a boundary once logged in).
+     *
+     * Comparing against what we last applied breaks any such cycle: a
+     * genuine layout change still differs and still applies, while a
+     * rounding echo is dropped and the loop stops. The tolerance is one
+     * logical pixel because that is exactly the quantum the rounding can
+     * disagree by.
+     */
+    const zoomChanged = lastApplied === null || Math.abs(lastApplied.zoom - zoom) > ZOOM_EPSILON
+    const sizeChanged =
+      lastApplied === null ||
+      Math.abs(lastApplied.w - wLogical) > 1 ||
+      Math.abs(lastApplied.h - hLogical) > 1
+    if (!zoomChanged && !sizeChanged) return
+
+    lastApplied = { w: wLogical, h: hLogical, zoom }
+    if (zoomChanged) {
+      void getCurrentWebview().setZoom(zoom)
+      setAppliedWebviewZoom(zoom)
+    }
+    if (sizeChanged) {
+      void appWindow.setSize(new LogicalSize(wLogical, hLogical))
+    }
   }
 
   /**

--- a/tests/unit/router/windowAutoFit.spec.ts
+++ b/tests/unit/router/windowAutoFit.spec.ts
@@ -1,0 +1,130 @@
+/**
+ * Specs for the content-fit resizer's idempotence (issue #367).
+ *
+ * The resizer measures content in CSS px and applies the result in
+ * rounded logical px, so a fixed point is not guaranteed: a height that
+ * rounds to H can measure back as H±1. Re-applying that echo fires the
+ * ResizeObserver, which fits again, which re-applies — the window
+ * jitters by a pixel for as long as the page is open.
+ *
+ * These tests pin the guard that breaks the cycle: apply only what is
+ * not already applied.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const setSize = vi.fn()
+const setZoom = vi.fn()
+
+vi.mock('@tauri-apps/api/window', () => ({
+  getCurrentWindow: () => ({ setSize }),
+}))
+vi.mock('@tauri-apps/api/webview', () => ({
+  getCurrentWebview: () => ({ setZoom }),
+}))
+vi.mock('element-plus', () => ({ ElMessage: { error: vi.fn() } }))
+
+import { createAppRouter, installRouterGuards } from '../../../src/router'
+import { setWindowFitSuspended } from '../../../src/services/windowFit'
+
+/** Fires whatever the resizer observed, on demand. */
+let notifyResize: (() => void) | null = null
+
+/** Content height the fake `[data-window-root]` reports. */
+let contentHeight = 500
+
+function installDom(): void {
+  document.body.innerHTML = '<main data-window-root></main>'
+  const root = document.querySelector('[data-window-root]') as HTMLElement
+  Object.defineProperty(root, 'scrollHeight', { get: () => contentHeight, configurable: true })
+}
+
+beforeEach(() => {
+  setSize.mockClear()
+  setZoom.mockClear()
+  notifyResize = null
+  contentHeight = 500
+  setWindowFitSuspended(false)
+  installDom()
+
+  // Run scheduled work immediately so a fit is synchronous with the
+  // notification that triggered it.
+  vi.stubGlobal('requestAnimationFrame', ((cb: FrameRequestCallback) => {
+    cb(0)
+    return 1
+  }) as typeof requestAnimationFrame)
+  vi.stubGlobal('cancelAnimationFrame', () => {})
+  vi.stubGlobal(
+    'ResizeObserver',
+    class {
+      constructor(cb: () => void) {
+        notifyResize = cb
+      }
+      observe(): void {}
+      disconnect(): void {}
+    },
+  )
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  document.body.innerHTML = ''
+})
+
+async function install(): Promise<void> {
+  const router = createAppRouter()
+  installRouterGuards(router, { isAuthenticated: () => true, clearSession: () => {} })
+  await router.push('/settings')
+  await router.isReady()
+}
+
+describe('content-fit resizer idempotence (#367)', () => {
+  it('resizes once for a given content height, however often it is notified', async () => {
+    await install()
+    const afterFirstFit = setSize.mock.calls.length
+    expect(afterFirstFit).toBeGreaterThan(0)
+
+    // Every notification re-measures the same content. Without the
+    // guard each one issues another setSize, and each setSize provokes
+    // the next notification — the jitter loop.
+    for (let i = 0; i < 5; i += 1) notifyResize?.()
+
+    expect(setSize.mock.calls.length).toBe(afterFirstFit)
+  })
+
+  it('still resizes when the content genuinely changes', async () => {
+    await install()
+    const before = setSize.mock.calls.length
+
+    contentHeight = 900
+    notifyResize?.()
+
+    expect(setSize.mock.calls.length).toBeGreaterThan(before)
+  })
+
+  it('does not re-apply the same zoom', async () => {
+    await install()
+    const before = setZoom.mock.calls.length
+
+    for (let i = 0; i < 3; i += 1) notifyResize?.()
+
+    expect(setZoom.mock.calls.length).toBe(before)
+  })
+
+  it('re-applies after an overlay held the window at its own size', async () => {
+    await install()
+    const before = setSize.mock.calls.length
+
+    // While suspended the overlay resizes the window itself, so what we
+    // last applied is stale — the restoring fit must not be skipped as
+    // "already applied".
+    setWindowFitSuspended(true)
+    notifyResize?.()
+    expect(setSize.mock.calls.length).toBe(before)
+
+    setWindowFitSuspended(false)
+    notifyResize?.()
+
+    expect(setSize.mock.calls.length).toBeGreaterThan(before)
+  })
+})


### PR DESCRIPTION
Closes #367.

## Symptom

After logging in, opening Settings makes the window jitter continuously. Before logging in it is steady.

## Cause

The content-fit resizer measures content in **CSS px** and applies the result in **rounded logical px**. Every `setSize` / `setZoom` changes the viewport, which fires the `ResizeObserver`, which fits again.

That converges only if a fixed point exists, and rounding does not guarantee one: a height that rounds to `H` can measure back as `H±1`, which re-applies, which measures back as `H` — forever. The window shifts by a pixel several times a second for as long as the page is open.

Settings is where it shows because its content only gets tall enough to land on such a boundary once the game and classic sections render, which needs a session. Hence "only after login".

## Fix

`fitWindow` compares the computed size and zoom against what it last pushed, and applies neither when both are unchanged — tolerance one logical pixel, exactly the quantum the rounding can disagree by. A real layout change still differs and still applies; a rounding echo is dropped and the loop stops.

The cache is invalidated while the fit is **suspended**: `AnnouncementModal` resizes the window itself in that window of time, so what we last applied is no longer what is on screen and the restoring fit must not be skipped as "already applied".

## Tests

Four specs, each **confirmed to fail with the guard removed** rather than merely passing with it present:

| spec | with guard | guard removed |
|---|---|---|
| repeated notifications, unchanged content → resize once | pass | **fail** |
| genuine height change still resizes | pass | pass |
| same zoom is not re-applied | pass | **fail** |
| fit after overlay suspension applies again | pass | pass |

685 frontend tests, typecheck / lint / prettier clean.

## What is not verified

Not reproduced against the reporter's own case: that needs a logged-in session. Driving the Settings page unauthenticated stays stable even with content parked exactly on the 95%-of-work-area boundary, and injecting oversized content converges too.

This fixes the mechanism that produces this symptom. If the jitter survives it, the cause is elsewhere — the next step would be tracing each fit's measurement into the log file (6.0.11 ships one), so the reporter's run reports the numbers instead of us guessing.
