### PR TITLE
fix(ui): stop the scroll hint animating forever while the app sits idle (#370)

### DIFF
--- a/src/pages/AccountList.vue
+++ b/src/pages/AccountList.vue
@@ -3154,8 +3154,29 @@ onBeforeUnmount(() => {
   z-index: 1;
 }
 
+/*
+ * #370: the bounce runs a fixed number of times, not forever.
+ *
+ * `v-if` keeps this element mounted for as long as the list is
+ * scrollable and not at the bottom — i.e. the whole time a user with
+ * more than a screenful of accounts sits idle. An `infinite` animation
+ * there never lets the compositor go to sleep: measured on an otherwise
+ * idle window, one such animation took the process tree from 0.009% to
+ * 0.451% of total CPU, and kept the GPU busy alongside it.
+ *
+ * Six iterations is nine seconds of motion, which is all the affordance
+ * needs — and because `v-if` recreates the element, the bounce replays
+ * every time the hint reappears, which is exactly when the user has
+ * scrolled and might need telling again.
+ */
 .account-list__scroll-hint svg {
-  animation: account-list__scroll-hint-bounce 1.5s ease-in-out infinite;
+  animation: account-list__scroll-hint-bounce 1.5s ease-in-out 6;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .account-list__scroll-hint svg {
+    animation: none;
+  }
 }
 
 @keyframes account-list__scroll-hint-bounce {


### PR DESCRIPTION
Closes #370.

## Symptom

After logging in and going idle, the app holds 1–2% CPU **and GPU**.

## Cause

GPU usage while nothing moves means something is still being composited every frame. The account list has exactly one animation that is neither a spinner nor gated on transient state: the "there is more below" **scroll hint**, whose bounce is `infinite`.

Its `v-if` keeps it mounted for as long as the list is scrollable and not scrolled to the bottom — for anyone with more than a screenful of accounts, that is the entire time they sit idle. The compositor never gets to sleep.

## Measured

On an otherwise idle window, summing CPU time across the whole process tree (`beanfun.exe` + its WebView2 children) over 15 s and normalising by core count:

| state | CPU |
|---|---|
| idle, no animation | **0.009 %** |
| one infinite CSS animation | **0.451 %** |
| finite animation, after it finishes | **0.004 %** |

Fifty times the idle cost, from one small bounce — and the third row is the fix measured the same way, back at the noise floor.

## Fix

Six iterations instead of `infinite`: nine seconds of motion, which is all the affordance needs. Because `v-if` recreates the element, the bounce **replays every time the hint reappears** — precisely when the user has scrolled and might need telling again. `prefers-reduced-motion: reduce` now disables it outright.

The other three infinite animations are spinners bound to transient state (`refreshing`, and the two loading views), so they stop on their own; left alone.

## Checks

685 frontend tests, typecheck / lint / prettier clean.
