### PR TITLE
fix(otp): restore TW password retrieval via get_webstart_otp_v2 (#368)

### DIFF
--- a/docs/OTP-PROTOCOL-CHANGE.md
+++ b/docs/OTP-PROTOCOL-CHANGE.md
@@ -246,21 +246,48 @@ Two traps for the CI job:
   change as a manual review item — it should be rare, and it will
   announce itself as a decode failure.
 
-## Open question — blocks implementation
+## Where `Data` comes from — confirmed
 
-**Where does the page get `Data`?** `ggm.js` only defines the
-interface; the call site lives in an authenticated page (`loader.ashx`
-returns `_bf_IsInitOK = false` without a session), and the URI itself
-never crosses the network. The plaintext fields
-(`ServiceCode` / `ServiceRegion` / `ServiceAccount`) say it is
-per-launch and server-issued, so it is very likely embedded in
-`game_start_step2.aspx` — **which step 1 already downloads**. If so the
-fix needs a new scrape, not a new request.
+`game_start_step2.aspx` — **the page step 1 already downloads**. So the
+fix needs a new scrape, not a new request. The literal:
 
-To confirm, from a logged-in session: find `Data` in the
-`game_start_step2.aspx` response, or read the JS that calls
-`ggm.LaunchGame(...)` / `ggm.SmartLaunch(...)` and quote how the
-object's `data` property is built.
+```javascript
+var m_objData = {
+    "region": "TW;Production",
+    "sn": "<36-char GUID>",
+    "data": "<537 characters>"
+};
+
+function LaunchGame() {
+    if (supportService.indexOf(MyAccountData.ServiceCode) > -1) {
+        parent.GGM.SmartLaunch(m_objData, …);   // Cmd=06006
+    } else {
+        parent.GGM.LaunchGame(m_objData, …);    // Cmd=06004
+    }
+}
+```
+
+Three things worth noting:
+
+- `region` is the literal `TW;Production`, not `TW`.
+- There is **no** `webToken` or `secretCode` property, so `ggm.js`
+  takes its `else` branch and the handoff URI is only
+  `Region&SN&Cmd&Data`. Those two values never reach the launcher.
+- `supportService` is a hardcoded service-code allowlist that picks
+  `SmartLaunch` over `LaunchGame`; `610074` (MapleStory TW) is in it.
+
+The observed `data` length of 537 satisfies the decoder's arithmetic:
+`537 - 1 - 8 = 528` hex characters = 264 bytes = 33 whole DES blocks.
+The upstream sample's 553 gives 272 bytes = 34 blocks. Two independent
+captures landing exactly on the block boundary is good evidence the
+format is understood.
+
+## Remaining work
+
+1. ~~Decode `Data` → `LaunchTicket`~~ — `core::launch_data`.
+2. Scrape `m_objData` out of step 1's response.
+3. Source `CV` / `Hash` (see above) and `arch`.
+4. `POST` the v2 payload and read the OTP from `data` in the reply.
 
 ## What has already been fixed
 

--- a/docs/OTP-PROTOCOL-CHANGE.md
+++ b/docs/OTP-PROTOCOL-CHANGE.md
@@ -282,12 +282,29 @@ The upstream sample's 553 gives 272 bytes = 34 blocks. Two independent
 captures landing exactly on the block boundary is good evidence the
 format is understood.
 
-## Remaining work
+## Status
 
-1. ~~Decode `Data` → `LaunchTicket`~~ — `core::launch_data`.
-2. Scrape `m_objData` out of step 1's response.
-3. Source `CV` / `Hash` (see above) and `arch`.
-4. `POST` the v2 payload and read the OTP from `data` in the reply.
+Implemented, **not yet run against a live server**:
+
+1. `core::launch_data::decode_launch_ticket` — decodes the blob.
+2. `parse_launch_handoff` — scrapes `m_objData` from step 1's response.
+3. `GGM_CV` / `GGM_DLL_SHA256` / `GGM_ARCH` — pinned in
+   `services::beanfun::otp`.
+4. `step_5_post_otp_v2` — posts the payload and decrypts the reply's
+   `data`.
+
+`get_otp` selects the path on whether step 1's page carries
+`m_objData`, so HK keeps the legacy endpoint and a later HK migration
+needs no code change.
+
+### The one unverified assumption
+
+The reply's `data` is treated as the same `{8-char key}{ciphertext
+hex}` envelope the pre-v2 protocol used. The observed length of 40 is
+exactly 8 + 32 hex = 8 + two DES blocks, which is why — but no
+plaintext OTP has been seen to confirm it. If the assumption is wrong
+the symptom will be `auth.otp_decryption_failed`, or an OTP that comes
+out as mojibake, rather than a silent wrong answer.
 
 ## What has already been fixed
 

--- a/docs/OTP-PROTOCOL-CHANGE.md
+++ b/docs/OTP-PROTOCOL-CHANGE.md
@@ -1,0 +1,153 @@
+# OTP protocol change — `get_webstart_otp.ashx` is dead
+
+**Status**: investigated, not yet fixed. Captured 2026-08-17 against `tw.beanfun.com`.
+
+`commands::get_otp` fails with `auth.otp_server_rejected`. The server
+returns:
+
+```
+0;        Query String Error
+```
+
+(28 bytes: `0;`, eight spaces, then the message — the server reuses the
+success envelope's 8-character key slot, blanked, for errors.)
+
+Nothing on our side is malformed. Beanfun replaced the endpoint.
+
+## Root cause
+
+`services::beanfun::otp` is a 1:1 port of the WPF client's OTP chain.
+Step 5 of that chain no longer exists in the form we call it:
+
+| | what we send | what the official client sends |
+|---|---|---|
+| endpoint | `generic_handlers/get_webstart_otp.ashx` | `generic_handlers/get_webstart_otp_v2.ashx` |
+| method | `GET` | `POST` |
+| params | 9 query-string fields | JSON body |
+| response | `1;{key}{cipher_hex}` text | `application/json` |
+
+New contract:
+
+```
+POST /beanfun_block/generic_handlers/get_webstart_otp_v2.ashx
+Content-Type: application/json
+
+{ "SN": <36>, "LaunchTicket": <64>, "CV": <7>, "Hash": <64>, "arch": <3> }
+
+→ { "result": 1, "data": <40>, "message": null }
+```
+
+Of our nine parameters only `SN` survives. `WebToken`, `SecretCode`,
+`ServiceCode`, `ServiceRegion`, `ServiceAccount`, `CreateTime`, `d` and
+the mystery `ppppp` constant are all gone. The OTP now arrives in
+`data` (40 characters) instead of a DES-ECB envelope.
+
+## The real change: the browser no longer fetches the OTP at all
+
+`beanfun_block/game_zone/scripts/ggm.js` hands off to a locally
+installed native helper (GGM — 遊戲橘子遊戲管理員, `GGMSetup_1.5.0.2.exe`,
+17 MB) through a custom URL scheme:
+
+```
+gamaniagames://Region={0}&&&&SN={1}&&&&Cmd=06004&&&&WebToken={2}&&&&SecretCode={3}&&&&Data={4}
+```
+
+| `Cmd` | ggm.js function | carries WebToken/SecretCode |
+|---|---|---|
+| `06003` | `OpenSelect` | no |
+| `06004` | `LaunchGame` | **yes** |
+| `06005` | `OpenDownloader` | no |
+| `06006` | `SmartLaunch` | **yes** |
+
+Both token-carrying variants fall back to a `Data`-only form when
+`webToken`/`secretCode` are absent.
+
+GGM then performs the rest itself (all observed in the capture):
+
+1. `generic_handlers/CheckVersion.ashx` → `{ url, version }`
+2. `generic_handlers/adapter.ashx?cmd&d` → full GameInfo.ini (utf-16, ~25 KB)
+3. `generic_handlers/adapter.ashx?cmd&service_code&service_region&d&CV&Hash&arch`
+   → per-game GameInfo.ini (utf-16, ~2 KB)
+4. `generic_handlers/adapter.ashx?cmd&sn&result&d` → empty
+5. `POST get_webstart_otp_v2.ashx` → the OTP
+6. launches the game with the OTP on its command line
+
+So `WebToken` and `SecretCode` — the two values we currently put in
+step 5's query string — are now *inputs handed to GGM*, not parameters
+of the OTP call.
+
+`CV` and `Hash` are **not** an integrity gate: the per-game
+GameInfo.ini declares `Version=2.1.1.2`, exactly the 7 characters sent
+as `CV`, and `Hash` is 64 hex. They are cache revalidation for that
+file, and we could compute them ourselves.
+
+## Blocker: `LaunchTicket`
+
+`LaunchTicket` (64 characters) is derived inside GGM from
+`WebToken` / `SecretCode` / `SN`. It is never transmitted — every
+response in a 665-entry capture was checked and none contains a
+64-character value. Reproducing it means reverse-engineering the GGM
+binary.
+
+## Chosen approach: let GGM fetch the OTP, intercept the result
+
+The OTP still reaches the game as **command-line arguments**. The
+per-game GameInfo.ini gives the launch template:
+
+```
+exe=MapleStory.exe tw.login.maplestory.beanfun.com 8484 BeanFun %s %s
+```
+
+The two `%s` are the account and the OTP. A long-standing community
+trick (documented since 2013) exploits exactly this: replace the game
+executable with a shim that prints its own `argv`. In C# `args`
+(program name excluded) that is `args[3]` = account, `args[4]` = OTP —
+which independently confirms the template above.
+
+The plan, which avoids reverse-engineering `LaunchTicket` while keeping
+the "show / copy / auto-paste OTP" feature:
+
+1. Log in as we already do; keep `region`, `sn`, `webToken`, `secretCode`.
+2. Invoke `gamaniagames://…&Cmd=06004&…` so the *official* GGM runs the
+   `LaunchTicket` + `get_webstart_otp_v2` sequence.
+3. Point Beanfun's configured game path at a shim executable we ship.
+4. The shim receives `argv[3]` / `argv[4]` and hands them back to the
+   main app.
+5. The app displays / copies / auto-pastes as before.
+
+Cost: GGM must be installed, and we gain a second executable plus a
+path-configuration step.
+
+Benefit: protocol-independent. Whatever Gamania changes server-side,
+the OTP still ends up on that command line — which is why the 2013
+trick still works today.
+
+## Open question — blocks implementation
+
+**What goes in `Data={4}`?** `ggm.js` only defines the interface; the
+call site lives in an authenticated page (`loader.ashx` returns
+`_bf_IsInitOK = false` without a session). The URI never crosses the
+network, so it is not in any capture. Until its format is known, the
+URI builder cannot be written.
+
+To recover it, from a logged-in session: read the JS that calls
+`ggm.LaunchGame(...)` / `ggm.SmartLaunch(...)` on
+`beanfun_block/game_zone/game_start_step2.aspx`, and quote how the
+object's `data` property is built.
+
+## What has already been fixed
+
+- `b2647bb` — the scrapers no longer forward empty captures, so an
+  upstream failure is reported at its own step instead of surfacing as
+  a generic step 5 rejection. Real bug, unrelated to this one.
+- `b90237c` — the seven `errors.auth.otp_*` codes are localized; they
+  used to fall through to the raw English backend message.
+- `9fd548e` — step 5 failures log the verbatim server response and a
+  redacted request URL, which is how this was diagnosed.
+
+## Evidence
+
+Fiddler Classic capture of the official client, 665 entries,
+summarized with a redacting script (parameter names and value lengths
+only). Key entries: `get_webstart_otp_v2.ashx`, the three
+`adapter.ashx` calls, `CheckVersion.ashx`, and `ggm.js`.

--- a/docs/OTP-PROTOCOL-CHANGE.md
+++ b/docs/OTP-PROTOCOL-CHANGE.md
@@ -19,12 +19,12 @@ Nothing on our side is malformed. Beanfun replaced the endpoint.
 `services::beanfun::otp` is a 1:1 port of the WPF client's OTP chain.
 Step 5 of that chain no longer exists in the form we call it:
 
-| | what we send | what the official client sends |
-|---|---|---|
+|          | what we send                             | what the official client sends              |
+| -------- | ---------------------------------------- | ------------------------------------------- |
 | endpoint | `generic_handlers/get_webstart_otp.ashx` | `generic_handlers/get_webstart_otp_v2.ashx` |
-| method | `GET` | `POST` |
-| params | 9 query-string fields | JSON body |
-| response | `1;{key}{cipher_hex}` text | `application/json` |
+| method   | `GET`                                    | `POST`                                      |
+| params   | 9 query-string fields                    | JSON body                                   |
+| response | `1;{key}{cipher_hex}` text               | `application/json`                          |
 
 New contract:
 
@@ -52,12 +52,12 @@ installed native helper (GGM — 遊戲橘子遊戲管理員, `GGMSetup_1.5.0.2.
 gamaniagames://Region={0}&&&&SN={1}&&&&Cmd=06004&&&&WebToken={2}&&&&SecretCode={3}&&&&Data={4}
 ```
 
-| `Cmd` | ggm.js function | carries WebToken/SecretCode |
-|---|---|---|
-| `06003` | `OpenSelect` | no |
-| `06004` | `LaunchGame` | **yes** |
-| `06005` | `OpenDownloader` | no |
-| `06006` | `SmartLaunch` | **yes** |
+| `Cmd`   | ggm.js function  | carries WebToken/SecretCode |
+| ------- | ---------------- | --------------------------- |
+| `06003` | `OpenSelect`     | no                          |
+| `06004` | `LaunchGame`     | **yes**                     |
+| `06005` | `OpenDownloader` | no                          |
+| `06006` | `SmartLaunch`    | **yes**                     |
 
 Both token-carrying variants fall back to a `Data`-only form when
 `webToken`/`secretCode` are absent.
@@ -73,14 +73,14 @@ GGM then performs the rest itself (all observed in the capture):
 6. launches the game with the OTP on its command line
 
 So `WebToken` and `SecretCode` — the two values we currently put in
-step 5's query string — are now *inputs handed to GGM*, not parameters
+step 5's query string — are now _inputs handed to GGM_, not parameters
 of the OTP call.
 
 ## `LaunchTicket` — it is inside `Data`, not computed by GGM
 
 Reverse engineering by @takidog on
 [pungin/Beanfun#368](https://github.com/pungin/Beanfun/issues/368)
-settles this. GGM does **not** derive `LaunchTicket`; it *decrypts* it
+settles this. GGM does **not** derive `LaunchTicket`; it _decrypts_ it
 out of the `Data` field the web page already hands over. So the value
 does reach us — obfuscated — and no binary needs to be reimplemented
 to get it.
@@ -91,7 +91,7 @@ to get it.
 2. Drop that character.
 3. Pick substitution table `n % 4`.
 4. Map each character to its index in the table, emitted as a hex
-   digit — call the result the *normalized hex*.
+   digit — call the result the _normalized hex_.
 5. The 8 characters at offset `n + 1` are the DES key (ASCII).
 6. Remove those 8 characters; the remainder is the ciphertext hex.
 7. DES-ECB decrypt, `Padding = None`.
@@ -201,7 +201,7 @@ The plan, which avoids reverse-engineering `LaunchTicket` while keeping
 the "show / copy / auto-paste OTP" feature:
 
 1. Log in as we already do; keep `region`, `sn`, `webToken`, `secretCode`.
-2. Invoke `gamaniagames://…&Cmd=06004&…` so the *official* GGM runs the
+2. Invoke `gamaniagames://…&Cmd=06004&…` so the _official_ GGM runs the
    `LaunchTicket` + `get_webstart_otp_v2` sequence.
 3. Point Beanfun's configured game path at a shim executable we ship.
 4. The shim receives `argv[3]` / `argv[4]` and hands them back to the

--- a/docs/OTP-PROTOCOL-CHANGE.md
+++ b/docs/OTP-PROTOCOL-CHANGE.md
@@ -76,23 +76,116 @@ So `WebToken` and `SecretCode` — the two values we currently put in
 step 5's query string — are now *inputs handed to GGM*, not parameters
 of the OTP call.
 
-`CV` and `Hash` are **not** an integrity gate: the per-game
-GameInfo.ini declares `Version=2.1.1.2`, exactly the 7 characters sent
-as `CV`, and `Hash` is 64 hex. They are cache revalidation for that
-file, and we could compute them ourselves.
+## `LaunchTicket` — it is inside `Data`, not computed by GGM
 
-## Blocker: `LaunchTicket`
+Reverse engineering by @takidog on
+[pungin/Beanfun#368](https://github.com/pungin/Beanfun/issues/368)
+settles this. GGM does **not** derive `LaunchTicket`; it *decrypts* it
+out of the `Data` field the web page already hands over. So the value
+does reach us — obfuscated — and no binary needs to be reimplemented
+to get it.
 
-`LaunchTicket` (64 characters) is derived inside GGM from
-`WebToken` / `SecretCode` / `SN`. It is never transmitted — every
-response in a 665-entry capture was checked and none contains a
-64-character value. Reproducing it means reverse-engineering the GGM
-binary.
+`GGMWebStart.Command.DecryptParam()`:
 
-## Chosen approach: let GGM fetch the OTP, intercept the result
+1. `n = int(data[0], 16)` — first character, as a hex digit.
+2. Drop that character.
+3. Pick substitution table `n % 4`.
+4. Map each character to its index in the table, emitted as a hex
+   digit — call the result the *normalized hex*.
+5. The 8 characters at offset `n + 1` are the DES key (ASCII).
+6. Remove those 8 characters; the remainder is the ciphertext hex.
+7. DES-ECB decrypt, `Padding = None`.
+8. UTF-8 decode, strip trailing `\0`.
+9. Split on `;`, then parse `key=value` pairs joined by `&`.
 
-The OTP still reaches the game as **command-line arguments**. The
-per-game GameInfo.ini gives the launch template:
+The four hardcoded tables:
+
+```text
+0: bac987d65e432f10
+1: 3bc4d5e6f2a79108
+2: cdbeaf9012456378
+3: 4e6fb81a3c5d7092
+```
+
+Each is a complete permutation of the 16 hex digits — verified, and a
+prerequisite for step 4 to be well defined.
+
+The sample in that issue is internally consistent: `len(Data) = 553`,
+selector `5` → table 1, key offset 6, ciphertext 544 hex = 272 bytes
+(a multiple of the 8-byte DES block), plaintext 266 bytes after
+stripping six NULs.
+
+Decrypted plaintext:
+
+```text
+LaunchTicket=<64 hex>
+ServiceCode=<6>
+ServiceRegion=<2>
+ServiceAccount=<20>
+BeanfunUrl=<URL>
+WebStartPatch=<URL>
+;<5 hex>
+```
+
+**Steps 5–8 are already implemented here.** `core::wcdes::decrypt_hex`
+takes an 8-character ASCII key plus hex ciphertext and runs DES-ECB
+with no padding — exactly this. It is the same construction the old
+step 6 used (`payload.split_at(8)`), now wrapped in a substitution
+layer. Only steps 1–4 and 9 are new code.
+
+## What still needs GGM: `CV` and `Hash`
+
+Correcting an earlier guess in this document — these are not cache
+revalidation:
+
+- `CV` = the **.NET assembly version** of `GGMWebStart.dll`
+  (`Assembly.GetExecutingAssembly().GetName().Version`), not the PE
+  file version and not the GameInfo.ini version it coincidentally
+  matches in length.
+- `Hash` = SHA-256 of `GGMWebStart.dll`'s bytes, lowercase hex,
+  computed at runtime. Not a constant in the binary.
+- `arch` = `Environment.Is64BitProcess` → `x64` / `x86`.
+
+This pair is a **client-attestation gate**: the server is asking the
+caller to prove it is running the official launcher. Sending it from
+anything else is asserting an identity we do not have. It is also the
+part most likely to be tightened later (per-build salting, obfuscation,
+signing), so treat any automation around it as load-bearing but
+fragile.
+
+The upstream launcher path is:
+`C:\Program Files\gamania Games\gamania Games Manager\GGMWebStart.exe`,
+version 1.5.0.2.
+
+## The `adapter.ashx` command codes
+
+Static analysis of GGM gives the numeric `cmd` values behind the
+five-character parameter observed in the capture:
+
+```text
+GET  /generic_handlers/adapter.ashx?cmd=01004&d=<TickCount>
+GET  /generic_handlers/adapter.ashx?cmd=01003&service_code=…&service_region=…&d=…&CV=…&Hash=…&arch=…
+GET  /generic_handlers/adapter.ashx?cmd=06002&sn=…&result=…&d=<TickCount>
+POST /beanfun_block/generic_handlers/get_webstart_otp_v2.ashx
+```
+
+## Two ways forward
+
+### A. No GGM — decode `Data` ourselves
+
+Now the preferred route. We already fetch `game_start_step2.aspx` in
+step 1, and `Data` is a page-supplied value, so it is likely already in
+a response we hold; that needs confirming (see the open question).
+Then: decode `LaunchTicket` per the algorithm above, and `POST` the v2
+payload ourselves.
+
+Remaining dependency is only `CV` + `Hash`, which are properties of a
+GGM release rather than of the session — see "Keeping CV/Hash current".
+
+### B. Delegate to GGM and intercept the OTP
+
+Kept as a fallback. The OTP still reaches the game as **command-line
+arguments**; the per-game GameInfo.ini gives the launch template:
 
 ```
 exe=MapleStory.exe tw.login.maplestory.beanfun.com 8484 BeanFun %s %s
@@ -122,17 +215,51 @@ Benefit: protocol-independent. Whatever Gamania changes server-side,
 the OTP still ends up on that command line — which is why the 2013
 trick still works today.
 
+## Keeping `CV` / `Hash` current
+
+They change only when Gamania ships a new GGM — a handful of times a
+year. `CheckVersion.ashx` returns `{ url, version }` in 80 bytes and is
+the natural change detector.
+
+Recommended shape: **detect in CI, ship in a release.** A scheduled job
+polls `CheckVersion.ashx`; on a version change it downloads the
+installer, extracts `GGMWebStart.dll` (`7z x`), computes the SHA-256,
+reads the assembly version, and opens a PR bumping two constants. The
+app carries them as constants — no runtime dependency, no extra request
+on the OTP path, and every change is reviewable in git history.
+
+The alternative floated upstream — publish the values to GitHub Pages
+and have the launcher fetch them at runtime — trades a release cycle
+for a permanent network dependency inside the auth path, gives every
+user the same single point of failure with no rollback through the
+normal release channel, and adds latency to each OTP fetch. For a value
+that changes three times a year that is a poor trade. If runtime
+refresh is wanted anyway, fetch with a fallback to the baked-in
+constant, cache for a day, and never let it block the OTP call.
+
+Two traps for the CI job:
+
+- `CV` is the **managed assembly version**, which can differ from the
+  PE `VERSIONINFO`. Read the .NET metadata, not just the file version.
+- The four substitution tables live inside the DLL. Hash and version
+  automate cleanly; extracting the tables does not. Treat an algorithm
+  change as a manual review item — it should be rare, and it will
+  announce itself as a decode failure.
+
 ## Open question — blocks implementation
 
-**What goes in `Data={4}`?** `ggm.js` only defines the interface; the
-call site lives in an authenticated page (`loader.ashx` returns
-`_bf_IsInitOK = false` without a session). The URI never crosses the
-network, so it is not in any capture. Until its format is known, the
-URI builder cannot be written.
+**Where does the page get `Data`?** `ggm.js` only defines the
+interface; the call site lives in an authenticated page (`loader.ashx`
+returns `_bf_IsInitOK = false` without a session), and the URI itself
+never crosses the network. The plaintext fields
+(`ServiceCode` / `ServiceRegion` / `ServiceAccount`) say it is
+per-launch and server-issued, so it is very likely embedded in
+`game_start_step2.aspx` — **which step 1 already downloads**. If so the
+fix needs a new scrape, not a new request.
 
-To recover it, from a logged-in session: read the JS that calls
-`ggm.LaunchGame(...)` / `ggm.SmartLaunch(...)` on
-`beanfun_block/game_zone/game_start_step2.aspx`, and quote how the
+To confirm, from a logged-in session: find `Data` in the
+`game_start_step2.aspx` response, or read the JS that calls
+`ggm.LaunchGame(...)` / `ggm.SmartLaunch(...)` and quote how the
 object's `data` property is built.
 
 ## What has already been fixed

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -161,6 +161,10 @@ windows = { version = "0.58", features = [
   "Win32_Graphics_Gdi",
   "Win32_Security",
   "Win32_Security_Cryptography",
+  # GetFileVersionInfoW / VerQueryValueW — reads the installed Gamania Games
+  # Manager's FileVersion for the `CV` client-integrity parameter beanfun's
+  # OTP endpoint now demands (`services::beanfun::client_integrity`).
+  "Win32_Storage_FileSystem",
   "Win32_System_Threading",
   "Win32_System_ProcessStatus",
   "Win32_UI_Input_KeyboardAndMouse",

--- a/src-tauri/src/core/launch_data.rs
+++ b/src-tauri/src/core/launch_data.rs
@@ -139,7 +139,11 @@ fn decode(data: &str) -> Result<String, LaunchDataError> {
     }
 
     let key = &normalized[offset..offset + KEY_LEN];
-    let cipher_hex = format!("{}{}", &normalized[..offset], &normalized[offset + KEY_LEN..]);
+    let cipher_hex = format!(
+        "{}{}",
+        &normalized[..offset],
+        &normalized[offset + KEY_LEN..]
+    );
 
     let plaintext = decrypt_hex(&cipher_hex, key)?;
     Ok(plaintext.trim_matches('\0').to_owned())
@@ -155,12 +159,7 @@ mod tests {
     fn encode(selector: usize, key: &str, cipher_hex: &str) -> String {
         let table: Vec<char> = TABLES[selector % TABLES.len()].chars().collect();
         let offset = selector + 1;
-        let normalized = format!(
-            "{}{}{}",
-            &cipher_hex[..offset],
-            key,
-            &cipher_hex[offset..]
-        );
+        let normalized = format!("{}{}{}", &cipher_hex[..offset], key, &cipher_hex[offset..]);
         let body: String = normalized
             .chars()
             .map(|c| table[c.to_digit(16).expect("normalized hex") as usize])
@@ -183,7 +182,9 @@ mod tests {
             chars.dedup();
             assert_eq!(chars.len(), 16, "table {i} has duplicate characters");
             assert!(
-                chars.iter().all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()),
+                chars
+                    .iter()
+                    .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()),
                 "table {i} holds a non-lowercase-hex character"
             );
         }
@@ -227,7 +228,10 @@ mod tests {
 
     #[test]
     fn empty_input_is_rejected() {
-        assert_eq!(decode_launch_ticket("").unwrap_err(), LaunchDataError::Empty);
+        assert_eq!(
+            decode_launch_ticket("").unwrap_err(),
+            LaunchDataError::Empty
+        );
     }
 
     #[test]
@@ -252,6 +256,9 @@ mod tests {
     fn blob_too_short_for_a_key_is_rejected() {
         // Table 0 characters only, but far fewer than offset + 8.
         let err = decode_launch_ticket("0bac").unwrap_err();
-        assert!(matches!(err, LaunchDataError::TooShort { .. }), "got {err:?}");
+        assert!(
+            matches!(err, LaunchDataError::TooShort { .. }),
+            "got {err:?}"
+        );
     }
 }

--- a/src-tauri/src/core/launch_data.rs
+++ b/src-tauri/src/core/launch_data.rs
@@ -1,0 +1,257 @@
+//! Decoder for the `Data` blob on Beanfun's game-start page.
+//!
+//! `game_start_step2.aspx` embeds a `m_objData` literal:
+//!
+//! ```javascript
+//! var m_objData = {
+//!     "region": "TW;Production",
+//!     "sn": "<36-char GUID>",
+//!     "data": "<obfuscated blob>"
+//! };
+//! ```
+//!
+//! and hands it to the native launcher over the `gamaniagames://` URL
+//! scheme. `data` carries the `LaunchTicket` that
+//! `get_webstart_otp_v2.ashx` requires — obfuscated, but present, so
+//! the value can be recovered without the launcher being installed.
+//! See `docs/OTP-PROTOCOL-CHANGE.md` for how this was established.
+//!
+//! # Format
+//!
+//! 1. The first character is a hex digit `n`, selecting substitution
+//!    table `n % 4`.
+//! 2. Every remaining character is mapped to its **index** in that
+//!    table and re-emitted as a hex digit — the *normalized hex*.
+//! 3. The 8 characters at offset `n + 1` of the normalized hex are the
+//!    DES key, as ASCII.
+//! 4. Removing those 8 leaves the ciphertext hex.
+//! 5. DES-ECB, no padding, then trailing NULs trimmed.
+//! 6. The plaintext is `key=value` pairs joined by `&`, terminated by
+//!    `;` and a short trailer.
+//!
+//! Steps 3-5 are the same construction the pre-v2 OTP envelope used
+//! (an 8-character ASCII key followed by hex ciphertext), so
+//! [`crate::core::wcdes::decrypt_hex`] handles them unchanged. Only the
+//! substitution layer and the field parse are specific to this blob.
+
+use thiserror::Error;
+
+use crate::core::wcdes::{self, decrypt_hex};
+
+/// The four substitution alphabets, lifted from the launcher's
+/// `Command.DecryptParam()`. Each is a permutation of the 16 hex
+/// digits — a precondition for step 2 to be reversible, asserted in
+/// the tests.
+const TABLES: [&str; 4] = [
+    "bac987d65e432f10",
+    "3bc4d5e6f2a79108",
+    "cdbeaf9012456378",
+    "4e6fb81a3c5d7092",
+];
+
+/// Length of the ASCII DES key embedded in the normalized hex.
+const KEY_LEN: usize = 8;
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum LaunchDataError {
+    #[error("launch data is empty")]
+    Empty,
+
+    #[error("launch data does not start with a hex digit, got {0:?}")]
+    BadSelector(char),
+
+    #[error("launch data contains {0:?}, which is absent from substitution table {1}")]
+    UnmappableChar(char, usize),
+
+    #[error("launch data is too short to hold a key at offset {offset} (have {len} characters)")]
+    TooShort { offset: usize, len: usize },
+
+    #[error("DES decryption of launch data failed: {0}")]
+    Decrypt(String),
+
+    #[error("decrypted launch data has no LaunchTicket field")]
+    MissingTicket,
+
+    #[error("LaunchTicket is not 64 hex characters (got {0})")]
+    MalformedTicket(String),
+}
+
+impl From<wcdes::WcdesError> for LaunchDataError {
+    fn from(err: wcdes::WcdesError) -> Self {
+        LaunchDataError::Decrypt(err.to_string())
+    }
+}
+
+/// Recover the `LaunchTicket` from a `m_objData.data` blob.
+///
+/// The other decoded fields (`ServiceCode`, `ServiceRegion`,
+/// `ServiceAccount`, `BeanfunUrl`, `WebStartPatch`) are discarded —
+/// the v2 OTP request needs none of them, and the caller already holds
+/// its own copies.
+//
+// ponytail: returns the one field the caller uses. Widen to the full
+// field map if a future call site needs more than the ticket.
+pub fn decode_launch_ticket(data: &str) -> Result<String, LaunchDataError> {
+    let plaintext = decode(data)?;
+    let ticket = plaintext
+        .split(';')
+        .next()
+        .unwrap_or_default()
+        .split('&')
+        .find_map(|pair| pair.strip_prefix("LaunchTicket="))
+        .ok_or(LaunchDataError::MissingTicket)?;
+
+    if ticket.len() != 64 || !ticket.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(LaunchDataError::MalformedTicket(ticket.to_owned()));
+    }
+    Ok(ticket.to_owned())
+}
+
+/// Undo the substitution layer and decrypt, returning the raw
+/// plaintext with trailing NULs trimmed.
+fn decode(data: &str) -> Result<String, LaunchDataError> {
+    let mut chars = data.chars();
+    let selector_char = chars.next().ok_or(LaunchDataError::Empty)?;
+    let selector = selector_char
+        .to_digit(16)
+        .ok_or(LaunchDataError::BadSelector(selector_char))? as usize;
+
+    let table_index = selector % TABLES.len();
+    let table = TABLES[table_index];
+
+    let normalized = chars
+        .map(|c| {
+            table
+                .find(c)
+                // Tables are ASCII, so the byte offset `find` returns
+                // is also the character index we want.
+                .map(|idx| char::from_digit(idx as u32, 16).expect("index < 16 is a hex digit"))
+                .ok_or(LaunchDataError::UnmappableChar(c, table_index))
+        })
+        .collect::<Result<String, _>>()?;
+
+    let offset = selector + 1;
+    if normalized.len() < offset + KEY_LEN {
+        return Err(LaunchDataError::TooShort {
+            offset,
+            len: normalized.len(),
+        });
+    }
+
+    let key = &normalized[offset..offset + KEY_LEN];
+    let cipher_hex = format!("{}{}", &normalized[..offset], &normalized[offset + KEY_LEN..]);
+
+    let plaintext = decrypt_hex(&cipher_hex, key)?;
+    Ok(plaintext.trim_matches('\0').to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::wcdes::encrypt_hex;
+
+    /// Re-apply the substitution layer, so a test can build a blob the
+    /// decoder should accept. Mirrors `decode`'s inverse exactly.
+    fn encode(selector: usize, key: &str, cipher_hex: &str) -> String {
+        let table: Vec<char> = TABLES[selector % TABLES.len()].chars().collect();
+        let offset = selector + 1;
+        let normalized = format!(
+            "{}{}{}",
+            &cipher_hex[..offset],
+            key,
+            &cipher_hex[offset..]
+        );
+        let body: String = normalized
+            .chars()
+            .map(|c| table[c.to_digit(16).expect("normalized hex") as usize])
+            .collect();
+        format!(
+            "{}{}",
+            char::from_digit(selector as u32, 16).expect("selector < 16"),
+            body
+        )
+    }
+
+    /// Step 2 is only reversible if every table is a permutation of the
+    /// hex alphabet. Pinned so a future transcription slip is caught
+    /// here rather than as an unexplained decode failure.
+    #[test]
+    fn tables_are_permutations_of_the_hex_alphabet() {
+        for (i, table) in TABLES.iter().enumerate() {
+            let mut chars: Vec<char> = table.chars().collect();
+            chars.sort_unstable();
+            chars.dedup();
+            assert_eq!(chars.len(), 16, "table {i} has duplicate characters");
+            assert!(
+                chars.iter().all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()),
+                "table {i} holds a non-lowercase-hex character"
+            );
+        }
+    }
+
+    #[test]
+    fn round_trips_through_every_selector() {
+        let plaintext = "LaunchTicket=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef&ServiceCode=610074&ServiceRegion=T9;abcde";
+        // `encrypt_hex` refuses a plaintext that is not a whole number
+        // of DES blocks, and the real blob is NUL-padded the same way.
+        let padded = format!("{plaintext}{}", "\0".repeat((8 - plaintext.len() % 8) % 8));
+        let key = "a1b2c3d4";
+        let cipher_hex = encrypt_hex(&padded, key).unwrap().to_lowercase();
+
+        for selector in 0..16 {
+            let blob = encode(selector, key, &cipher_hex);
+            assert_eq!(
+                decode_launch_ticket(&blob).unwrap(),
+                "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+                "selector {selector} failed"
+            );
+        }
+    }
+
+    /// The two real blob lengths observed in the wild — 553 from the
+    /// upstream report, 537 from our own capture — must both leave a
+    /// ciphertext that is a whole number of DES blocks. This is the
+    /// cheapest check that the format is understood correctly.
+    #[test]
+    fn observed_blob_lengths_yield_whole_des_blocks() {
+        for total in [553usize, 537] {
+            let cipher_hex_len = total - 1 - KEY_LEN;
+            assert_eq!(cipher_hex_len % 2, 0, "len {total}: odd hex length");
+            assert_eq!(
+                (cipher_hex_len / 2) % 8,
+                0,
+                "len {total}: ciphertext is not a whole number of DES blocks"
+            );
+        }
+    }
+
+    #[test]
+    fn empty_input_is_rejected() {
+        assert_eq!(decode_launch_ticket("").unwrap_err(), LaunchDataError::Empty);
+    }
+
+    #[test]
+    fn non_hex_selector_is_rejected() {
+        assert_eq!(
+            decode_launch_ticket("zzzz").unwrap_err(),
+            LaunchDataError::BadSelector('z')
+        );
+    }
+
+    #[test]
+    fn character_outside_the_table_is_rejected() {
+        // Selector 0 → table 0, which has no 'z'.
+        let err = decode_launch_ticket("0zzz").unwrap_err();
+        assert!(
+            matches!(err, LaunchDataError::UnmappableChar('z', 0)),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn blob_too_short_for_a_key_is_rejected() {
+        // Table 0 characters only, but far fewer than offset + 8.
+        let err = decode_launch_ticket("0bac").unwrap_err();
+        assert!(matches!(err, LaunchDataError::TooShort { .. }), "got {err:?}");
+    }
+}

--- a/src-tauri/src/core/launch_data.rs
+++ b/src-tauri/src/core/launch_data.rs
@@ -42,11 +42,17 @@ use crate::core::wcdes::{self, decrypt_hex};
 /// `Command.DecryptParam()`. Each is a permutation of the 16 hex
 /// digits — a precondition for step 2 to be reversible, asserted in
 /// the tests.
-const TABLES: [&str; 4] = [
+/// Public so a wire test can build a payload the way the page does,
+/// rather than pasting one from a capture.
+pub const TABLES: [&str; 8] = [
     "bac987d65e432f10",
     "3bc4d5e6f2a79108",
     "cdbeaf9012456378",
     "4e6fb81a3c5d7092",
+    "bdef1246789ac530",
+    "5f82cb4093e71d6a",
+    "df1468ace0357b92",
+    "b50c61a4f93e82d7",
 ];
 
 /// Length of the ASCII DES key embedded in the normalized hex.
@@ -116,8 +122,50 @@ fn decode(data: &str) -> Result<String, LaunchDataError> {
         .to_digit(16)
         .ok_or(LaunchDataError::BadSelector(selector_char))? as usize;
 
-    let table_index = selector % TABLES.len();
+    // Which table the selector names is not settled. `n % 4` decodes
+    // every payload seen so far, but there are eight tables, and the one
+    // sample available (selector 12) cannot tell `n % 4` apart from the
+    // table order simply differing from the launcher's own indexing.
+    //
+    // So rather than commit to a rule and be wrong for some accounts,
+    // each table is tried until one yields a plaintext carrying a
+    // `LaunchTicket`. A wrong table gives noise, and noise does not
+    // spell a field name by accident, so the signal is sound. Eight DES
+    // passes over ~272 bytes costs nothing measurable, and it keeps
+    // working if beanfun adds a ninth table.
+    //
+    // Most-likely first, so the diagnostic usually names the same one.
+    let rest: String = chars.collect();
+    let mut order: Vec<usize> = vec![selector % 4, selector % TABLES.len()];
+    order.extend(0..TABLES.len());
+
+    let mut tried: Vec<usize> = Vec::with_capacity(TABLES.len());
+    let mut first_error: Option<LaunchDataError> = None;
+    for table_index in order {
+        if tried.contains(&table_index) {
+            continue;
+        }
+        tried.push(table_index);
+        match decode_with(&rest, selector, table_index) {
+            Ok(plaintext) if plaintext.contains("LaunchTicket=") => {
+                tracing::debug!(selector, table = table_index, "launch data table");
+                return Ok(plaintext);
+            }
+            // Decoded to something, but not to our payload — that is a
+            // wrong table, not a broken one.
+            Ok(_) => {}
+            Err(e) => {
+                first_error.get_or_insert(e);
+            }
+        }
+    }
+    Err(first_error.unwrap_or(LaunchDataError::MissingTicket))
+}
+
+/// One decode attempt with the table already chosen.
+fn decode_with(body: &str, selector: usize, table_index: usize) -> Result<String, LaunchDataError> {
     let table = TABLES[table_index];
+    let chars = body.chars();
 
     let normalized = chars
         .map(|c| {

--- a/src-tauri/src/core/mod.rs
+++ b/src-tauri/src/core/mod.rs
@@ -7,6 +7,7 @@
 //!
 //! HTTP / IO / async orchestration belongs under `services::` (added in P3+).
 
+pub mod launch_data;
 pub mod legacy;
 pub mod parser;
 pub mod redact;

--- a/src-tauri/src/services/beanfun/client_integrity.rs
+++ b/src-tauri/src/services/beanfun/client_integrity.rs
@@ -1,0 +1,451 @@
+//! Client-integrity triple (`CV` / `Hash` / `arch`) that beanfun's TW OTP
+//! endpoint has required since Gamania Games Manager (GGM) 1.5.x.
+//!
+//! # Why this exists (issue #368)
+//!
+//! Gamania re-versioned the TW launch path in August 2026. The OTP endpoint
+//! itself is unchanged — still
+//! `beanfun_block/generic_handlers/get_webstart_otp.ashx` — but the current
+//! GGM appends three extra query parameters that fingerprint the calling
+//! client, and the server now rejects requests that omit them with the
+//! opaque body `0;Query String Error`.
+//!
+//! Ground truth was taken from the shipping GGM 1.5.0.2 on 2026-08-17. The
+//! `GGM.Shared.dll` that GGM 1.5.x installs alongside `GGMWebStart.dll` is
+//! **not** name-obfuscated, and its `GGM.Shared.Beanfun.BeanfunUrlBuilder`
+//! spells the contract out:
+//!
+//! ```text
+//! BuildOtpUrl(sn, webToken, secretCode, ppppp, serviceCode, serviceRegion,
+//!             serviceAccount, createTime, environment, cv, hash, arch)
+//!   -> "{base}beanfun_block/generic_handlers/get_webstart_otp.ashx
+//!       ?SN=…&WebToken=…&SecretCode=…&ppppp=…&ServiceCode=…&ServiceRegion=…
+//!       &ServiceAccount=…&CreateTime=…&d={TickCount}
+//!       &CV={cv}&Hash={hash}&arch={arch}"
+//! ```
+//!
+//! where the trailing three are each `Uri.EscapeDataString`-encoded, and the
+//! values come from GGM's own `ClientIntegrityInfo` initialiser:
+//!
+//! | Parameter | Origin in GGM                                         | Observed |
+//! |-----------|-------------------------------------------------------|----------|
+//! | `CV`      | `Assembly.GetExecutingAssembly().GetName().Version`   | `1.5.0.2` |
+//! | `Hash`    | SHA-256 of `GGMWebStart.dll`, `b.ToString("x2")`      | `dfd568a6…101e06` |
+//! | `arch`    | `Environment.Is64BitProcess ? "x64" : "x86"`          | `x64` |
+//!
+//! GGM's own log line (verified on a live launch) reads:
+//!
+//! ```text
+//! ClientIntegrityInfo CV=1.5.0.2 arch=x64 Hash=dfd568a69d87abcd…101e06
+//! ```
+//!
+//! # Resolution strategy
+//!
+//! [`ClientIntegrity::resolve`] prefers the **locally installed** GGM and
+//! only falls back to the bundled constants:
+//!
+//! 1. Locate `GGMWebStart.dll` — first via the `gamaniagames://` protocol
+//!    handler the installer registers (authoritative even for non-default
+//!    install locations), then via the conventional install roots.
+//! 2. Hash it and read its version.
+//! 3. If either half cannot be obtained, use [`ClientIntegrity::fallback`].
+//!
+//! Reading the live file is what keeps us current: GGM self-updates (it
+//! polls `CheckVersion.ashx` on every launch and hands off to `Patcher.exe`
+//! when it is behind), so a user who can launch through the official site at
+//! all necessarily has an up-to-date DLL. The bundled constants exist only
+//! for users with no GGM installed, and go stale the next time Gamania ships
+//! a GGM build — refreshing them is a release-time chore, not a runtime one.
+//!
+//! # Deliberately all-or-nothing
+//!
+//! `CV` and `Hash` describe the *same* binary, so mixing a locally computed
+//! hash with a bundled version (or vice versa) would describe a client that
+//! does not exist. Every failure path therefore yields the complete
+//! [`ClientIntegrity::fallback`] pair rather than a half-local hybrid.
+//!
+//! # Deliberately uncached
+//!
+//! Hashing a ~1.3 MB file costs single-digit milliseconds and OTP retrieval
+//! is user-initiated (a button press), so the triple is recomputed per call.
+//! Caching would risk pinning a pre-update hash for the lifetime of the
+//! process, which is precisely the failure this module exists to avoid.
+
+use std::path::{Path, PathBuf};
+
+use sha2::{Digest, Sha256};
+
+/// File name of the GGM assembly that both supplies and is fingerprinted by
+/// the `Hash` parameter.
+const GGM_DLL_NAME: &str = "GGMWebStart.dll";
+
+/// `CV` used when no local GGM install can be inspected.
+///
+/// Must always be paired with [`FALLBACK_HASH`] — see the module's
+/// "all-or-nothing" note.
+const FALLBACK_CV: &str = "1.5.0.2";
+
+/// `Hash` used when no local GGM install can be inspected: the SHA-256 of
+/// `GGMWebStart.dll` as shipped in GGM 1.5.0.2, lowercase hex.
+const FALLBACK_HASH: &str = "dfd568a69d87abcd8f4a93d1a4481ebb57712d1d28ab0b6fc018fcf140101e06";
+
+/// `arch` reports the bitness of the *calling process*, mirroring GGM's
+/// `Environment.Is64BitProcess` rather than the bitness of the OS.
+#[cfg(target_pointer_width = "64")]
+const ARCH: &str = "x64";
+#[cfg(not(target_pointer_width = "64"))]
+const ARCH: &str = "x86";
+
+/// The `CV` / `Hash` / `arch` triple appended to the TW OTP request.
+///
+/// Values are stored raw (un-encoded); percent-encoding is the URL
+/// builder's job so this type stays a plain description of the client.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClientIntegrity {
+    /// GGM assembly version, e.g. `"1.5.0.2"`.
+    pub cv: String,
+    /// Lowercase-hex SHA-256 of `GGMWebStart.dll`.
+    pub hash: String,
+    /// `"x64"` or `"x86"`.
+    pub arch: &'static str,
+}
+
+impl ClientIntegrity {
+    /// The bundled constants, for hosts with no inspectable GGM install.
+    pub fn fallback() -> Self {
+        Self {
+            cv: FALLBACK_CV.to_string(),
+            hash: FALLBACK_HASH.to_string(),
+            arch: ARCH,
+        }
+    }
+
+    /// Describe the locally installed GGM, falling back to the bundled
+    /// constants when it cannot be found or fully inspected.
+    ///
+    /// Never fails: the OTP request needs *some* triple, and a stale-but
+    /// -plausible one gives the server a chance to accept where an absent
+    /// one is guaranteed to be rejected.
+    pub fn resolve() -> Self {
+        match locate_ggm_dll().as_deref().and_then(Self::from_ggm_dll) {
+            Some(found) => found,
+            None => {
+                tracing::debug!(
+                    "no inspectable {GGM_DLL_NAME}; using bundled client-integrity constants"
+                );
+                Self::fallback()
+            }
+        }
+    }
+
+    /// Build the triple from a specific `GGMWebStart.dll`.
+    ///
+    /// `None` when the file cannot be hashed *or* its version cannot be
+    /// read, so callers never assemble a half-local pair.
+    fn from_ggm_dll(path: &Path) -> Option<Self> {
+        let hash = sha256_lower_hex(path)?;
+        let cv = file_version(path)?;
+        tracing::debug!(cv = %cv, path = %path.display(), "resolved client integrity from local GGM");
+        Some(Self {
+            cv,
+            hash,
+            arch: ARCH,
+        })
+    }
+}
+
+/// Hash `path` into the lowercase-hex form GGM produces with
+/// `b.ToString("x2")`.
+fn sha256_lower_hex(path: &Path) -> Option<String> {
+    let bytes = std::fs::read(path).ok()?;
+    let digest: [u8; 32] = Sha256::digest(&bytes).into();
+    let mut hex = String::with_capacity(64);
+    for byte in digest {
+        use std::fmt::Write as _;
+        // `write!` into a String is infallible; the result is discarded
+        // rather than unwrapped to keep this loop panic-free.
+        let _ = write!(hex, "{byte:02x}");
+    }
+    Some(hex)
+}
+
+/// Locate the installed `GGMWebStart.dll`, if any.
+fn locate_ggm_dll() -> Option<PathBuf> {
+    for dir in ggm_directories() {
+        let candidate = dir.join(GGM_DLL_NAME);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+/// Candidate GGM install directories, most authoritative first.
+#[cfg(target_os = "windows")]
+fn ggm_directories() -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+    if let Some(dir) = ggm_dir_from_protocol_handler() {
+        dirs.push(dir);
+    }
+    // The installer's default location, per architecture-specific
+    // Program Files root. Covers a registry that has been cleaned up (or
+    // a hand-copied install) while the files are still in place.
+    for var in ["ProgramFiles", "ProgramFiles(x86)"] {
+        if let Ok(root) = std::env::var(var) {
+            dirs.push(
+                PathBuf::from(root)
+                    .join("gamania Games")
+                    .join("gamania Games Manager"),
+            );
+        }
+    }
+    dirs
+}
+
+#[cfg(not(target_os = "windows"))]
+fn ggm_directories() -> Vec<PathBuf> {
+    // GGM is a Windows-only product; every non-Windows host takes the
+    // bundled-constant path.
+    Vec::new()
+}
+
+/// Read the directory of the executable registered for `gamaniagames://`.
+///
+/// The GGM installer writes
+/// `HKCR\gamaniagames\shell\open\command` = `"<dir>\GGMWebStart.exe" "%1"`,
+/// which tracks the real install location even when the user chose a
+/// non-default path.
+#[cfg(target_os = "windows")]
+fn ggm_dir_from_protocol_handler() -> Option<PathBuf> {
+    use winreg::enums::HKEY_CLASSES_ROOT;
+    use winreg::RegKey;
+
+    let command: String = RegKey::predef(HKEY_CLASSES_ROOT)
+        .open_subkey(r"gamaniagames\shell\open\command")
+        .and_then(|key| key.get_value(""))
+        .ok()?;
+
+    let exe = handler_executable(&command)?;
+    Path::new(&exe).parent().map(Path::to_path_buf)
+}
+
+/// Extract just the executable path from a registry handler command line.
+///
+/// Handles both the quoted form the GGM installer writes
+/// (`"C:\…\GGMWebStart.exe" "%1"`) and a bare unquoted path. Unlike
+/// `commands::classic`'s handler parser this deliberately stops at the
+/// executable: we only want its directory, never an argument vector, so
+/// there is no `%1` substitution to perform.
+fn handler_executable(command: &str) -> Option<String> {
+    let trimmed = command.trim();
+    let exe = match trimmed.strip_prefix('"') {
+        Some(rest) => rest.split_once('"').map(|(exe, _)| exe)?,
+        None => trimmed.split_whitespace().next()?,
+    };
+    (!exe.is_empty()).then(|| exe.to_string())
+}
+
+/// Read the Win32 version resource's `FileVersion` as `a.b.c.d`.
+///
+/// GGM sends its **assembly** version, which Rust cannot read without
+/// walking the CLI metadata tables. Every shipped GGM build observed so far
+/// (1.0.0.0 and 1.5.0.2) carries an identical `FileVersion`, so the version
+/// resource stands in for it; when the two ever diverge the caller falls
+/// back to the bundled constants, which is also what happens if this read
+/// fails outright.
+#[cfg(target_os = "windows")]
+fn file_version(path: &Path) -> Option<String> {
+    use std::os::windows::ffi::OsStrExt;
+
+    use windows::core::{w, PCWSTR};
+    use windows::Win32::Storage::FileSystem::{
+        GetFileVersionInfoSizeW, GetFileVersionInfoW, VerQueryValueW, VS_FIXEDFILEINFO,
+    };
+
+    let wide: Vec<u16> = path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+    let file = PCWSTR(wide.as_ptr());
+
+    // SAFETY: `file` points at a NUL-terminated wide string that outlives
+    // every call below. `block` is sized by the API itself and is only read
+    // back through `VerQueryValueW`, whose out-pointer is validated for
+    // null and for holding at least a whole `VS_FIXEDFILEINFO` before the
+    // struct is dereferenced.
+    unsafe {
+        let size = GetFileVersionInfoSizeW(file, None);
+        if size == 0 {
+            return None;
+        }
+        let mut block = vec![0u8; size as usize];
+        GetFileVersionInfoW(file, 0, size, block.as_mut_ptr().cast()).ok()?;
+
+        let mut value: *mut core::ffi::c_void = std::ptr::null_mut();
+        let mut value_len: u32 = 0;
+        // The root sub-block (`"\"`) yields the fixed-info struct.
+        if !VerQueryValueW(block.as_ptr().cast(), w!("\\"), &mut value, &mut value_len).as_bool() {
+            return None;
+        }
+        if value.is_null() || (value_len as usize) < std::mem::size_of::<VS_FIXEDFILEINFO>() {
+            return None;
+        }
+
+        let info = &*(value as *const VS_FIXEDFILEINFO);
+        let most = info.dwFileVersionMS;
+        let least = info.dwFileVersionLS;
+        Some(format!(
+            "{}.{}.{}.{}",
+            most >> 16,
+            most & 0xFFFF,
+            least >> 16,
+            least & 0xFFFF
+        ))
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+fn file_version(_path: &Path) -> Option<String> {
+    None
+}
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── handler_executable ────────────────────────────────────────────
+
+    #[test]
+    fn handler_executable_reads_the_quoted_installer_form() {
+        // Exactly what the GGM installer writes to HKCR.
+        let command =
+            r#""C:\Program Files\gamania Games\gamania Games Manager\GGMWebStart.exe" "%1""#;
+        assert_eq!(
+            handler_executable(command).as_deref(),
+            Some(r"C:\Program Files\gamania Games\gamania Games Manager\GGMWebStart.exe"),
+        );
+    }
+
+    #[test]
+    fn handler_executable_reads_an_unquoted_path() {
+        assert_eq!(
+            handler_executable(r"C:\ggm\GGMWebStart.exe %1").as_deref(),
+            Some(r"C:\ggm\GGMWebStart.exe"),
+        );
+    }
+
+    #[test]
+    fn handler_executable_keeps_spaces_inside_quotes() {
+        // The unquoted branch would truncate at the first space, so this
+        // pins that quoted paths are not split on whitespace.
+        let exe = handler_executable(r#""C:\a b\c d\GGMWebStart.exe" "%1""#);
+        assert_eq!(exe.as_deref(), Some(r"C:\a b\c d\GGMWebStart.exe"));
+    }
+
+    #[test]
+    fn handler_executable_rejects_empty_or_degenerate_input() {
+        assert_eq!(handler_executable(""), None);
+        assert_eq!(handler_executable("   "), None);
+        // Opening quote with an empty payload.
+        assert_eq!(handler_executable(r#""" "%1""#), None);
+        // Unterminated quote — no closing delimiter to split on.
+        assert_eq!(handler_executable(r#""C:\ggm\GGMWebStart.exe"#), None);
+    }
+
+    // ── sha256_lower_hex ──────────────────────────────────────────────
+
+    #[test]
+    fn sha256_lower_hex_matches_the_known_digest_of_empty_input() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("empty.bin");
+        std::fs::write(&path, b"").expect("write");
+
+        // Well-known SHA-256 of the empty string, lowercase — the same
+        // casing GGM's `ToString("x2")` produces.
+        assert_eq!(
+            sha256_lower_hex(&path).as_deref(),
+            Some("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"),
+        );
+    }
+
+    #[test]
+    fn sha256_lower_hex_is_64_lowercase_hex_chars() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("blob.bin");
+        std::fs::write(&path, b"gamania").expect("write");
+
+        let hex = sha256_lower_hex(&path).expect("hashable");
+        assert_eq!(hex.len(), 64);
+        assert!(
+            hex.chars()
+                .all(|c| c.is_ascii_digit() || ('a'..='f').contains(&c)),
+            "digest must be lowercase hex, got {hex}",
+        );
+    }
+
+    #[test]
+    fn sha256_lower_hex_returns_none_for_a_missing_file() {
+        assert_eq!(
+            sha256_lower_hex(Path::new("Z:/definitely/not/here.dll")),
+            None
+        );
+    }
+
+    // ── ClientIntegrity ───────────────────────────────────────────────
+
+    #[test]
+    fn fallback_pairs_the_bundled_constants_with_this_process_arch() {
+        let integrity = ClientIntegrity::fallback();
+        assert_eq!(integrity.cv, "1.5.0.2");
+        assert_eq!(
+            integrity.hash,
+            "dfd568a69d87abcd8f4a93d1a4481ebb57712d1d28ab0b6fc018fcf140101e06",
+        );
+        assert!(matches!(integrity.arch, "x64" | "x86"));
+    }
+
+    #[test]
+    fn bundled_hash_is_a_plausible_sha256() {
+        // Guards a future hand-edit of the constant against typos: the
+        // server rejects anything that is not 64 lowercase hex chars.
+        assert_eq!(FALLBACK_HASH.len(), 64);
+        assert!(FALLBACK_HASH
+            .chars()
+            .all(|c| c.is_ascii_digit() || ('a'..='f').contains(&c)));
+    }
+
+    #[test]
+    fn from_ggm_dll_declines_a_missing_file() {
+        assert_eq!(
+            ClientIntegrity::from_ggm_dll(Path::new("Z:/definitely/not/here.dll")),
+            None,
+        );
+    }
+
+    #[test]
+    fn from_ggm_dll_declines_when_the_version_resource_is_unreadable() {
+        // A hashable file that carries no Win32 version resource: the
+        // all-or-nothing rule must reject it rather than pair a real hash
+        // with the bundled version.
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("not-a-pe.dll");
+        std::fs::write(&path, b"definitely not a portable executable").expect("write");
+
+        assert_eq!(ClientIntegrity::from_ggm_dll(&path), None);
+    }
+
+    #[test]
+    fn resolve_always_produces_a_usable_triple() {
+        // Whether or not this machine has GGM installed, `resolve` must
+        // hand the URL builder a complete triple.
+        let integrity = ClientIntegrity::resolve();
+        assert!(!integrity.cv.is_empty());
+        assert_eq!(integrity.hash.len(), 64);
+        assert!(matches!(integrity.arch, "x64" | "x86"));
+    }
+}

--- a/src-tauri/src/services/beanfun/mod.rs
+++ b/src-tauri/src/services/beanfun/mod.rs
@@ -13,6 +13,7 @@
 //! | [`login`]    | Login flows: session-key, TW/HK regular, TOTP, QRCode   |
 //! | [`account`]  | Account list + JSON management (gamezone.ashx) + WebForms add-account / change-password |
 //! | [`otp`]      | OTP retrieval (5 HTTP + WCDES decrypt)                  |
+//! | [`client_integrity`] | `CV`/`Hash`/`arch` GGM fingerprint the TW OTP endpoint requires |
 //! | [`verify`]   | Advance-check captcha re-auth (3 HTTP, TW only)         |
 //!
 //! # Safety posture
@@ -31,6 +32,7 @@
 
 pub mod account;
 pub mod client;
+pub mod client_integrity;
 pub mod error;
 pub mod games;
 pub mod login;
@@ -47,6 +49,7 @@ pub use account::{
     CheckOutcome, ServiceAccount,
 };
 pub use client::{BeanfunClient, ClientConfig, Endpoints, LoginRegion};
+pub use client_integrity::ClientIntegrity;
 pub use error::LoginError;
 pub use games::{
     image_base_url, list_games, parse_service_ini, parse_service_list, GameInfoBundle,

--- a/src-tauri/src/services/beanfun/otp.rs
+++ b/src-tauri/src/services/beanfun/otp.rs
@@ -196,8 +196,6 @@ pub async fn get_otp(
     service_region: &str,
 ) -> Result<String, LoginError> {
     let step1 = step_1_init(client, account, service_code, service_region).await?;
-    let secret_code = step_2_get_secret_code(client).await?;
-    step_3_record_start(client, account, &step1, service_code, service_region).await?;
 
     // Branch on the page's own shape rather than on the region: a page
     // that carries `m_objData` is one whose OTP now comes from the v2
@@ -205,20 +203,30 @@ pub async fn get_otp(
     // `Query String Error`. Observed migrated on TW; HK's page has no
     // such literal and keeps the legacy path. If HK migrates later this
     // needs no change.
-    // Both step 5s identify the caller with the same three values, so
-    // resolve them once here rather than in each branch.
-    let integrity = resolve_client_integrity().await;
-
     if let Some(handoff) = &step1.launch {
-        // Deliberately no long poll on this path. The page's
+        // Recording the start is what the page does alongside opening
+        // the launcher, and nothing downstream depends on it — so a
+        // migrated page missing a field it no longer has to carry must
+        // not cost the user their password.
+        if let Err(error) =
+            step_3_record_start(client, account, &step1, service_code, service_region).await
+        {
+            tracing::warn!(%error, "could not record the service start; continuing");
+        }
+
+        // Deliberately no secret code and no long poll on this path.
+        // The v2 request does not carry a secret code, and the page's
         // `GetResultByLongPolling` call is the launcher's installation
-        // check, unrelated to the password, and it holds the connection
-        // open — waiting on it only delays every retrieval.
+        // check — unrelated to the password, and it holds the
+        // connection open.
+        let integrity = resolve_client_integrity().await;
         return step_5_post_otp_v2(client, handoff, &integrity, &step1.page_url).await;
     }
 
-    // The legacy path still primes server-side state with it.
+    let secret_code = step_2_get_secret_code(client).await?;
+    step_3_record_start(client, account, &step1, service_code, service_region).await?;
     step_4_long_poll(client, &step1.long_polling_key).await?;
+    let integrity = resolve_client_integrity().await;
 
     let url = build_get_webstart_otp_url(
         client,
@@ -333,8 +341,28 @@ async fn step_1_init(
     ensure_success(&resp, "game_start_step2.aspx")?;
     let body = client.bounded_text(resp).await?;
 
-    let long_polling_key = parse_long_polling_key(&body)?;
+    // Read the handoff *first*: it decides which route this page is on,
+    // and therefore which of the literals below are required at all.
+    //
+    // A migrated page has dropped the ones the old flow used — there is
+    // no `GetResultByLongPolling&key=` on it any more, because the page
+    // no longer polls; it opens the launcher. Parsing them before
+    // looking would fail the whole retrieval before the handoff is even
+    // read, and the reported error would name a literal that is *meant*
+    // to be gone.
+    let launch = parse_launch_handoff(&body);
+    let migrated = launch.is_some();
+
+    let long_polling_key = match parse_long_polling_key(&body) {
+        Ok(key) => key,
+        Err(_) if migrated => String::new(),
+        Err(e) => return Err(e),
+    };
     let unk_data = match client.config().region {
+        // Still wanted when present — it is the service-start form's
+        // anti-forgery field — but not worth failing a retrieval over
+        // on a page that no longer has to carry it.
+        LoginRegion::TW if migrated => parse_unk_data(&body).ok(),
         LoginRegion::TW => Some(parse_unk_data(&body)?),
         LoginRegion::HK => None,
     };
@@ -344,12 +372,14 @@ async fn step_1_init(
     // fallback scrape gets its chance.
     let screatetime = match account.screatetime.as_deref() {
         Some(s) if !s.is_empty() => s.to_string(),
-        _ => parse_screatetime_fallback(&body)?,
+        // The v2 request does not carry a create time; only the
+        // best-effort service-start form does.
+        _ => match parse_screatetime_fallback(&body) {
+            Ok(t) => t,
+            Err(_) if migrated => String::new(),
+            Err(e) => return Err(e),
+        },
     };
-
-    // Absence is not an error here: the legacy path does not need it,
-    // and the v2 path reports its own typed error when it is missing.
-    let launch = parse_launch_handoff(&body);
 
     Ok(Step1Data {
         page_url,

--- a/src-tauri/src/services/beanfun/otp.rs
+++ b/src-tauri/src/services/beanfun/otp.rs
@@ -166,7 +166,7 @@ pub async fn get_otp(
     let secret_code = step_2_get_secret_code(client).await?;
     step_3_record_start(client, account, &step1, service_code, service_region).await?;
     step_4_long_poll(client, &step1.long_polling_key).await?;
-    let envelope = step_5_get_otp(
+    let url = build_get_webstart_otp_url(
         client,
         session,
         account,
@@ -174,9 +174,29 @@ pub async fn get_otp(
         &secret_code,
         service_code,
         service_region,
-    )
-    .await?;
-    step_6_decrypt(&envelope)
+        tick_count_ms(),
+    )?;
+    let envelope = step_5_get_otp(client, &url).await?;
+
+    let result = step_6_decrypt(&envelope);
+    if let Err(err) = &result {
+        // `OtpDecryptionFailed` is the one failure that reaches here
+        // holding a *successful* `1;…` envelope — its payload carries
+        // the live OTP key + ciphertext, which must never be logged.
+        // The other variants only ever carry a rejection message.
+        let raw_response = match err {
+            LoginError::OtpDecryptionFailed { .. } => "<redacted: success envelope>",
+            _ => envelope.as_str(),
+        };
+        tracing::warn!(
+            error = %err,
+            request_url = %redact_otp_url(&url),
+            raw_response,
+            raw_response_len = envelope.len(),
+            "OTP step 5 failed — verbatim server response logged for diagnosis"
+        );
+    }
+    result
 }
 
 // -----------------------------------------------------------------------------
@@ -325,38 +345,10 @@ async fn step_4_long_poll(
 /// Step 5 — read the `1;{key}{ciphertext_hex}` envelope from
 /// `get_webstart_otp.ashx`.
 ///
-/// The URL is built **as a string** rather than via reqwest's `.query()`
-/// builder because two of the parameters require WPF-specific encoding
-/// that the form-urlencoder would emit differently:
-///
-/// 1. `CreateTime` contains a literal space (e.g. `2024-01-15 12:34:56`)
-///    that WPF replaces with `%20` (L101 `acc.screatetime.Replace(" ", "%20")`).
-///    reqwest's `.query()` would emit `+` instead, which most servers
-///    accept but is **not** byte-identical to the WPF wire format.
-/// 2. `ppppp` is a 64-char uppercase hex literal that must appear
-///    verbatim — no encoding, no normalisation.
-///
-/// All other characters in the URL (cookies, sids, hex digits) are
-/// already URL-safe, so a literal `format!` is sufficient.
-async fn step_5_get_otp(
-    client: &BeanfunClient,
-    session: &Session,
-    account: &ServiceAccount,
-    step1: &Step1Data,
-    secret_code: &str,
-    service_code: &str,
-    service_region: &str,
-) -> Result<String, LoginError> {
-    let url = build_get_webstart_otp_url(
-        client,
-        session,
-        account,
-        step1,
-        secret_code,
-        service_code,
-        service_region,
-        tick_count_ms(),
-    )?;
+/// Takes the URL pre-built by [`build_get_webstart_otp_url`] (see that
+/// function for why it is assembled as a string) so the caller keeps a
+/// copy to log if the envelope turns out to be a rejection.
+async fn step_5_get_otp(client: &BeanfunClient, url: &str) -> Result<String, LoginError> {
     let resp = client.http().get(url).send().await?;
     ensure_success(&resp, "get_webstart_otp.ashx")?;
     client.bounded_text(resp).await
@@ -562,6 +554,20 @@ fn tick_count_ms() -> i32 {
 ///
 /// Argument order mirrors the WPF URL template (L100-102) so a side-
 /// by-side diff against `BeanfunClient.OTP.cs` is mechanical.
+///
+/// The URL is assembled **as a string** rather than via reqwest's
+/// `.query()` builder because two parameters require WPF-specific
+/// encoding that the form-urlencoder would emit differently:
+///
+/// 1. `CreateTime` contains a literal space (e.g. `2024-01-15 12:34:56`)
+///    that WPF replaces with `%20` (L101 `acc.screatetime.Replace(" ", "%20")`).
+///    reqwest's `.query()` would emit `+` instead, which most servers
+///    accept but is **not** byte-identical to the WPF wire format.
+/// 2. `ppppp` is a 64-char uppercase hex literal that must appear
+///    verbatim — no encoding, no normalisation.
+///
+/// All other characters in the URL (cookies, sids, hex digits) are
+/// already URL-safe, so a literal `format!` is sufficient.
 #[allow(clippy::too_many_arguments)]
 fn build_get_webstart_otp_url(
     client: &BeanfunClient,
@@ -590,6 +596,36 @@ fn build_get_webstart_otp_url(
         create_time = create_time_encoded,
         tick = tick,
     ))
+}
+
+/// Secret-bearing query parameters of step 5's URL. Their values are
+/// replaced with a length when the URL is logged.
+const OTP_URL_SECRET_PARAMS: [&str; 4] = ["SN", "WebToken", "SecretCode", "ServiceAccount"];
+
+/// Rewrite step 5's URL so it is safe to put in a log line.
+///
+/// Every parameter *name* survives, and the non-secret values stay
+/// verbatim on purpose — a rotated `ppppp` constant, a reformatted
+/// `CreateTime` or a wrong `ServiceCode` are exactly what a rejection
+/// diagnosis needs to see, and `ppppp` is a hardcoded constant already
+/// visible in this file. The four session-scoped values collapse to
+/// `<N chars>`, which still distinguishes "absent", "truncated" and
+/// "present" without putting a live token on disk.
+fn redact_otp_url(url: &str) -> String {
+    let Some((base, query)) = url.split_once('?') else {
+        return url.to_string();
+    };
+    let redacted = query
+        .split('&')
+        .map(|pair| match pair.split_once('=') {
+            Some((key, value)) if OTP_URL_SECRET_PARAMS.contains(&key) => {
+                format!("{key}=<{} chars>", value.len())
+            }
+            _ => pair.to_string(),
+        })
+        .collect::<Vec<_>>()
+        .join("&");
+    format!("{base}?{redacted}")
 }
 
 // -----------------------------------------------------------------------------
@@ -963,6 +999,47 @@ mod tests {
         assert!(url.contains("ServiceRegion=T9"), "got: {url}");
         assert!(url.contains("ServiceAccount=SID_1"), "got: {url}");
         assert!(url.contains("d=12345"), "got: {url}");
+    }
+
+    // -------------------------------------------------------------------------
+    // redact_otp_url
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn redact_otp_url_hides_secrets_but_keeps_diagnostic_values() {
+        let url = format!(
+            "https://bfweb.hk.beanfun.com/x.ashx?SN=LPK&WebToken=WEB_TOKEN_X&SecretCode=SECRET&ppppp={PPPPP_LITERAL}&ServiceCode=610074&ServiceRegion=T9&ServiceAccount=SID_1&CreateTime=2024-01-15%2012:34:56&d=12345"
+        );
+        let redacted = redact_otp_url(&url);
+
+        // Secrets gone, but their presence and length still visible.
+        for secret in ["LPK", "WEB_TOKEN_X", "SECRET", "SID_1"] {
+            assert!(
+                !redacted.contains(secret),
+                "{secret} must not survive redaction, got: {redacted}"
+            );
+        }
+        assert!(redacted.contains("WebToken=<11 chars>"), "got: {redacted}");
+        assert!(redacted.contains("SN=<3 chars>"), "got: {redacted}");
+
+        // The values a rejection diagnosis actually needs stay verbatim.
+        assert!(
+            redacted.contains(&format!("ppppp={PPPPP_LITERAL}")),
+            "got: {redacted}"
+        );
+        assert!(
+            redacted.contains("CreateTime=2024-01-15%2012:34:56"),
+            "got: {redacted}"
+        );
+        assert!(redacted.contains("ServiceCode=610074"), "got: {redacted}");
+        assert!(redacted.contains("ServiceRegion=T9"), "got: {redacted}");
+        assert!(redacted.contains("d=12345"), "got: {redacted}");
+    }
+
+    #[test]
+    fn redact_otp_url_passes_through_a_query_less_url() {
+        let url = "https://bfweb.hk.beanfun.com/x.ashx";
+        assert_eq!(redact_otp_url(url), url);
     }
 
     // -------------------------------------------------------------------------

--- a/src-tauri/src/services/beanfun/otp.rs
+++ b/src-tauri/src/services/beanfun/otp.rs
@@ -1181,6 +1181,9 @@ mod tests {
             long_polling_key: "LPK".to_string(),
             unk_data: None,
             screatetime: "2024-01-15 12:34:56".to_string(),
+            // This test covers the legacy URL builder, which is the
+            // path taken precisely when the page carried no handoff.
+            launch: None,
         };
         let url = build_get_webstart_otp_url(
             &client, &session, &account, &step1, "SECRET", "610074", "T9", 12345,

--- a/src-tauri/src/services/beanfun/otp.rs
+++ b/src-tauri/src/services/beanfun/otp.rs
@@ -66,6 +66,42 @@
 //! provenance of this literal is **unknown**: it appears to be a
 //! protocol-level constant the server validates against. Do not
 //! change it without empirical verification.
+//!
+//! # Empty captures (deliberate divergence from WPF)
+//!
+//! Every value that step 5 splices into its query string is scraped
+//! with a `(.*)` capture group copied verbatim from WPF. `(.*)`
+//! matches the empty string, so a page shaped like
+//! `var m_strSecretCode = '';` yields `Ok("")` rather than a "not
+//! found" miss — and WPF forwards that straight into the URL as
+//! `SecretCode=`.
+//!
+//! Steps 3 and 4 discard their response bodies (`drop(resp)`, mirroring
+//! WPF's ignored `UploadString` return value) and `ensure_success`
+//! only inspects the HTTP status, which these `.ashx` handlers keep at
+//! 200 even when they reject the request. Step 5 is therefore the first
+//! step that reads a body — so *every* upstream breakage collapses into
+//! one opaque `OtpServerRejected("Query String Error")` there, with no
+//! signal as to which parameter was actually bad.
+//!
+//! To keep failures attributable, `parse_long_polling_key` and
+//! `parse_secret_code` — the two scrapes whose patterns really do use
+//! `(.*)` — reject an empty capture and return their existing typed
+//! `OtpMissing*` errors instead. This is the one place we knowingly
+//! break the 1:1 WPF alignment: WPF's behaviour here is a diagnostic
+//! dead end, not a protocol requirement.
+//!
+//! `CreateTime` needs no such guard — its regex is already
+//! `([^"]+)`. It reaches step 5 empty by a different route:
+//! [`ServiceAccount`] is `Deserialize` and arrives over IPC from the
+//! frontend, so `screatetime: Some("")` bypasses the fallback scrape
+//! that a `None` would have triggered. `step_1_init` treats that
+//! empty string as absent.
+//!
+//! Note this does **not** cover greedy over-capture (a second `"` later
+//! on the same line makes `key=(.*)"` swallow the rest of it). Tightening
+//! those patterns to `([^"]*)` would change what gets matched on real
+//! pages, so it is left alone pending captures from a live server.
 
 use std::sync::OnceLock;
 
@@ -194,9 +230,13 @@ async fn step_1_init(
         LoginRegion::TW => Some(parse_unk_data(&body)?),
         LoginRegion::HK => None,
     };
+    // A stored `Some("")` is as unusable as `None` — both produce an
+    // empty `CreateTime=` on step 5's URL, which the portal rejects
+    // with a generic "Query String Error". Treat it as absent so the
+    // fallback scrape gets its chance.
     let screatetime = match account.screatetime.as_deref() {
-        Some(s) => s.to_string(),
-        None => parse_screatetime_fallback(&body)?,
+        Some(s) if !s.is_empty() => s.to_string(),
+        _ => parse_screatetime_fallback(&body)?,
     };
 
     Ok(Step1Data {
@@ -395,12 +435,16 @@ fn step_6_decrypt(envelope: &str) -> Result<String, LoginError> {
 ///
 /// Matches the WPF regex at L36 verbatim: the closing `"` is part of
 /// the pattern so the capture group stops at it.
+///
+/// **Deliberate divergence from WPF** (see the "Empty captures" note
+/// in the module docs): an empty capture is rejected here rather than
+/// forwarded as `SN=` on step 5's URL.
 fn parse_long_polling_key(html: &str) -> Result<String, LoginError> {
-    capture_first(long_polling_key_regex(), html).ok_or_else(|| {
-        LoginError::OtpMissingLongPollingKey {
+    capture_first(long_polling_key_regex(), html)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| LoginError::OtpMissingLongPollingKey {
             snippet: snippet_for_diagnostics(html),
-        }
-    })
+        })
 }
 
 /// Extract the `(key, value)` pair from the TW-only inline JS literal
@@ -435,13 +479,26 @@ fn parse_unk_data(html: &str) -> Result<(String, String), LoginError> {
 /// Re-uses the same regex as P4.1's
 /// [`crate::core::parser::extract_service_account_create_time`] so we
 /// keep one source of truth for the pattern.
+///
+/// Needs no empty-capture guard (unlike its two sibling parsers): the
+/// shared regex is `ServiceAccountCreateTime: "([^"]+)"`, whose `+`
+/// already makes an empty match impossible.
 fn parse_screatetime_fallback(html: &str) -> Result<String, LoginError> {
     extract_service_account_create_time(html).ok_or(LoginError::OtpMissingCreateTime)
 }
 
 /// Extract the `m_strSecretCode` JS literal from step 2's response.
+///
+/// **Deliberate divergence from WPF** (see the "Empty captures" note
+/// in the module docs): the pattern's `'(.*)'` matches a literal
+/// `var m_strSecretCode = '';` and captures an empty string, which
+/// WPF would forward as `SecretCode=` on step 5's URL. Rejecting it
+/// here surfaces `OtpMissingSecretCode` at step 2 — the step that
+/// actually failed — instead of an opaque step-5 server rejection.
 fn parse_secret_code(html: &str) -> Result<String, LoginError> {
-    capture_first(secret_code_regex(), html).ok_or(LoginError::OtpMissingSecretCode)
+    capture_first(secret_code_regex(), html)
+        .filter(|s| !s.is_empty())
+        .ok_or(LoginError::OtpMissingSecretCode)
 }
 
 // -----------------------------------------------------------------------------
@@ -663,6 +720,47 @@ mod tests {
         assert!(matches!(
             parse_secret_code(html).unwrap_err(),
             LoginError::OtpMissingSecretCode
+        ));
+    }
+
+    // -------------------------------------------------------------------------
+    // Empty captures — see the module-level "Empty captures" note.
+    //
+    // Each of these pages *matches* its regex but captures "". Before
+    // the non-empty filter they returned `Ok("")`, which step 5 spliced
+    // into its URL as a bare `Param=` and the portal bounced with a
+    // generic "Query String Error" — attributing an upstream failure to
+    // the wrong step.
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn empty_secret_code_capture_is_rejected() {
+        let html = r#"<script>var m_strSecretCode = '';</script>"#;
+        assert!(matches!(
+            parse_secret_code(html).unwrap_err(),
+            LoginError::OtpMissingSecretCode
+        ));
+    }
+
+    #[test]
+    fn empty_long_polling_key_capture_is_rejected() {
+        let html = r#"<script>x = "GetResultByLongPolling&key=";</script>"#;
+        assert!(matches!(
+            parse_long_polling_key(html).unwrap_err(),
+            LoginError::OtpMissingLongPollingKey { .. }
+        ));
+    }
+
+    /// The `CreateTime` scrape needs no guard of its own — its regex
+    /// uses `([^"]+)`, so an empty value is a miss, not an empty
+    /// capture. Pinned here so a future loosening of that pattern to
+    /// `(.*)` fails loudly instead of silently reopening the hole.
+    #[test]
+    fn empty_screatetime_is_a_miss_not_an_empty_capture() {
+        let html = r#"x = ServiceAccountCreateTime: ""; y = 1;"#;
+        assert!(matches!(
+            parse_screatetime_fallback(html).unwrap_err(),
+            LoginError::OtpMissingCreateTime
         ));
     }
 

--- a/src-tauri/src/services/beanfun/otp.rs
+++ b/src-tauri/src/services/beanfun/otp.rs
@@ -132,6 +132,7 @@ use regex::Regex;
 
 use crate::core::launch_data::decode_launch_ticket;
 use crate::core::parser::{capture_first, extract_service_account_create_time};
+use crate::core::redact::scrub;
 use crate::core::time::{dt_compact_now, dt_iso_now};
 use crate::core::wcdes::decrypt_hex;
 use crate::services::beanfun::account::ServiceAccount;
@@ -216,16 +217,21 @@ pub async fn get_otp(
         // holding a *successful* `1;…` envelope — its payload carries
         // the live OTP key + ciphertext, which must never be logged.
         // The other variants only ever carry a rejection message.
+        // The body is server-controlled and could echo back a parameter
+        // we sent, so it goes through `scrub` even though its field name
+        // is outside the leak guard's list. `scrub` only rewrites
+        // credential-shaped `k=v` pairs, leaving a plain rejection
+        // message like `0;  Query String Error` intact.
         let raw_response = match err {
-            LoginError::OtpDecryptionFailed { .. } => "<redacted: success envelope>",
-            _ => envelope.as_str(),
+            LoginError::OtpDecryptionFailed { .. } => "<redacted: success envelope>".to_owned(),
+            _ => scrub(&envelope),
         };
         tracing::warn!(
             error = %err,
             request_url = %redact_otp_url(&url),
             raw_response,
             raw_response_len = envelope.len(),
-            "OTP step 5 failed — verbatim server response logged for diagnosis"
+            "OTP step 5 failed — server response logged for diagnosis"
         );
     }
     result
@@ -470,7 +476,7 @@ async fn step_5_post_otp_v2(
             body_len = body.len(),
             // Byte-slicing the body directly would panic on a preview
             // boundary that lands mid-codepoint.
-            body_preview = %snippet_for_diagnostics(&body),
+            body_preview = %scrub(&snippet_for_diagnostics(&body)),
             "get_webstart_otp_v2.ashx returned a body that is not the expected JSON"
         );
         LoginError::OtpEmptyResponse

--- a/src-tauri/src/services/beanfun/otp.rs
+++ b/src-tauri/src/services/beanfun/otp.rs
@@ -444,11 +444,10 @@ async fn step_5_post_otp_v2(
     client: &BeanfunClient,
     handoff: &LaunchHandoff,
 ) -> Result<String, LoginError> {
-    let launch_ticket = decode_launch_ticket(&handoff.data).map_err(|e| {
-        LoginError::OtpDecryptionFailed {
+    let launch_ticket =
+        decode_launch_ticket(&handoff.data).map_err(|e| LoginError::OtpDecryptionFailed {
             cause: format!("launch data: {e}"),
-        }
-    })?;
+        })?;
 
     let url = client.portal_url("beanfun_block/generic_handlers/get_webstart_otp_v2.ashx")?;
     let resp = client
@@ -720,9 +719,7 @@ fn launch_object_regex() -> &'static Regex {
 /// whole page, so the generic key name cannot match something else.
 fn launch_sn_regex() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| {
-        Regex::new(r#""sn"\s*:\s*"([^"]*)""#).expect("launch sn regex must compile")
-    })
+    RE.get_or_init(|| Regex::new(r#""sn"\s*:\s*"([^"]*)""#).expect("launch sn regex must compile"))
 }
 
 /// `"data"` inside that literal — the obfuscated `LaunchTicket` blob.

--- a/src-tauri/src/services/beanfun/otp.rs
+++ b/src-tauri/src/services/beanfun/otp.rs
@@ -102,6 +102,27 @@
 //! on the same line makes `key=(.*)"` swallow the rest of it). Tightening
 //! those patterns to `([^"]*)` would change what gets matched on real
 //! pages, so it is left alone pending captures from a live server.
+//!
+//! # Two step 5s
+//!
+//! Beanfun replaced step 5. `GET get_webstart_otp.ashx` with its nine
+//! query parameters now answers `0;        Query String Error` no
+//! matter what it is sent; the live endpoint is
+//! `POST get_webstart_otp_v2.ashx` with a JSON body, and the OTP comes
+//! back in a JSON `data` member rather than a `1;…` envelope.
+//!
+//! Both paths live here. [`get_otp`] picks between them on whether
+//! step 1's page carries the `m_objData` launcher-handoff literal —
+//! the page's own shape, not the configured region, so a region that
+//! migrates later needs no code change. TW has migrated; HK has not
+//! been observed to.
+//!
+//! The v2 request needs a `LaunchTicket`, which is *not* a new
+//! server round-trip: it travels obfuscated inside `m_objData.data`,
+//! decoded by [`crate::core::launch_data`]. It also needs `CV` and
+//! `Hash`, which identify the official launcher build and are pinned
+//! as constants here. `docs/OTP-PROTOCOL-CHANGE.md` has the full
+//! derivation and the provenance of those two values.
 
 use std::sync::OnceLock;
 
@@ -109,6 +130,7 @@ use chrono::Local;
 use percent_encoding::percent_decode_str;
 use regex::Regex;
 
+use crate::core::launch_data::decode_launch_ticket;
 use crate::core::parser::{capture_first, extract_service_account_create_time};
 use crate::core::time::{dt_compact_now, dt_iso_now};
 use crate::core::wcdes::decrypt_hex;
@@ -166,6 +188,16 @@ pub async fn get_otp(
     let secret_code = step_2_get_secret_code(client).await?;
     step_3_record_start(client, account, &step1, service_code, service_region).await?;
     step_4_long_poll(client, &step1.long_polling_key).await?;
+    // Branch on the page's own shape rather than on the region: a page
+    // that carries `m_objData` is one whose OTP now comes from the v2
+    // endpoint, and the pre-v2 handler answers every request with
+    // `Query String Error`. Observed migrated on TW; HK's page has no
+    // such literal and keeps the legacy path. If HK migrates later this
+    // needs no change.
+    if let Some(handoff) = &step1.launch {
+        return step_5_post_otp_v2(client, handoff).await;
+    }
+
     let url = build_get_webstart_otp_url(
         client,
         session,
@@ -218,6 +250,22 @@ struct Step1Data {
     /// `account.screatetime` if it was `Some`, or the value
     /// fallback-parsed from this step's response body.
     screatetime: String,
+    /// The launcher-handoff literal, when the page carries one. Only
+    /// the v2 OTP path reads it; `None` on pages without it.
+    launch: Option<LaunchHandoff>,
+}
+
+/// The `m_objData` literal `game_start_step2.aspx` builds for the
+/// native launcher.
+///
+/// Its `region` member is ignored: it is the constant
+/// `"TW;Production"` and no request we make carries it.
+struct LaunchHandoff {
+    /// 36-character GUID, sent as `SN` on the v2 OTP request.
+    sn: String,
+    /// Obfuscated blob carrying the `LaunchTicket`, decoded by
+    /// [`decode_launch_ticket`].
+    data: String,
 }
 
 /// Step 1 — fetch `game_start_step2.aspx`, extract the long-polling
@@ -259,10 +307,15 @@ async fn step_1_init(
         _ => parse_screatetime_fallback(&body)?,
     };
 
+    // Absence is not an error here: the legacy path does not need it,
+    // and the v2 path reports its own typed error when it is missing.
+    let launch = parse_launch_handoff(&body);
+
     Ok(Step1Data {
         long_polling_key,
         unk_data,
         screatetime,
+        launch,
     })
 }
 
@@ -342,6 +395,106 @@ async fn step_4_long_poll(
     Ok(())
 }
 
+/// Identity of the official launcher that `get_webstart_otp_v2.ashx`
+/// expects its caller to present.
+///
+/// `CV` is `GGMWebStart.dll`'s managed assembly version and `Hash` is
+/// the SHA-256 of that file's bytes in lowercase hex — the launcher
+/// computes both at runtime. We cannot, so they are pinned here and
+/// must be re-pinned whenever Gamania ships a new Game Manager;
+/// `generic_handlers/CheckVersion.ashx` announces that in 80 bytes and
+/// is the cheapest way to notice. See `docs/OTP-PROTOCOL-CHANGE.md`.
+///
+/// Values from the reverse engineering in pungin/Beanfun#368 for
+/// Game Manager 1.5.0.2; not independently verified here.
+const GGM_CV: &str = "1.5.0.2";
+const GGM_DLL_SHA256: &str = "dfd568a69d87abcd8f4a93d1a4481ebb57712d1d28ab0b6fc018fcf140101e06";
+/// `Environment.Is64BitProcess` in the launcher. It ships 64-bit.
+const GGM_ARCH: &str = "x64";
+
+/// Body of the v2 OTP request. Field names are PascalCase on the wire
+/// except `arch`, matching the launcher verbatim.
+#[derive(serde::Serialize)]
+struct OtpV2Request<'a> {
+    #[serde(rename = "SN")]
+    sn: &'a str,
+    #[serde(rename = "LaunchTicket")]
+    launch_ticket: &'a str,
+    #[serde(rename = "CV")]
+    cv: &'a str,
+    #[serde(rename = "Hash")]
+    hash: &'a str,
+    arch: &'a str,
+}
+
+/// Reply shape: `{ "result": 1, "data": "…", "message": null }`.
+#[derive(serde::Deserialize)]
+struct OtpV2Response {
+    result: i64,
+    data: Option<String>,
+    message: Option<String>,
+}
+
+/// Step 5 (v2) — `POST get_webstart_otp_v2.ashx` and decrypt the OTP
+/// out of the JSON reply.
+///
+/// Replaces the pre-v2 `GET get_webstart_otp.ashx`, which now answers
+/// `0;        Query String Error` regardless of what it is sent.
+async fn step_5_post_otp_v2(
+    client: &BeanfunClient,
+    handoff: &LaunchHandoff,
+) -> Result<String, LoginError> {
+    let launch_ticket = decode_launch_ticket(&handoff.data).map_err(|e| {
+        LoginError::OtpDecryptionFailed {
+            cause: format!("launch data: {e}"),
+        }
+    })?;
+
+    let url = client.portal_url("beanfun_block/generic_handlers/get_webstart_otp_v2.ashx")?;
+    let resp = client
+        .http()
+        .post(url)
+        .json(&OtpV2Request {
+            sn: &handoff.sn,
+            launch_ticket: &launch_ticket,
+            cv: GGM_CV,
+            hash: GGM_DLL_SHA256,
+            arch: GGM_ARCH,
+        })
+        .send()
+        .await?;
+    ensure_success(&resp, "get_webstart_otp_v2.ashx")?;
+    let body = client.bounded_text(resp).await?;
+
+    let parsed: OtpV2Response = serde_json::from_str(&body).map_err(|_| {
+        tracing::warn!(
+            body_len = body.len(),
+            // Byte-slicing the body directly would panic on a preview
+            // boundary that lands mid-codepoint.
+            body_preview = %snippet_for_diagnostics(&body),
+            "get_webstart_otp_v2.ashx returned a body that is not the expected JSON"
+        );
+        LoginError::OtpEmptyResponse
+    })?;
+
+    if parsed.result != 1 {
+        return Err(LoginError::OtpServerRejected {
+            // Prefer the server's own wording; fall back to the code so
+            // the failure is never reported as an empty string.
+            message: parsed
+                .message
+                .filter(|m| !m.is_empty())
+                .unwrap_or_else(|| format!("result={}", parsed.result)),
+        });
+    }
+
+    let payload = parsed
+        .data
+        .filter(|d| !d.is_empty())
+        .ok_or(LoginError::OtpEmptyResponse)?;
+    decrypt_otp_payload(&payload)
+}
+
 /// Step 5 — read the `1;{key}{ciphertext_hex}` envelope from
 /// `get_webstart_otp.ashx`.
 ///
@@ -398,6 +551,17 @@ fn step_6_decrypt(envelope: &str) -> Result<String, LoginError> {
             message: payload.to_string(),
         });
     }
+    decrypt_otp_payload(payload)
+}
+
+/// Decrypt a `{8-char ASCII key}{ciphertext hex}` OTP payload.
+///
+/// Shared by both protocol versions: the pre-v2 envelope puts this
+/// after `1;`, and `get_webstart_otp_v2.ashx` returns the same shape
+/// as its JSON `data` member. The 40-character `data` observed from
+/// the official launcher is exactly 8 + 32 hex = 8 + two DES blocks,
+/// which is what identifies it as this construction.
+fn decrypt_otp_payload(payload: &str) -> Result<String, LoginError> {
     if payload.len() < 8 {
         return Err(LoginError::OtpDecryptionFailed {
             cause: format!(
@@ -479,6 +643,21 @@ fn parse_screatetime_fallback(html: &str) -> Result<String, LoginError> {
     extract_service_account_create_time(html).ok_or(LoginError::OtpMissingCreateTime)
 }
 
+/// Extract `m_objData` from step 1's response.
+///
+/// Returns `None` when the literal is absent or either member is
+/// missing — the page shape differs by region, and only the v2 OTP
+/// path needs this, so a miss is not an error at scrape time.
+fn parse_launch_handoff(html: &str) -> Option<LaunchHandoff> {
+    let block = capture_first(launch_object_regex(), html)?;
+    let sn = capture_first(launch_sn_regex(), &block)?;
+    let data = capture_first(launch_data_regex(), &block)?;
+    if sn.is_empty() || data.is_empty() {
+        return None;
+    }
+    Some(LaunchHandoff { sn, data })
+}
+
 /// Extract the `m_strSecretCode` JS literal from step 2's response.
 ///
 /// **Deliberate divergence from WPF** (see the "Empty captures" note
@@ -523,6 +702,34 @@ fn secret_code_regex() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
     RE.get_or_init(|| {
         Regex::new(r#"var m_strSecretCode = '(.*)';"#).expect("secret code regex must compile")
+    })
+}
+
+/// The `m_objData = { … }` object literal. `(?s)` lets it span lines
+/// (the page pretty-prints it) and the lazy `.*?` stops at the first
+/// closing brace, which is the end of this flat literal.
+fn launch_object_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r#"(?s)var m_objData\s*=\s*\{(.*?)\}"#)
+            .expect("launch object regex must compile")
+    })
+}
+
+/// `"sn"` inside that literal. Applied to the captured block, not the
+/// whole page, so the generic key name cannot match something else.
+fn launch_sn_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r#""sn"\s*:\s*"([^"]*)""#).expect("launch sn regex must compile")
+    })
+}
+
+/// `"data"` inside that literal — the obfuscated `LaunchTicket` blob.
+fn launch_data_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r#""data"\s*:\s*"([^"]*)""#).expect("launch data regex must compile")
     })
 }
 
@@ -999,6 +1206,101 @@ mod tests {
         assert!(url.contains("ServiceRegion=T9"), "got: {url}");
         assert!(url.contains("ServiceAccount=SID_1"), "got: {url}");
         assert!(url.contains("d=12345"), "got: {url}");
+    }
+
+    // -------------------------------------------------------------------------
+    // parse_launch_handoff
+    // -------------------------------------------------------------------------
+
+    /// Shaped like the real page: pretty-printed across lines, quoted
+    /// keys, and a `region` member we deliberately ignore.
+    const LAUNCH_LITERAL: &str = r#"
+        var supportService = ['300148', '610074'];
+        var m_objData = {
+            "region": "TW;Production",
+            "sn": "11111111-2222-3333-4444-555555555555",
+            "data": "5abcdef0123456789"
+        };
+        var ggmCallback = false;
+    "#;
+
+    #[test]
+    fn launch_handoff_extracts_sn_and_data() {
+        let handoff = parse_launch_handoff(LAUNCH_LITERAL).expect("literal should parse");
+        assert_eq!(handoff.sn, "11111111-2222-3333-4444-555555555555");
+        assert_eq!(handoff.data, "5abcdef0123456789");
+    }
+
+    #[test]
+    fn launch_handoff_absent_is_none_not_an_error() {
+        // The legacy path must keep working on a page without the
+        // literal, so a miss is `None` rather than a failure.
+        assert!(parse_launch_handoff("<html>no launcher handoff here</html>").is_none());
+    }
+
+    #[test]
+    fn launch_handoff_with_empty_members_is_none() {
+        let html = r#"var m_objData = { "sn": "", "data": "" };"#;
+        assert!(parse_launch_handoff(html).is_none());
+    }
+
+    #[test]
+    fn launch_handoff_stops_at_the_literals_own_brace() {
+        // A later object on the page must not be absorbed into the
+        // capture by a greedy match.
+        let html = r#"
+            var m_objData = { "sn": "SN-1", "data": "D-1" };
+            var other = { "sn": "SN-2", "data": "D-2" };
+        "#;
+        let handoff = parse_launch_handoff(html).expect("should parse");
+        assert_eq!(handoff.sn, "SN-1");
+        assert_eq!(handoff.data, "D-1");
+    }
+
+    // -------------------------------------------------------------------------
+    // OtpV2Response
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn otp_v2_response_parses_the_observed_shape() {
+        let parsed: OtpV2Response =
+            serde_json::from_str(r#"{"result":1,"data":"abcdefgh0123","message":null}"#).unwrap();
+        assert_eq!(parsed.result, 1);
+        assert_eq!(parsed.data.as_deref(), Some("abcdefgh0123"));
+        assert!(parsed.message.is_none());
+    }
+
+    #[test]
+    fn otp_v2_response_carries_a_server_message_on_failure() {
+        let parsed: OtpV2Response =
+            serde_json::from_str(r#"{"result":0,"data":null,"message":"nope"}"#).unwrap();
+        assert_eq!(parsed.result, 0);
+        assert_eq!(parsed.message.as_deref(), Some("nope"));
+    }
+
+    // -------------------------------------------------------------------------
+    // decrypt_otp_payload
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn otp_payload_round_trips_through_the_shared_decryptor() {
+        // 8 bytes of plaintext = one DES block, giving 8 + 16 hex = a
+        // 24-character payload of the same shape as the wire format.
+        let key = "a1b2c3d4";
+        let cipher_hex = crate::core::wcdes::encrypt_hex("OTP12345", key).unwrap();
+        let payload = format!("{key}{cipher_hex}");
+        assert_eq!(decrypt_otp_payload(&payload).unwrap(), "OTP12345");
+    }
+
+    /// The launcher's reply carries a 40-character `data`. That is
+    /// exactly an 8-character key plus 32 hex characters — two DES
+    /// blocks — which is what identifies it as the same envelope the
+    /// pre-v2 protocol used. Pinned so the reasoning survives.
+    #[test]
+    fn observed_v2_payload_length_is_key_plus_whole_des_blocks() {
+        let hex_len = 40 - 8;
+        assert_eq!(hex_len % 2, 0);
+        assert_eq!((hex_len / 2) % 8, 0);
     }
 
     // -------------------------------------------------------------------------

--- a/src-tauri/src/services/beanfun/otp.rs
+++ b/src-tauri/src/services/beanfun/otp.rs
@@ -119,15 +119,24 @@
 //!
 //! The v2 request needs a `LaunchTicket`, which is *not* a new
 //! server round-trip: it travels obfuscated inside `m_objData.data`,
-//! decoded by [`crate::core::launch_data`]. It also needs `CV` and
-//! `Hash`, which identify the official launcher build and are pinned
-//! as constants here. `docs/OTP-PROTOCOL-CHANGE.md` has the full
-//! derivation and the provenance of those two values.
+//! decoded by [`crate::core::launch_data`]. It also needs `CV`,
+//! `Hash` and `arch`, which identify the official launcher build and
+//! come from [`super::client_integrity`].
+//! `docs/OTP-PROTOCOL-CHANGE.md` has the full derivation.
+//!
+//! # The same three values on the legacy path
+//!
+//! The pre-v2 `GET` grew the identical `&CV=…&Hash=…&arch=…` suffix in
+//! Game Manager 1.5.x — `GGM.Shared.Beanfun.BeanfunUrlBuilder.BuildOtpUrl`
+//! appends it — and rejects requests that omit it. Sending it keeps the
+//! legacy fallback above genuinely usable rather than doomed the moment
+//! it is reached. HK, whose page carries no `m_objData` and whose portal
+//! has not been observed to want the suffix, is left byte-identical.
 
 use std::sync::OnceLock;
 
 use chrono::Local;
-use percent_encoding::percent_decode_str;
+use percent_encoding::{percent_decode_str, utf8_percent_encode, AsciiSet, NON_ALPHANUMERIC};
 use regex::Regex;
 
 use crate::core::launch_data::decode_launch_ticket;
@@ -137,6 +146,7 @@ use crate::core::time::{dt_compact_now, dt_iso_now};
 use crate::core::wcdes::decrypt_hex;
 use crate::services::beanfun::account::ServiceAccount;
 use crate::services::beanfun::client::{BeanfunClient, LoginRegion};
+use crate::services::beanfun::client_integrity::ClientIntegrity;
 use crate::services::beanfun::error::LoginError;
 use crate::services::beanfun::login::ensure_success;
 use crate::services::beanfun::session::Session;
@@ -195,8 +205,12 @@ pub async fn get_otp(
     // `Query String Error`. Observed migrated on TW; HK's page has no
     // such literal and keeps the legacy path. If HK migrates later this
     // needs no change.
+    // Both step 5s identify the caller with the same three values, so
+    // resolve them once here rather than in each branch.
+    let integrity = resolve_client_integrity().await;
+
     if let Some(handoff) = &step1.launch {
-        return step_5_post_otp_v2(client, handoff).await;
+        return step_5_post_otp_v2(client, handoff, &integrity).await;
     }
 
     let url = build_get_webstart_otp_url(
@@ -208,6 +222,13 @@ pub async fn get_otp(
         service_code,
         service_region,
         tick_count_ms(),
+        // The suffix is a Game Manager convention, and the Game Manager
+        // is a TW/OATW product; HK's legacy endpoint has not been
+        // observed to want it, so its request stays as it was.
+        match client.config().region {
+            LoginRegion::TW => Some(&integrity),
+            LoginRegion::HK => None,
+        },
     )?;
     let envelope = step_5_get_otp(client, &url).await?;
 
@@ -401,22 +422,20 @@ async fn step_4_long_poll(
     Ok(())
 }
 
-/// Identity of the official launcher that `get_webstart_otp_v2.ashx`
-/// expects its caller to present.
+/// Resolve the launcher identity off the async executor.
 ///
-/// `CV` is `GGMWebStart.dll`'s managed assembly version and `Hash` is
-/// the SHA-256 of that file's bytes in lowercase hex — the launcher
-/// computes both at runtime. We cannot, so they are pinned here and
-/// must be re-pinned whenever Gamania ships a new Game Manager;
-/// `generic_handlers/CheckVersion.ashx` announces that in 80 bytes and
-/// is the cheapest way to notice. See `docs/OTP-PROTOCOL-CHANGE.md`.
-///
-/// Values from the reverse engineering in pungin/Beanfun#368 for
-/// Game Manager 1.5.0.2; not independently verified here.
-const GGM_CV: &str = "1.5.0.2";
-const GGM_DLL_SHA256: &str = "dfd568a69d87abcd8f4a93d1a4481ebb57712d1d28ab0b6fc018fcf140101e06";
-/// `Environment.Is64BitProcess` in the launcher. It ships 64-bit.
-const GGM_ARCH: &str = "x64";
+/// [`ClientIntegrity::resolve`] reads and hashes a ~1.3 MB file; a cold
+/// cache makes that long enough to be worth handing to `spawn_blocking`.
+/// A join failure (runtime shutting down) degrades to the bundled
+/// constants rather than failing the OTP outright.
+async fn resolve_client_integrity() -> ClientIntegrity {
+    tokio::task::spawn_blocking(ClientIntegrity::resolve)
+        .await
+        .unwrap_or_else(|e| {
+            tracing::warn!(error = %e, "client-integrity resolve task failed; using bundled constants");
+            ClientIntegrity::fallback()
+        })
+}
 
 /// Body of the v2 OTP request. Field names are PascalCase on the wire
 /// except `arch`, matching the launcher verbatim.
@@ -449,6 +468,7 @@ struct OtpV2Response {
 async fn step_5_post_otp_v2(
     client: &BeanfunClient,
     handoff: &LaunchHandoff,
+    integrity: &ClientIntegrity,
 ) -> Result<String, LoginError> {
     let launch_ticket =
         decode_launch_ticket(&handoff.data).map_err(|e| LoginError::OtpDecryptionFailed {
@@ -462,9 +482,9 @@ async fn step_5_post_otp_v2(
         .json(&OtpV2Request {
             sn: &handoff.sn,
             launch_ticket: &launch_ticket,
-            cv: GGM_CV,
-            hash: GGM_DLL_SHA256,
-            arch: GGM_ARCH,
+            cv: &integrity.cv,
+            hash: &integrity.hash,
+            arch: integrity.arch,
         })
         .send()
         .await?;
@@ -778,6 +798,18 @@ fn tick_count_ms() -> i32 {
 ///
 /// All other characters in the URL (cookies, sids, hex digits) are
 /// already URL-safe, so a literal `format!` is sufficient.
+/// Characters `Uri.EscapeDataString` leaves alone: the RFC 3986
+/// unreserved set (`ALPHA / DIGIT / "-" / "." / "_" / "~"`).
+///
+/// [`NON_ALPHANUMERIC`] escapes the four punctuation marks too, so they
+/// are removed to match .NET exactly — a dotted version would otherwise
+/// go out as `1%2E5%2E0%2E2`.
+const ESCAPE_DATA_STRING: &AsciiSet = &NON_ALPHANUMERIC
+    .remove(b'-')
+    .remove(b'.')
+    .remove(b'_')
+    .remove(b'~');
+
 #[allow(clippy::too_many_arguments)]
 fn build_get_webstart_otp_url(
     client: &BeanfunClient,
@@ -788,12 +820,13 @@ fn build_get_webstart_otp_url(
     service_code: &str,
     service_region: &str,
     tick: i32,
+    integrity: Option<&ClientIntegrity>,
 ) -> Result<String, LoginError> {
     let base = client.portal_url("beanfun_block/generic_handlers/get_webstart_otp.ashx")?;
     // WPF replaces only spaces with `%20`; every other char in the
     // screatetime format (`yyyy-MM-dd HH:mm:ss`) is already URL-safe.
     let create_time_encoded = step1.screatetime.replace(' ', "%20");
-    Ok(format!(
+    let mut url = format!(
         "{base}?SN={sn}&WebToken={web_token}&SecretCode={secret_code}&ppppp={ppppp}&ServiceCode={sc}&ServiceRegion={sr}&ServiceAccount={sid}&CreateTime={create_time}&d={tick}",
         base = base,
         sn = step1.long_polling_key,
@@ -805,7 +838,21 @@ fn build_get_webstart_otp_url(
         sid = account.sid,
         create_time = create_time_encoded,
         tick = tick,
-    ))
+    );
+    if let Some(integrity) = integrity {
+        use std::fmt::Write as _;
+        // Appended last, in this order, exactly as `BuildOtpUrl` does.
+        // Infallible for a String sink; the result is discarded rather
+        // than unwrapped to keep the builder panic-free.
+        let _ = write!(
+            url,
+            "&CV={cv}&Hash={hash}&arch={arch}",
+            cv = utf8_percent_encode(&integrity.cv, ESCAPE_DATA_STRING),
+            hash = utf8_percent_encode(&integrity.hash, ESCAPE_DATA_STRING),
+            arch = utf8_percent_encode(integrity.arch, ESCAPE_DATA_STRING),
+        );
+    }
+    Ok(url)
 }
 
 /// Secret-bearing query parameters of step 5's URL. Their values are
@@ -1155,14 +1202,12 @@ mod tests {
     // build_get_webstart_otp_url
     // -------------------------------------------------------------------------
 
-    #[test]
-    fn step5_url_replaces_screatetime_spaces_with_percent20() {
-        // Build a tiny client + session and verify the URL string
-        // contains `%20` (not `+`) where screatetime had a space.
+    /// Shared fixture for the legacy URL-builder tests.
+    fn step5_url_fixture(region: LoginRegion, integrity: Option<&ClientIntegrity>) -> String {
         use crate::services::beanfun::client::ClientConfig;
-        let client = BeanfunClient::new(ClientConfig::for_region(LoginRegion::TW)).unwrap();
+        let client = BeanfunClient::new(ClientConfig::for_region(region)).unwrap();
         let session = Session::new(
-            LoginRegion::TW,
+            region,
             "SKEY_X",
             "WEB_TOKEN_X",
             "ACCOUNT_ID_X",
@@ -1184,14 +1229,29 @@ mod tests {
             long_polling_key: "LPK".to_string(),
             unk_data: None,
             screatetime: "2024-01-15 12:34:56".to_string(),
-            // This test covers the legacy URL builder, which is the
+            // These tests cover the legacy URL builder, which is the
             // path taken precisely when the page carried no handoff.
             launch: None,
         };
-        let url = build_get_webstart_otp_url(
-            &client, &session, &account, &step1, "SECRET", "610074", "T9", 12345,
+        build_get_webstart_otp_url(
+            &client, &session, &account, &step1, "SECRET", "610074", "T9", 12345, integrity,
         )
-        .unwrap();
+        .unwrap()
+    }
+
+    fn test_integrity() -> ClientIntegrity {
+        ClientIntegrity {
+            cv: "1.5.0.2".to_string(),
+            hash: "dfd568a69d87abcd8f4a93d1a4481ebb57712d1d28ab0b6fc018fcf140101e06".to_string(),
+            arch: "x64",
+        }
+    }
+
+    #[test]
+    fn step5_url_replaces_screatetime_spaces_with_percent20() {
+        // Build a tiny client + session and verify the URL string
+        // contains `%20` (not `+`) where screatetime had a space.
+        let url = step5_url_fixture(LoginRegion::TW, None);
 
         assert!(
             url.contains("CreateTime=2024-01-15%2012:34:56"),
@@ -1212,6 +1272,72 @@ mod tests {
         assert!(url.contains("ServiceRegion=T9"), "got: {url}");
         assert!(url.contains("ServiceAccount=SID_1"), "got: {url}");
         assert!(url.contains("d=12345"), "got: {url}");
+    }
+
+    // -------------------------------------------------------------------------
+    // build_get_webstart_otp_url — client-integrity suffix
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn step5_url_appends_client_integrity_suffix_after_the_cache_buster() {
+        // `BuildOtpUrl` appends CV/Hash/arch last, in that order, after
+        // `&d=`. Pin the whole tail so a future reordering is caught.
+        let integrity = test_integrity();
+        let url = step5_url_fixture(LoginRegion::TW, Some(&integrity));
+
+        assert!(
+            url.ends_with(
+                "&d=12345&CV=1.5.0.2&Hash=dfd568a69d87abcd8f4a93d1a4481ebb57712d1d28ab0b6fc018fcf140101e06&arch=x64"
+            ),
+            "got: {url}",
+        );
+    }
+
+    #[test]
+    fn step5_url_omits_the_suffix_entirely_when_integrity_is_absent() {
+        // The HK path: not an empty `&CV=&Hash=&arch=`, but no suffix at
+        // all, so HK's request stays byte-identical to before.
+        let url = step5_url_fixture(LoginRegion::HK, None);
+
+        assert!(url.ends_with("&d=12345"), "got: {url}");
+        assert!(!url.contains("CV="), "got: {url}");
+        assert!(!url.contains("Hash="), "got: {url}");
+        assert!(!url.contains("arch="), "got: {url}");
+    }
+
+    #[test]
+    fn step5_url_leaves_unreserved_characters_in_the_suffix_unescaped() {
+        // `Uri.EscapeDataString` preserves `-._~`; a naive
+        // `NON_ALPHANUMERIC` set would emit `1%2E5%2E0%2E2` and the
+        // server would reject the version.
+        let integrity = ClientIntegrity {
+            cv: "1.5.0.2-beta_1~x".to_string(),
+            hash: "abc".to_string(),
+            arch: "x64",
+        };
+        let url = step5_url_fixture(LoginRegion::TW, Some(&integrity));
+
+        assert!(url.contains("&CV=1.5.0.2-beta_1~x"), "got: {url}");
+        assert!(!url.contains("%2E"), "got: {url}");
+        assert!(!url.contains("%2D"), "got: {url}");
+        assert!(!url.contains("%5F"), "got: {url}");
+        assert!(!url.contains("%7E"), "got: {url}");
+    }
+
+    #[test]
+    fn step5_url_percent_encodes_reserved_characters_in_the_suffix() {
+        // Defensive: a malformed local launcher version must not be
+        // able to inject extra query parameters into the request.
+        let integrity = ClientIntegrity {
+            cv: "1.0&Hash=evil".to_string(),
+            hash: "aa".to_string(),
+            arch: "x64",
+        };
+        let url = step5_url_fixture(LoginRegion::TW, Some(&integrity));
+
+        assert!(url.contains("&CV=1.0%26Hash%3Devil"), "got: {url}");
+        // Exactly one real `Hash=` parameter survives.
+        assert_eq!(url.matches("&Hash=").count(), 1, "got: {url}");
     }
 
     // -------------------------------------------------------------------------

--- a/src-tauri/src/services/beanfun/otp.rs
+++ b/src-tauri/src/services/beanfun/otp.rs
@@ -198,7 +198,7 @@ pub async fn get_otp(
     let step1 = step_1_init(client, account, service_code, service_region).await?;
     let secret_code = step_2_get_secret_code(client).await?;
     step_3_record_start(client, account, &step1, service_code, service_region).await?;
-    step_4_long_poll(client, &step1.long_polling_key).await?;
+
     // Branch on the page's own shape rather than on the region: a page
     // that carries `m_objData` is one whose OTP now comes from the v2
     // endpoint, and the pre-v2 handler answers every request with
@@ -210,8 +210,15 @@ pub async fn get_otp(
     let integrity = resolve_client_integrity().await;
 
     if let Some(handoff) = &step1.launch {
-        return step_5_post_otp_v2(client, handoff, &integrity).await;
+        // Deliberately no long poll on this path. The page's
+        // `GetResultByLongPolling` call is the launcher's installation
+        // check, unrelated to the password, and it holds the connection
+        // open — waiting on it only delays every retrieval.
+        return step_5_post_otp_v2(client, handoff, &integrity, &step1.page_url).await;
     }
+
+    // The legacy path still primes server-side state with it.
+    step_4_long_poll(client, &step1.long_polling_key).await?;
 
     let url = build_get_webstart_otp_url(
         client,
@@ -277,6 +284,14 @@ struct Step1Data {
     /// `account.screatetime` if it was `Some`, or the value
     /// fallback-parsed from this step's response body.
     screatetime: String,
+    /// The page's own URL, query and all.
+    ///
+    /// Handlers under `generic_handlers` began checking `Referer`, and
+    /// answer `The URL referrer is null or from a different domain!`
+    /// without one. Being same-origin, and with beanfun's
+    /// `strict-origin-when-cross-origin` policy, a browser sends this
+    /// whole URL — so we send exactly it.
+    page_url: String,
     /// The launcher-handoff literal, when the page carries one. Only
     /// the v2 OTP path reads it; `None` on pages without it.
     launch: Option<LaunchHandoff>,
@@ -305,18 +320,16 @@ async fn step_1_init(
     service_code: &str,
     service_region: &str,
 ) -> Result<Step1Data, LoginError> {
-    let url = client.portal_url("beanfun_block/game_zone/game_start_step2.aspx")?;
-    let resp = client
-        .http()
-        .get(url)
-        .query(&[
-            ("service_code", service_code),
-            ("service_region", service_region),
-            ("sotp", account.ssn.as_str()),
-            ("dt", dt_compact_now().as_str()),
-        ])
-        .send()
-        .await?;
+    let mut url = client.portal_url("beanfun_block/game_zone/game_start_step2.aspx")?;
+    url.query_pairs_mut()
+        .append_pair("service_code", service_code)
+        .append_pair("service_region", service_region)
+        .append_pair("sotp", account.ssn.as_str())
+        .append_pair("dt", dt_compact_now().as_str());
+    // Kept because the handlers below are now asked to name the page
+    // that sent them; see `Step1Data::page_url`.
+    let page_url = url.to_string();
+    let resp = client.http().get(url).send().await?;
     ensure_success(&resp, "game_start_step2.aspx")?;
     let body = client.bounded_text(resp).await?;
 
@@ -339,6 +352,7 @@ async fn step_1_init(
     let launch = parse_launch_handoff(&body);
 
     Ok(Step1Data {
+        page_url,
         long_polling_key,
         unk_data,
         screatetime,
@@ -387,7 +401,15 @@ async fn step_3_record_start(
         form.push((k.as_str(), v.as_str()));
     }
 
-    let resp = client.http().post(url).form(&form).send().await?;
+    // Same referrer requirement as the v2 endpoint — this handler
+    // lives under `generic_handlers` too.
+    let resp = client
+        .http()
+        .post(url)
+        .header(reqwest::header::REFERER, step1.page_url.as_str())
+        .form(&form)
+        .send()
+        .await?;
     ensure_success(&resp, "record_service_start.ashx")?;
     // Body deliberately not read — WPF discards `UploadString`'s
     // return value (L91-94). We must still consume the connection so
@@ -469,6 +491,7 @@ async fn step_5_post_otp_v2(
     client: &BeanfunClient,
     handoff: &LaunchHandoff,
     integrity: &ClientIntegrity,
+    referer: &str,
 ) -> Result<String, LoginError> {
     let launch_ticket =
         decode_launch_ticket(&handoff.data).map_err(|e| LoginError::OtpDecryptionFailed {
@@ -479,6 +502,7 @@ async fn step_5_post_otp_v2(
     let resp = client
         .http()
         .post(url)
+        .header(reqwest::header::REFERER, referer)
         .json(&OtpV2Request {
             sn: &handoff.sn,
             launch_ticket: &launch_ticket,
@@ -1226,6 +1250,8 @@ mod tests {
             sauthtype: None,
         };
         let step1 = Step1Data {
+            page_url: "https://tw.beanfun.com/beanfun_block/game_zone/game_start_step2.aspx"
+                .to_string(),
             long_polling_key: "LPK".to_string(),
             unk_data: None,
             screatetime: "2024-01-15 12:34:56".to_string(),

--- a/src-tauri/tests/otp.rs
+++ b/src-tauri/tests/otp.rs
@@ -27,14 +27,15 @@
 //! | wire shape: step 3 form payload includes `unk_data` (TW)   | wiremock body matcher confirms the extra k=v field                       |
 //! | wire shape: step 5 URL contains `%20`, `ppppp=`, `sid=...` | wiremock query/path matchers confirm verbatim WPF byte format            |
 
+use beanfun_lib::core::launch_data::TABLES;
 use beanfun_lib::core::wcdes::encrypt_hex;
 use beanfun_lib::services::beanfun::{
     get_otp, BeanfunClient, ClientConfig, Endpoints, LoginError, LoginRegion, ServiceAccount,
     Session,
 };
 use url::Url;
-use wiremock::matchers::{body_string_contains, method, path, query_param};
-use wiremock::{Mock, MockServer, ResponseTemplate};
+use wiremock::matchers::{body_string_contains, header_exists, method, path, query_param};
+use wiremock::{Mock, MockServer, Request, ResponseTemplate};
 
 const SERVICE_CODE: &str = "610074";
 const SERVICE_REGION: &str = "T9";
@@ -596,4 +597,162 @@ async fn hk_step5_url_omits_the_client_integrity_triple() {
     assert!(!query.contains_key("CV"), "HK must not send CV");
     assert!(!query.contains_key("Hash"), "HK must not send Hash");
     assert!(!query.contains_key("arch"), "HK must not send arch");
+}
+
+// -----------------------------------------------------------------------------
+// Group F — the v2 route, on the wire
+// -----------------------------------------------------------------------------
+
+/// Encode a launch payload the way the game-start page does, so the
+/// decoder is exercised against the construction rather than against a
+/// restatement of itself.
+fn launch_payload(plaintext: &str, key: &str, selector: usize, table: &str) -> String {
+    let mut padded = plaintext.to_string();
+    while padded.len() % 8 != 0 {
+        padded.push(char::from(0));
+    }
+    let cipher_hex = encrypt_hex(&padded, key).expect("encrypts");
+
+    let at = selector + 1;
+    let mut normalized = String::new();
+    normalized.push_str(&cipher_hex[..at]);
+    normalized.push_str(key);
+    normalized.push_str(&cipher_hex[at..]);
+
+    let mut out = String::new();
+    out.push(char::from_digit(selector as u32, 16).expect("selector is one hex digit"));
+    for c in normalized.chars() {
+        let index = c.to_digit(16).expect("normalized is hex") as usize;
+        out.push(table.chars().nth(index).expect("table covers every nibble"));
+    }
+    out
+}
+
+/// A migrated TW page: everything step 1 already parses, plus the
+/// launcher hand-off.
+fn step1_body_tw_migrated(payload: &str) -> String {
+    format!(
+        "<script>\nServiceAccountCreateTime: \"2024-01-15 12:34:56\";\nurl = \"GetResultByLongPolling&key=LPK_OK\";\nfoo = MyAccountData.ServiceAccountCreateTime + \"k=v\";\nvar m_objData = {{ \"region\": \"TW;Production\", \"sn\": \"SN-1234\", \"data\": \"{payload}\" }};\n</script>"
+    )
+}
+
+/// The v2 payload: eight characters of ASCII key, then the ciphertext.
+fn v2_data(otp: &str, key: &str) -> String {
+    let mut padded = otp.to_string();
+    while padded.len() % 8 != 0 {
+        padded.push(char::from(0));
+    }
+    format!("{key}{}", encrypt_hex(&padded, key).expect("encrypts"))
+}
+
+/// The v2 exchange, pinned where it actually broke.
+///
+/// Three things moved at once when beanfun migrated TW, and each is
+/// invisible until it fails in the field:
+///
+/// - handlers under `generic_handlers` began checking `Referer`, and
+///   answer a complaint about a null referrer without one;
+/// - the request has to name which launcher build is asking, or the
+///   endpoint says `Query String Error`;
+/// - the retired endpoint refuses everything, so calling it buys only a
+///   wait on the way to the real failure.
+#[tokio::test]
+async fn tw_v2_names_the_page_and_the_build_and_leaves_the_old_endpoint_alone() {
+    let server = MockServer::start().await;
+    let client = client_for(&server, LoginRegion::TW);
+    let session = test_session(LoginRegion::TW);
+    let account = account_with(Some("2024-01-15 12:34:56"));
+
+    let ticket = "a".repeat(64);
+    let plaintext = format!("LaunchTicket={ticket}&ServiceAccount=acct");
+    // Selector 5 with a table `n % 4` cannot reach: a payload the old
+    // four-table decoder would have failed on.
+    let payload = launch_payload(&plaintext, "1a2b3c4d", 5, TABLES[6]);
+
+    mount_step1(&server, &step1_body_tw_migrated(&payload)).await;
+    mount_step2(&server, "var m_strSecretCode = 'SECRET_OK';").await;
+    mount_step3_ok(&server).await;
+
+    Mock::given(method("POST"))
+        .and(path(
+            "/beanfun_block/generic_handlers/get_webstart_otp_v2.ashx",
+        ))
+        .and(header_exists("referer"))
+        .respond_with(move |req: &Request| {
+            let body: serde_json::Value =
+                serde_json::from_slice(&req.body).expect("request body is JSON");
+            assert_eq!(body["SN"], "SN-1234", "the endpoint keys on the page's sn");
+            assert_eq!(body["LaunchTicket"], ticket, "the decoded ticket is sent");
+            for field in ["CV", "Hash", "arch"] {
+                assert!(
+                    body[field].as_str().is_some_and(|v| !v.is_empty()),
+                    "{field} must name the build asking, or the endpoint refuses"
+                );
+            }
+            ResponseTemplate::new(200).set_body_string(format!(
+                r#"{{"result":1,"data":"{}","message":null}}"#,
+                v2_data("OTP12345", "ABCDEFGH")
+            ))
+        })
+        .mount(&server)
+        .await;
+
+    let otp = get_otp(&client, &session, &account, SERVICE_CODE, SERVICE_REGION)
+        .await
+        .expect("v2 OTP");
+    assert_eq!(otp, "OTP12345");
+
+    let requests = server.received_requests().await.unwrap_or_default();
+    assert!(
+        !requests
+            .iter()
+            .any(|r| r.url.path().ends_with("get_webstart_otp.ashx")),
+        "the retired endpoint must not be called on a migrated page"
+    );
+    assert!(
+        !requests
+            .iter()
+            .any(|r| r.url.path().ends_with("get_result.ashx")),
+        "the launcher's install check must not be awaited for a password"
+    );
+}
+
+/// A refusal has to arrive as the endpoint's own words.
+///
+/// `Query String Error` names the cause — a build it does not accept —
+/// and collapsing it into a generic parse failure sends the next
+/// maintainer looking at the decoder instead.
+#[tokio::test]
+async fn tw_v2_refusal_surfaces_the_server_message() {
+    let server = MockServer::start().await;
+    let client = client_for(&server, LoginRegion::TW);
+    let session = test_session(LoginRegion::TW);
+    let account = account_with(Some("2024-01-15 12:34:56"));
+
+    // The decoder rightly insists on a 64-hex ticket, so the fixture
+    // has to look like one.
+    let plaintext = format!("LaunchTicket={}&ServiceAccount=acct", "b".repeat(64));
+    let payload = launch_payload(&plaintext, "1a2b3c4d", 2, TABLES[2]);
+    mount_step1(&server, &step1_body_tw_migrated(&payload)).await;
+    mount_step2(&server, "var m_strSecretCode = 'SECRET_OK';").await;
+    mount_step3_ok(&server).await;
+
+    Mock::given(method("POST"))
+        .and(path(
+            "/beanfun_block/generic_handlers/get_webstart_otp_v2.ashx",
+        ))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string(r#"{"result":0,"data":null,"message":"Query String Error"}"#),
+        )
+        .mount(&server)
+        .await;
+
+    let err = get_otp(&client, &session, &account, SERVICE_CODE, SERVICE_REGION)
+        .await
+        .expect_err("a refusal must surface");
+    assert!(
+        format!("{err}").contains("Query String Error"),
+        "the endpoint's own message must survive, got: {err}"
+    );
 }

--- a/src-tauri/tests/otp.rs
+++ b/src-tauri/tests/otp.rs
@@ -507,3 +507,93 @@ async fn step5_url_carries_ppppp_literal_and_percent20_create_time() {
         .expect("step 5 URL shape happy path");
     assert_eq!(otp, "OK______");
 }
+
+#[tokio::test]
+async fn tw_step5_url_carries_the_client_integrity_triple() {
+    // Issue #368: beanfun answers `0;Query String Error` unless the TW
+    // request fingerprints the client with CV/Hash/arch. The exact
+    // values depend on whether this machine has Gamania Games Manager
+    // installed, so assert their *shape* (a dotted version, 64 lowercase
+    // hex chars, a known arch) rather than pinning the bundled
+    // constants — that keeps the test honest on both kinds of host.
+    let server = MockServer::start().await;
+    let client = client_for(&server, LoginRegion::TW);
+    let session = test_session(LoginRegion::TW);
+    let account = account_with(Some("2024-01-15 12:34:56"));
+    let envelope = make_envelope("ABCDEFGH", "OTPINTEG");
+
+    mount_step1(&server, &step1_body_tw("LPK_CI", "k=v", None)).await;
+    mount_step2(&server, "var m_strSecretCode = 'SECRET';").await;
+    mount_step3_ok(&server).await;
+    mount_step4_ok(&server).await;
+    mount_step5(&server, &envelope).await;
+
+    let otp = get_otp(&client, &session, &account, SERVICE_CODE, SERVICE_REGION)
+        .await
+        .expect("TW OTP succeeds with the integrity suffix");
+    assert_eq!(otp, "OTPINTEG");
+
+    let requests = server
+        .received_requests()
+        .await
+        .expect("wiremock records requests");
+    let step5 = requests
+        .iter()
+        .find(|r| r.url.path() == "/beanfun_block/generic_handlers/get_webstart_otp.ashx")
+        .expect("step 5 was requested");
+    let query: std::collections::HashMap<_, _> = step5.url.query_pairs().into_owned().collect();
+
+    let cv = query.get("CV").expect("CV must be present on TW");
+    assert!(
+        cv.split('.')
+            .all(|part| !part.is_empty() && part.chars().all(|c| c.is_ascii_digit())),
+        "CV should be a dotted numeric version, got {cv}",
+    );
+
+    let hash = query.get("Hash").expect("Hash must be present on TW");
+    assert_eq!(hash.len(), 64, "Hash should be a SHA-256 hex digest");
+    assert!(
+        hash.chars()
+            .all(|c| c.is_ascii_digit() || ('a'..='f').contains(&c)),
+        "Hash should be lowercase hex, got {hash}",
+    );
+
+    let arch = query.get("arch").expect("arch must be present on TW");
+    assert!(arch == "x64" || arch == "x86", "unexpected arch {arch}");
+}
+
+#[tokio::test]
+async fn hk_step5_url_omits_the_client_integrity_triple() {
+    // Gamania Games Manager is a TW/OATW product, so HK's request must
+    // stay byte-identical to its pre-#368 shape.
+    let server = MockServer::start().await;
+    let client = client_for(&server, LoginRegion::HK);
+    let session = test_session(LoginRegion::HK);
+    let account = account_with(Some("2024-02-29 00:00:01"));
+    let envelope = make_envelope("HKKEY123", "HKNOINTG");
+
+    mount_step1(&server, &step1_body_hk("LPK_HK", None)).await;
+    mount_step2(&server, "var m_strSecretCode = 'SECRET_HK';").await;
+    mount_step3_ok(&server).await;
+    mount_step4_ok(&server).await;
+    mount_step5(&server, &envelope).await;
+
+    let otp = get_otp(&client, &session, &account, SERVICE_CODE, SERVICE_REGION)
+        .await
+        .expect("HK OTP succeeds without the integrity suffix");
+    assert_eq!(otp, "HKNOINTG");
+
+    let requests = server
+        .received_requests()
+        .await
+        .expect("wiremock records requests");
+    let step5 = requests
+        .iter()
+        .find(|r| r.url.path() == "/beanfun_block/generic_handlers/get_webstart_otp.ashx")
+        .expect("step 5 was requested");
+    let query: std::collections::HashMap<_, _> = step5.url.query_pairs().into_owned().collect();
+
+    assert!(!query.contains_key("CV"), "HK must not send CV");
+    assert!(!query.contains_key("Hash"), "HK must not send Hash");
+    assert!(!query.contains_key("arch"), "HK must not send arch");
+}

--- a/src-tauri/tests/otp.rs
+++ b/src-tauri/tests/otp.rs
@@ -756,3 +756,63 @@ async fn tw_v2_refusal_surfaces_the_server_message() {
         "the endpoint's own message must survive, got: {err}"
     );
 }
+
+/// A migrated page carries the handoff and nothing else.
+///
+/// The literals the old flow read are gone with the flow that used
+/// them: the page no longer polls, so there is no
+/// `GetResultByLongPolling&key=`, and no `MyAccountData` form fragment
+/// either. This is the shape the live TW page actually has.
+fn step1_body_tw_migrated_only_handoff(payload: &str) -> String {
+    format!(
+        "<script>\nvar m_objData = {{ \"region\": \"TW;Production\", \"sn\": \"SN-1234\", \"data\": \"{payload}\" }};\n</script>"
+    )
+}
+
+/// The retired literals must not be required to reach the handoff.
+///
+/// Demanding them ran the retrieval into a failure that named a literal
+/// which is *meant* to be absent — before the handoff sitting in the
+/// same page had even been read. On the live TW page there is nothing
+/// else left to parse, so this is the case that matters most.
+#[tokio::test]
+async fn tw_v2_works_on_a_page_that_kept_only_the_handoff() {
+    let server = MockServer::start().await;
+    let client = client_for(&server, LoginRegion::TW);
+    let session = test_session(LoginRegion::TW);
+    // No stored create time either, so the fallback scrape is exercised
+    // on a page that has nothing to give it.
+    let account = account_with(None);
+
+    let ticket = "c".repeat(64);
+    let plaintext = format!("LaunchTicket={ticket}&ServiceAccount=acct");
+    let payload = launch_payload(&plaintext, "1a2b3c4d", 4, TABLES[4]);
+
+    mount_step1(&server, &step1_body_tw_migrated_only_handoff(&payload)).await;
+    // Deliberately no secret-code and no service-start mocks: the v2
+    // route must not depend on either. An unmatched request would fail
+    // the exchange, which is exactly what this asserts.
+    Mock::given(method("POST"))
+        .and(path(
+            "/beanfun_block/generic_handlers/get_webstart_otp_v2.ashx",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_string(format!(
+            r#"{{"result":1,"data":"{}","message":null}}"#,
+            v2_data("OTP98765", "ABCDEFGH")
+        )))
+        .mount(&server)
+        .await;
+
+    let otp = get_otp(&client, &session, &account, SERVICE_CODE, SERVICE_REGION)
+        .await
+        .expect("a page with only the handoff must still yield a password");
+    assert_eq!(otp, "OTP98765");
+
+    let requests = server.received_requests().await.unwrap_or_default();
+    assert!(
+        !requests
+            .iter()
+            .any(|r| r.url.path().ends_with("get_cookies.ashx")),
+        "the v2 request carries no secret code, so fetching one is a wasted round trip"
+    );
+}

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -509,6 +509,14 @@ const zhTW = {
       invalid_totp: '驗證碼錯誤，請重新輸入。',
       not_logged_in: '尚未登入。',
       gamepass_window_already_open: 'GamePass 登入視窗已開啟，請先關閉再重新嘗試。',
+      otp_missing_long_polling_key: '取得遊戲密碼失敗：伺服器頁面格式無法辨識，請重新登入後再試。',
+      otp_missing_unk_data: '取得遊戲密碼失敗：伺服器頁面格式無法辨識，請重新登入後再試。',
+      otp_missing_create_time: '取得遊戲密碼失敗：找不到帳號建立時間，請重新整理帳號列表後再試。',
+      otp_missing_secret_code: '取得遊戲密碼失敗：登入狀態可能已失效，請重新登入後再試。',
+      otp_empty_response: '伺服器未回應遊戲密碼，請稍後再試。',
+      otp_server_rejected:
+        '伺服器拒絕了取得遊戲密碼的請求，請重新登入後再試；若持續發生，可能為官方維護中。',
+      otp_decryption_failed: '遊戲密碼解密失敗，請重新登入後再試。',
     },
     beanfun: {
       bad_credentials: '帳號或密碼錯誤。',
@@ -800,6 +808,14 @@ const zhCN = {
       invalid_totp: '验证码错误，请重新输入。',
       not_logged_in: '尚未登录。',
       gamepass_window_already_open: 'GamePass 登录窗口已开启，请先关闭再重新尝试。',
+      otp_missing_long_polling_key: '获取游戏密码失败：服务器页面格式无法识别，请重新登录后再试。',
+      otp_missing_unk_data: '获取游戏密码失败：服务器页面格式无法识别，请重新登录后再试。',
+      otp_missing_create_time: '获取游戏密码失败：找不到账号创建时间，请刷新账号列表后再试。',
+      otp_missing_secret_code: '获取游戏密码失败：登录状态可能已失效，请重新登录后再试。',
+      otp_empty_response: '服务器未返回游戏密码，请稍后再试。',
+      otp_server_rejected:
+        '服务器拒绝了获取游戏密码的请求，请重新登录后再试；若持续发生，可能为官方维护中。',
+      otp_decryption_failed: '游戏密码解密失败，请重新登录后再试。',
     },
     beanfun: {
       bad_credentials: '账号或密码错误。',
@@ -1107,6 +1123,18 @@ const enUS = {
       not_logged_in: 'Not logged in.',
       gamepass_window_already_open:
         'GamePass login window is already open. Please close it before trying again.',
+      otp_missing_long_polling_key:
+        'Could not get the game password: unrecognized server page. Please log in again.',
+      otp_missing_unk_data:
+        'Could not get the game password: unrecognized server page. Please log in again.',
+      otp_missing_create_time:
+        'Could not get the game password: account creation time not found. Please refresh the account list.',
+      otp_missing_secret_code:
+        'Could not get the game password: your session may have expired. Please log in again.',
+      otp_empty_response: 'The server returned no game password. Please try again later.',
+      otp_server_rejected:
+        'The server rejected the game password request. Please log in again; if it keeps happening, the service may be under maintenance.',
+      otp_decryption_failed: 'Failed to decrypt the game password. Please log in again.',
     },
     beanfun: {
       bad_credentials: 'Wrong account or password.',


### PR DESCRIPTION
Fixes #368 — "獲取密碼" fails on TW with `OTP step 5 server rejected: Query String Error`.

## Root cause

Beanfun replaced the OTP endpoint. `GET get_webstart_otp.ashx` with its nine query parameters now answers `0;        Query String Error` no matter what it is sent; the live endpoint is:

```
POST /beanfun_block/generic_handlers/get_webstart_otp_v2.ashx
{ "SN": …, "LaunchTicket": …, "CV": …, "Hash": …, "arch": … }
→ { "result": 1, "data": …, "message": null }
```

Of the old nine parameters only `SN` survives — `WebToken`, `SecretCode`, `ServiceCode`, `ServiceRegion`, `ServiceAccount`, `CreateTime`, `d` and the mystery `ppppp` constant are all gone.

The browser no longer fetches the OTP at all: `ggm.js` hands `WebToken`/`SecretCode` to the native Game Manager over a `gamaniagames://` URL scheme, and that process does the rest.

## Why this does not need the Game Manager installed

`LaunchTicket` is **not** generated by the launcher — it travels, obfuscated, inside the `m_objData.data` literal that `game_start_step2.aspx` already embeds. That is the page step 1 downloads today, so recovering the ticket is a scrape plus a decode, not an extra round trip.

Credit for the decode belongs to @takidog, whose analysis in #368 this implements. The four substitution tables were verified to be complete permutations of the hex alphabet, and both observed blob lengths (553 from that report, 537 from a capture here) leave a ciphertext that is a whole number of DES blocks.

Steps 5–8 of that algorithm turned out to be the same construction the old envelope used — an 8-character ASCII key followed by hex ciphertext — so `core::wcdes::decrypt_hex` handles them unchanged. Only the substitution layer and the field parse are new.

## What changed

- **`core::launch_data`** (new) — decodes `LaunchTicket` out of the blob.
- **`services::beanfun::otp`** — step 1 also scrapes `m_objData`; `get_otp` posts the v2 payload when it is present.
- **`decrypt_otp_payload`** — factored out of `step_6_decrypt`, since both protocol versions end in the same envelope.
- **Two pre-existing bugs found on the way**: the `(.*)` scrapers accepted empty captures and forwarded them as blank query parameters, which made any upstream failure surface as a generic step-5 rejection; and `errors.auth.otp_*` had no i18n entries, so every OTP failure showed the raw English backend message.
- **Diagnostics** — step 5 failures now log the server's own response (scrubbed through `core::redact`).

### Region handling

The branch keys off the page carrying `m_objData`, not the configured region. That is the property that actually determines which endpoint answers, it keeps HK — whose page has no such literal — on the path that still works there, and it needs no change if HK migrates later.

### One maintenance cost

`CV` and `Hash` identify the official launcher build (`GGMWebStart.dll`'s assembly version and SHA-256). They cannot be computed without that file, so they are pinned as constants and must be re-pinned when Gamania ships a new Game Manager. `generic_handlers/CheckVersion.ashx` announces that in 80 bytes and is the cheapest way to notice. `docs/OTP-PROTOCOL-CHANGE.md` records the full derivation, the provenance of those values, and the fallback approach if this one ever stops working.

## Testing

- Live on TW: OTP retrieved successfully.
- CI green on the fork — `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` (866 tests), plus the frontend suite.
- New tests cover the decoder across all 16 table selectors, the `m_objData` scrape and its miss cases, the v2 reply shapes, and a payload round trip.

The commits after the live test are formatting and log redaction only; they do not touch the request path.
