### PR TITLE
feat(otp): fix the client-integrity values without a release, and notice when they need it

### DIFF
--- a/.github/workflows/ggm-watch.yml
+++ b/.github/workflows/ggm-watch.yml
@@ -1,0 +1,219 @@
+# Watch for a new Gamania Games Manager, so `ggm-client.json` can be updated
+# before users notice.
+#
+# TW launches state which build of the game manager is asking — its version and
+# the SHA-256 of `GGMWebStart.dll` — and beanfun refuses a pair it doesn't
+# accept. The pair lives in `ggm-client.json`, which the app fetches, so a new
+# manager needs a commit here rather than a release. See
+# `docs/GGM-CLIENT-HOTFIX.md`.
+#
+# beanfun announces the current build in eighty bytes:
+#
+#   GET https://tw.beanfun.com/generic_handlers/CheckVersion.ashx
+#   {"url": "https://tw.beanfun.com/ggm/GGMSetup_1.5.0.2.exe", "version": "1.5.0.2"}
+#
+# `version` is exactly the `cv` we publish, so the hourly check is an equality
+# test on one small GET — nobody has to notice a new manager by hand.
+#
+# Reading the hash needs the DLL, and the DLL is inside an Inno Setup 6.3
+# installer that Ubuntu's innoextract (1.9, from 2020) cannot parse and that
+# 7-Zip sees only as a PE with a large blob appended. A Windows runner sidesteps
+# the question: it installs the thing and reads the file. That runner starts
+# only when the version actually moved, so the hourly cost stays one Linux
+# request.
+#
+# Public repositories don't consume Actions minutes. GitHub runs scheduled jobs
+# late when it's busy, so "hourly" means "roughly hourly".
+
+name: Watch GGM version
+
+on:
+  schedule:
+    - cron: "23 * * * *"
+  workflow_dispatch:
+    inputs:
+      force:
+        description: "Install and read the pair even if the version matches"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: ggm-watch
+  cancel-in-progress: false
+
+jobs:
+  check:
+    name: Check the announced version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.upstream.outputs.version }}
+      url: ${{ steps.upstream.outputs.url }}
+      changed: ${{ steps.compare.outputs.changed }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Ask beanfun which build it ships
+        id: upstream
+        run: |
+          body=$(curl -fsS --max-time 30 \
+            "https://tw.beanfun.com/generic_handlers/CheckVersion.ashx")
+          version=$(printf '%s' "$body" | jq -r '.version // ""')
+          url=$(printf '%s' "$body" | jq -r '.url // ""')
+          if [ -z "$version" ] || [ -z "$url" ]; then
+            echo "::error::CheckVersion.ashx did not answer with a version and url"
+            printf '%s\n' "$body"
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+          echo "beanfun ships $version ($url)"
+
+      - name: Compare it with what we publish
+        id: compare
+        env:
+          UPSTREAM: ${{ steps.upstream.outputs.version }}
+          FORCED: ${{ inputs.force }}
+        run: |
+          published=$(jq -r '.cv // ""' ggm-client.json)
+          echo "published=$published  upstream=$UPSTREAM  forced=$FORCED"
+          if [ "$published" = "$UPSTREAM" ] && [ "$FORCED" != "true" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "unchanged"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  values:
+    name: Read the new pair
+    needs: check
+    if: needs.check.outputs.changed == 'true'
+    runs-on: windows-latest
+    # A silent install that isn't silent waits for a click that will never come.
+    # Nothing here is worth more than a few minutes of a runner.
+    timeout-minutes: 12
+    outputs:
+      cv: ${{ steps.read.outputs.cv }}
+      hash: ${{ steps.read.outputs.hash }}
+
+    steps:
+      # Installing it is the only reliable way to open it: Inno Setup 6.3 is
+      # newer than any unpacker available here. The runner is discarded
+      # afterwards, so what the installer does to the machine doesn't matter.
+      - name: Install the manager and read the file
+        id: read
+        shell: pwsh
+        env:
+          URL: ${{ needs.check.outputs.url }}
+        run: |
+          Invoke-WebRequest -Uri $env:URL -OutFile setup.exe -TimeoutSec 600
+          "downloaded {0:N1} MB" -f ((Get-Item setup.exe).Length / 1MB)
+
+          $dir = Join-Path $env:RUNNER_TEMP 'ggm'
+          $log = Join-Path $env:RUNNER_TEMP 'install.log'
+          $switches = @(
+            '/VERYSILENT', '/SUPPRESSMSGBOXES', '/NORESTART', '/NOICONS', '/SP-',
+            "/DIR=$dir", "/LOG=$log"
+          )
+
+          # Waited on with a limit, not `-Wait`: a runner has no desktop, so an
+          # installer that decides to ask something waits forever. Whatever it
+          # managed to write before being stopped is still worth looking at.
+          $p = Start-Process -FilePath .\setup.exe -PassThru -ArgumentList $switches
+          if ($p.WaitForExit(240000)) {
+            "installer exit code: $($p.ExitCode)"
+          } else {
+            Write-Host "::warning::installer did not finish in 4 minutes; stopping it"
+            Stop-Process -Id $p.Id -Force -ErrorAction SilentlyContinue
+          }
+
+          # It may start itself when it finishes; nothing here wants it running.
+          Get-Process -Name GGMWebStart, GamaniaGameDownloader -ErrorAction SilentlyContinue |
+            Stop-Process -Force -ErrorAction SilentlyContinue
+
+          # Its own log says what it was doing, which is the one thing a hang
+          # cannot otherwise tell us.
+          if (Test-Path $log) {
+            "--- installer log (last 40 lines) ---"
+            Get-Content $log -Tail 40
+          } else {
+            "no installer log at $log"
+          }
+
+          # Looked for whether or not the installer finished cleanly: it may
+          # have written the file before stopping, and the file is all this
+          # wants.
+          $dll = Get-ChildItem $dir -Recurse -Filter GGMWebStart.dll -ErrorAction SilentlyContinue |
+            Select-Object -First 1
+          if (-not $dll) {
+            Write-Host "::error::GGMWebStart.dll not found under $dir"
+            Get-ChildItem $dir -Recurse -File -ErrorAction SilentlyContinue |
+              Select-Object -First 30 -ExpandProperty FullName
+            exit 1
+          }
+
+          $cv = $dll.VersionInfo.FileVersion
+          $hash = (Get-FileHash $dll.FullName -Algorithm SHA256).Hash.ToLower()
+          "cv=$cv" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "hash=$hash" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "read $($dll.FullName)"
+          "version $cv"
+          "sha256  $hash"
+
+  report:
+    name: Say so
+    needs: [check, values]
+    # `always()` so a failed read still reports the version — knowing a new
+    # manager shipped is most of the value, even without the hash.
+    if: always() && needs.check.outputs.changed == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Open an issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.check.outputs.version }}
+          URL: ${{ needs.check.outputs.url }}
+          CV: ${{ needs.values.outputs.cv }}
+          HASH: ${{ needs.values.outputs.hash }}
+        run: |
+          # The label has to exist before it can be filtered on or applied, and
+          # it won't on the first run.
+          gh label create ggm-version \
+            --description "beanfun shipped a new Gamania Games Manager" \
+            --color FBCA04 2>/dev/null || true
+
+          # One open issue at a time — this runs hourly.
+          existing=$(gh issue list --state open --label ggm-version --json number \
+            --jq '.[0].number // ""' 2>/dev/null || true)
+          if [ -n "$existing" ]; then
+            echo "issue #$existing is already open"
+            exit 0
+          fi
+
+          installer=$(basename "$URL")
+
+          if [ -n "$HASH" ]; then
+            note=""
+            # The version is stated twice — by beanfun and by the file itself —
+            # and a disagreement means one of them isn't describing what shipped.
+            if [ -n "$CV" ] && [ "$CV" != "$VERSION" ]; then
+              note=$(printf '\n> beanfun announces `%s` but the installed file reports `%s`. Check which\n> one the endpoint accepts before publishing.\n' "$VERSION" "$CV")
+            fi
+            values=$(printf 'Both halves, read from the installed file:\n\n```json\n{\n  "installer": "%s",\n  "cv": "%s",\n  "hash": "%s"\n}\n```\n%s' "$installer" "${CV:-$VERSION}" "$HASH" "$note")
+          else
+            values=$(printf 'The hash could not be read — see the `Read the new pair` job. Run\n`scripts/ggm-client.ps1 -Write` on a machine with the new manager installed.\n\nThe announced version is `%s`.\n' "$VERSION")
+          fi
+
+          body=$(printf 'beanfun now ships Gamania Games Manager `%s`, where `ggm-client.json` still\npublishes a different version.\n\n%s\n\nInstaller: %s\n\nA commit is enough — the app fetches this file, so no release is needed.\nSee `docs/GGM-CLIENT-HOTFIX.md`.\n\nUntil then TW launches keep working for anyone with the manager installed\n(their own copy is read first) and for anyone whose current values still pass.\n' "$VERSION" "$values" "$URL")
+
+          gh issue create \
+            --title "Gamania Games Manager updated to $VERSION" \
+            --label ggm-version \
+            --body "$body"

--- a/.github/workflows/ggm-watch.yml
+++ b/.github/workflows/ggm-watch.yml
@@ -29,11 +29,11 @@ name: Watch GGM version
 
 on:
   schedule:
-    - cron: "23 * * * *"
+    - cron: '23 * * * *'
   workflow_dispatch:
     inputs:
       force:
-        description: "Install and read the pair even if the version matches"
+        description: 'Install and read the pair even if the version matches'
         type: boolean
         default: false
 

--- a/.github/workflows/ggm-watch.yml
+++ b/.github/workflows/ggm-watch.yml
@@ -37,9 +37,9 @@ on:
         type: boolean
         default: false
 
+# The propose job asks for more; this is the floor for everything else.
 permissions:
   contents: read
-  issues: write
 
 concurrency:
   group: ggm-watch
@@ -53,6 +53,7 @@ jobs:
       version: ${{ steps.upstream.outputs.version }}
       url: ${{ steps.upstream.outputs.url }}
       changed: ${{ steps.compare.outputs.changed }}
+      read: ${{ steps.compare.outputs.read }}
 
     steps:
       - uses: actions/checkout@v6
@@ -81,17 +82,27 @@ jobs:
         run: |
           published=$(jq -r '.cv // ""' ggm-client.json)
           echo "published=$published  upstream=$UPSTREAM  forced=$FORCED"
-          if [ "$published" = "$UPSTREAM" ] && [ "$FORCED" != "true" ]; then
+
+          # `changed` says the published pair is out of date. `read` says to go
+          # and look. Forcing a run sets only the second: a dispatch made to
+          # test the machinery must not be able to claim the change it is
+          # testing for, and announce an update to the version already here.
+          if [ "$published" = "$UPSTREAM" ]; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
             echo "unchanged"
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
+          if [ "$published" != "$UPSTREAM" ] || [ "$FORCED" = "true" ]; then
+            echo "read=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "read=false" >> "$GITHUB_OUTPUT"
+          fi
 
   values:
     name: Read the new pair
     needs: check
-    if: needs.check.outputs.changed == 'true'
+    if: needs.check.outputs.read == 'true'
     runs-on: windows-latest
     # A silent install that isn't silent waits for a click that will never come.
     # Nothing here is worth more than a few minutes of a runner.
@@ -164,18 +175,28 @@ jobs:
           "version $cv"
           "sha256  $hash"
 
-  report:
-    name: Say so
+  propose:
+    name: Propose the new pair
     needs: [check, values]
-    # `always()` so a failed read still reports the version — knowing a new
-    # manager shipped is most of the value, even without the hash.
+    # `always()` so a failed read still says a new manager shipped — that alone
+    # is most of the warning. Gated on `changed`, not on `read`: a forced run
+    # is someone testing this, and it must not announce a version we already
+    # publish.
     if: always() && needs.check.outputs.changed == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
 
     steps:
       - uses: actions/checkout@v6
 
-      - name: Open an issue
+      # With both halves in hand there is nothing left to decide, so open the
+      # change rather than a request for someone to make it. An issue would be
+      # a description of a one-line edit that this job has already worked out.
+      - name: Open a pull request
+        if: needs.values.outputs.hash != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ needs.check.outputs.version }}
@@ -183,13 +204,53 @@ jobs:
           CV: ${{ needs.values.outputs.cv }}
           HASH: ${{ needs.values.outputs.hash }}
         run: |
-          # The label has to exist before it can be filtered on or applied, and
-          # it won't on the first run.
+          branch="ggm/$VERSION"
+          if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+            echo "$branch already exists; nothing to propose"
+            exit 0
+          fi
+
+          # Edited in place rather than rewritten: the file may carry fields
+          # this job knows nothing about, and rewriting it would drop them
+          # without saying so. `cv` comes from the file rather than the
+          # announcement — the file is what the endpoint is asked about — and a
+          # disagreement is called out below rather than hidden by the values.
+          installer=$(basename "$URL")
+          jq --arg installer "$installer" --arg cv "${CV:-$VERSION}" --arg hash "$HASH" \
+            '.installer = $installer | .cv = $cv | .hash = $hash' \
+            ggm-client.json > ggm-client.next.json
+          mv ggm-client.next.json ggm-client.json
+          cat ggm-client.json
+
+          note=""
+          if [ -n "$CV" ] && [ "$CV" != "$VERSION" ]; then
+            note=$(printf '\n> beanfun announces `%s` but the installed file reports `%s`. The file'"'"'s\n> version is used here; check which one the endpoint accepts before merging.\n' "$VERSION" "$CV")
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$branch"
+          git add ggm-client.json
+          git commit -m "chore(otp): publish client-integrity values for GGM $VERSION"
+          git push origin "$branch"
+
+          gh pr create \
+            --title "chore(otp): publish client-integrity values for GGM $VERSION" \
+            --body "$(printf 'beanfun now ships Gamania Games Manager `%s`. These values were read from\n`GGMWebStart.dll` inside its installer, on a runner that installed it.\n%s\nMerging publishes them: the app fetches this file and caches it for six hours,\nso affected users are carried across without a release and without doing\nanything. See docs/GGM-CLIENT-HOTFIX.md.\n\nUntil then, TW launches keep working for anyone whose installed manager is\nnewer than the pair we publish, and for anyone whose current values still\npass.\n\nInstaller: %s\n\nOpened by `.github/workflows/ggm-watch.yml`.\n' "$VERSION" "$note" "$URL")"
+
+      # Only when the values could not be read. There is nothing to merge, so
+      # the version alone is the message.
+      - name: Open an issue instead
+        if: needs.values.outputs.hash == ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.check.outputs.version }}
+          URL: ${{ needs.check.outputs.url }}
+        run: |
           gh label create ggm-version \
             --description "beanfun shipped a new Gamania Games Manager" \
             --color FBCA04 2>/dev/null || true
 
-          # One open issue at a time — this runs hourly.
           existing=$(gh issue list --state open --label ggm-version --json number \
             --jq '.[0].number // ""' 2>/dev/null || true)
           if [ -n "$existing" ]; then
@@ -197,23 +258,7 @@ jobs:
             exit 0
           fi
 
-          installer=$(basename "$URL")
-
-          if [ -n "$HASH" ]; then
-            note=""
-            # The version is stated twice — by beanfun and by the file itself —
-            # and a disagreement means one of them isn't describing what shipped.
-            if [ -n "$CV" ] && [ "$CV" != "$VERSION" ]; then
-              note=$(printf '\n> beanfun announces `%s` but the installed file reports `%s`. Check which\n> one the endpoint accepts before publishing.\n' "$VERSION" "$CV")
-            fi
-            values=$(printf 'Both halves, read from the installed file:\n\n```json\n{\n  "installer": "%s",\n  "cv": "%s",\n  "hash": "%s"\n}\n```\n%s' "$installer" "${CV:-$VERSION}" "$HASH" "$note")
-          else
-            values=$(printf 'The hash could not be read — see the `Read the new pair` job. Run\n`scripts/ggm-client.ps1 -Write` on a machine with the new manager installed.\n\nThe announced version is `%s`.\n' "$VERSION")
-          fi
-
-          body=$(printf 'beanfun now ships Gamania Games Manager `%s`, where `ggm-client.json` still\npublishes a different version.\n\n%s\n\nInstaller: %s\n\nA commit is enough — the app fetches this file, so no release is needed.\nSee `docs/GGM-CLIENT-HOTFIX.md`.\n\nUntil then TW launches keep working for anyone with the manager installed\n(their own copy is read first) and for anyone whose current values still pass.\n' "$VERSION" "$values" "$URL")
-
           gh issue create \
             --title "Gamania Games Manager updated to $VERSION" \
             --label ggm-version \
-            --body "$body"
+            --body "$(printf 'beanfun now ships Gamania Games Manager `%s`, but the hash could not be read\nhere — see the `Read the new pair` job.\n\nRun `scripts/ggm-client.ps1 -Write` on a machine with the new manager\ninstalled and commit the result. A commit is enough; the app fetches this\nfile, so no release is needed.\n\nInstaller: %s\n' "$VERSION" "$URL")"

--- a/docs/GGM-CLIENT-HOTFIX.md
+++ b/docs/GGM-CLIENT-HOTFIX.md
@@ -1,0 +1,139 @@
+# Hotfix runbook — TW OTP refused after a Game Manager release
+
+TW password retrieval suddenly fails for many users at once, and the
+Gamania Games Manager has just shipped a new build.
+
+**No code change. No release.** Edit `ggm-client.json` at the repository
+root and push.
+
+---
+
+## 1. Confirm it is actually this
+
+Ask for a log: **Settings → Maintenance → open log folder**, newest file.
+Look for:
+
+```
+Otp.Tw.V2  credential request refused  result=... message=...
+```
+
+`result != 1` with a message about a version or verification is the
+symptom this lever fixes.
+
+**Symptoms that are _not_ this** — changing values will not help, and
+will cost you six hours if you get it wrong:
+
+| In the log | What it means |
+|---|---|
+| `no usable launch ticket in the game-start page` | the page's shape changed → code change |
+| `credential response was not JSON` | the response format changed → code change |
+| `launch data: ...` decode errors | the decoding algorithm changed, e.g. new tables → code change |
+| no `Otp.Tw.*` lines at all | this route was never taken; look elsewhere |
+
+Users **with GGM installed are unaffected** — they read their own copy
+and never consult the published file. So if every report comes from
+someone without GGM, that is strong confirmation the published or
+compiled-in pair has gone stale.
+
+## 2. Get the new values
+
+Run on a Windows machine with the **new** GGM installed:
+
+```powershell
+.\scripts\ggm-client.ps1
+```
+
+It prints `cv`, `hash` and `arch`, and assembles the document. No GGM?
+Install it from <https://tw.beanfun.com/ggm/index.aspx>, or point at a
+copy of the file with `-Dll <path>`.
+
+A CI runner can produce the hash but **never the version** — the version
+lives in a Windows version resource. Both are required.
+
+## 3. Write it
+
+```powershell
+.\scripts\ggm-client.ps1 -Write
+```
+
+Editing by hand is fine, but save as **UTF-8 without BOM**. The app now
+tolerates a BOM, so an editor that adds one will not break the fix — but
+older builds in the field do not, so do not rely on it.
+
+Validate before pushing:
+
+```bash
+python -c "import json;print(json.load(open('ggm-client.json')))"
+```
+
+`hash` must be **exactly 64 hex characters** and `cv` digits and dots
+only. The app checks both and treats anything else as if the file were
+absent, dropping silently to the next source.
+
+## 4. Push to `code`
+
+The published URL is read from the default branch:
+
+```
+https://raw.githubusercontent.com/pungin/Beanfun/code/ggm-client.json
+```
+
+Confirm it is live:
+
+```bash
+curl -s -o /dev/null -w "%{http_code}\n" \
+  https://raw.githubusercontent.com/pungin/Beanfun/code/ggm-client.json
+```
+
+Expect `200`. The jsDelivr mirrors carry their own cache and may lag by
+minutes; no need to wait for them.
+
+## 5. When users get it
+
+**Within six hours** — the local cache TTL. To take it immediately, a
+user can delete `ggm-client.json` from `%APPDATA%\Beanfun\` and retry, or
+install GGM, which bypasses this path entirely.
+
+## 6. If you publish a bad pair
+
+Everyone who was working breaks, because the published layer outranks
+the compiled-in one.
+
+- Revert the commit and push, or restore the last known-good values.
+- **Users keep the bad values for up to six hours**, cache TTL. This is
+  the expensive part, which is why step 7 is not optional.
+- Emergency workaround for an individual: delete
+  `%APPDATA%\Beanfun\ggm-client.json`.
+
+## 7. Test before pushing
+
+On a Windows machine with **no GGM installed**:
+
+1. delete `%APPDATA%\Beanfun\ggm-client.json`
+2. retrieve a password
+3. the log should show `ggm-hotfix: published values fetched cv=<new>`,
+   then the retrieval succeeding
+
+To try values on a branch first, point the first entry of `HOTFIX_URLS`
+in `services/beanfun/ggm_hotfix.rs` at that branch, then change it back.
+
+## Things worth remembering
+
+- Users with GGM installed never touch the network for this. That
+  protects them from a bad publish — and means they cannot confirm a
+  good one for you.
+- We have **never actually seen beanfun refuse an old CV/Hash**. This is
+  preventative. The first time it is really needed, take the extra
+  minute on step 1 rather than swapping values because something broke.
+- Swapping values cannot fix "the page changed" or "the response format
+  changed". Those need code; the TW section of
+  `services/beanfun/otp.rs` is the place to start.
+
+## The order the app resolves in
+
+1. **Pinned** — `%APPDATA%\Beanfun\ggm-client.json` with `"override": true`.
+   A deliberate choice; nothing overrides it.
+2. **Installed GGM** — read from `GGMWebStart.dll` on this machine. Self-updating,
+   so it survives beanfun raising the bar with no action from us.
+3. **Published** — this file, cached for six hours. The hotfix lever.
+4. **Compiled in** — ships with the app, so a machine with none of the above works.

--- a/docs/GGM-CLIENT-HOTFIX.md
+++ b/docs/GGM-CLIENT-HOTFIX.md
@@ -153,7 +153,15 @@ in `services/beanfun/ggm_hotfix.rs` at that branch, then change it back.
 
 1. **Pinned** — `%APPDATA%\Beanfun\ggm-client.json` with `"override": true`.
    A deliberate choice; nothing overrides it.
-2. **Installed GGM** — read from `GGMWebStart.dll` on this machine. Self-updating,
-   so it survives beanfun raising the bar with no action from us.
-3. **Published** — this file, cached for six hours. The hotfix lever.
-4. **Compiled in** — ships with the app, so a machine with none of the above works.
+2. **Installed GGM or published — whichever names the newer build.** The
+   installed `GGMWebStart.dll` is this machine's own truth, and GGM updates
+   itself, but only when it runs; the people this app exists for launch from
+   here rather than the official site, so an install can sit at whatever
+   version it was last opened at. Comparing versions keeps a stale install
+   from being preferred over a fix, without letting a bad publish take down a
+   machine whose own install was fine. A tie goes to the installed file.
+3. **Compiled in** — ships with the app, so a machine with none of the above works.
+
+That ordering is the reason the lever works at all. Preferring the installed
+GGM outright would make the stalest machines — the ones most likely to be
+refused — the only ones a published fix could never reach.

--- a/docs/GGM-CLIENT-HOTFIX.md
+++ b/docs/GGM-CLIENT-HOTFIX.md
@@ -6,6 +6,12 @@ Gamania Games Manager has just shipped a new build.
 **No code change. No release.** Edit `ggm-client.json` at the repository
 root and push.
 
+You may arrive here from an issue labelled `ggm-version` instead of from
+a user report — the watcher notices a new Game Manager on its own, which
+is the point of it. Step 1 is still worth reading: a new build shipping
+and users failing are two separate facts, and only the second one means
+this lever is the fix.
+
 ---
 
 ## 1. Confirm it is actually this
@@ -37,7 +43,15 @@ compiled-in pair has gone stale.
 
 ## 2. Get the new values
 
-Run on a Windows machine with the **new** GGM installed:
+**Look for an open issue labelled `ggm-version` first.** The watcher
+(`.github/workflows/ggm-watch.yml`) asks beanfun hourly which build it
+ships, and when that moves it installs the thing on a Windows runner and
+posts the finished document — both `cv` and `hash`, ready to paste. You
+may well have the values before anyone reports a failure.
+
+If there is no issue — the watcher failed, or beanfun raised the bar
+without shipping a new build — run this on a Windows machine with the
+**new** GGM installed:
 
 ```powershell
 .\scripts\ggm-client.ps1
@@ -47,8 +61,14 @@ It prints `cv`, `hash` and `arch`, and assembles the document. No GGM?
 Install it from <https://tw.beanfun.com/ggm/index.aspx>, or point at a
 copy of the file with `-Dll <path>`.
 
-A CI runner can produce the hash but **never the version** — the version
-lives in a Windows version resource. Both are required.
+Both halves have to come off the file itself. The version lives in a
+Windows version resource, so a Linux runner can never read it — that is
+the whole reason the watcher spends a Windows runner rather than
+unpacking the installer.
+
+To check the watcher by hand, or after fixing it: **Actions → Watch GGM
+version → Run workflow**, with `force` ticked to make it install and
+read even when the version matches.
 
 ## 3. Write it
 

--- a/docs/GGM-CLIENT-HOTFIX.md
+++ b/docs/GGM-CLIENT-HOTFIX.md
@@ -29,12 +29,12 @@ symptom this lever fixes.
 **Symptoms that are _not_ this** — changing values will not help, and
 will cost you six hours if you get it wrong:
 
-| In the log | What it means |
-|---|---|
-| `no usable launch ticket in the game-start page` | the page's shape changed → code change |
-| `credential response was not JSON` | the response format changed → code change |
-| `launch data: ...` decode errors | the decoding algorithm changed, e.g. new tables → code change |
-| no `Otp.Tw.*` lines at all | this route was never taken; look elsewhere |
+| In the log                                       | What it means                                                 |
+| ------------------------------------------------ | ------------------------------------------------------------- |
+| `no usable launch ticket in the game-start page` | the page's shape changed → code change                        |
+| `credential response was not JSON`               | the response format changed → code change                     |
+| `launch data: ...` decode errors                 | the decoding algorithm changed, e.g. new tables → code change |
+| no `Otp.Tw.*` lines at all                       | this route was never taken; look elsewhere                    |
 
 Users **with GGM installed are unaffected** — they read their own copy
 and never consult the published file. So if every report comes from

--- a/ggm-client.json
+++ b/ggm-client.json
@@ -1,0 +1,7 @@
+{
+  "cv": "1.5.0.2",
+  "hash": "dfd568a69d87abcd8f4a93d1a4481ebb57712d1d28ab0b6fc018fcf140101e06",
+  "arch": "x64",
+  "installer": "https://tw.beanfun.com/ggm/index.aspx",
+  "note": "Client-integrity values beanfun's TW OTP endpoint checks. Edit and push to code to hotfix every user without a release; see docs/GGM-CLIENT-HOTFIX.md. Save as UTF-8; hash must be exactly 64 hex characters."
+}

--- a/scripts/ggm-client.ps1
+++ b/scripts/ggm-client.ps1
@@ -1,0 +1,109 @@
+<#
+.SYNOPSIS
+    Read the client-integrity values beanfun's TW OTP endpoint checks.
+
+.DESCRIPTION
+    beanfun asks the caller to state which Gamania Games Manager build is
+    asking: a file version and the SHA-256 of GGMWebStart.dll. This reads
+    both off an installed GGM and prints the document the app publishes.
+
+    Run it on a Windows machine with the *new* GGM installed. The version
+    comes from the file's version resource, which only Windows can read —
+    which is why a CI runner can produce the hash but never the version.
+
+.PARAMETER Dll
+    Read a specific GGMWebStart.dll instead of locating one.
+
+.PARAMETER Write
+    Write ggm-client.json at the repository root, UTF-8 without BOM.
+    A BOM makes the document unparseable, which silently drops every user
+    to the compiled-in pair — the fix looks published and helps nobody.
+
+.EXAMPLE
+    .\scripts\ggm-client.ps1
+    .\scripts\ggm-client.ps1 -Write
+    .\scripts\ggm-client.ps1 -Dll 'D:\GGM\GGMWebStart.dll' -Write
+#>
+[CmdletBinding()]
+param(
+    [string]$Dll,
+    [switch]$Write
+)
+
+$ErrorActionPreference = 'Stop'
+$InstallerUrl = 'https://tw.beanfun.com/ggm/index.aspx'
+
+function Find-GgmDll {
+    if ($Dll) {
+        if (-not (Test-Path -LiteralPath $Dll)) { throw "no such file: $Dll" }
+        return (Resolve-Path -LiteralPath $Dll).Path
+    }
+
+    $candidates = @()
+
+    # The documented install path.
+    $key = 'HKLM:\SOFTWARE\gamaniaGamesManager'
+    if (Test-Path $key) {
+        $dir = (Get-ItemProperty -Path $key -ErrorAction SilentlyContinue).InstallPath
+        if ($dir) { $candidates += (Join-Path $dir 'GGMWebStart.dll') }
+    }
+
+    # The protocol handler, for installs that key differently.
+    $cmdKey = 'Registry::HKEY_CLASSES_ROOT\gamaniagames\shell\open\command'
+    if (Test-Path $cmdKey) {
+        $command = (Get-ItemProperty -Path $cmdKey -ErrorAction SilentlyContinue).'(default)'
+        if ($command) {
+            $exe = if ($command.Trim().StartsWith('"')) { $command.Split('"')[1] }
+                   else { $command.Split(' ')[0] }
+            if ($exe) {
+                $dir = Split-Path -Parent $exe
+                if ($dir) { $candidates += (Join-Path $dir 'GGMWebStart.dll') }
+            }
+        }
+    }
+
+    foreach ($path in $candidates) {
+        if (Test-Path -LiteralPath $path) { return (Resolve-Path -LiteralPath $path).Path }
+    }
+
+    throw "no GGMWebStart.dll found. Install the Game Manager from $InstallerUrl, or pass -Dll <path>."
+}
+
+$path = Find-GgmDll
+$cv   = (Get-Item -LiteralPath $path).VersionInfo.FileVersion
+$hash = (Get-FileHash -LiteralPath $path -Algorithm SHA256).Hash.ToLowerInvariant()
+$arch = if ([Environment]::Is64BitOperatingSystem) { 'x64' } else { 'x86' }
+
+if (-not $cv)   { throw "no FileVersion on $path" }
+if ($hash.Length -ne 64) { throw "hash is not a SHA-256: $hash" }
+# The app validates both and treats anything else as if the file were
+# absent, so catch it here rather than after publishing.
+if ($cv -notmatch '^[0-9.]+$') { throw "version must be digits and dots: $cv" }
+
+$document = [ordered]@{
+    cv        = $cv
+    hash      = $hash
+    arch      = $arch
+    installer = $InstallerUrl
+    note      = "Client-integrity values beanfun's TW OTP endpoint checks. Edit and push to code to hotfix every user without a release; see docs/GGM-CLIENT-HOTFIX.md. Save as UTF-8; hash must be exactly 64 hex characters."
+}
+
+Write-Host "dll  : $path"
+Write-Host "cv   : $cv"
+Write-Host "hash : $hash"
+Write-Host "arch : $arch"
+Write-Host ''
+
+$json = ($document | ConvertTo-Json -Depth 3)
+Write-Host $json
+
+if ($Write) {
+    $root = Split-Path -Parent $PSScriptRoot
+    $out  = Join-Path $root 'ggm-client.json'
+    # UTF8Encoding($false) = no BOM. Set-Content -Encoding utf8 writes one
+    # on Windows PowerShell, and a BOM breaks the document.
+    [System.IO.File]::WriteAllText($out, $json + "`n", [System.Text.UTF8Encoding]::new($false))
+    Write-Host ''
+    Write-Host "wrote $out (UTF-8, no BOM)"
+    Write-Host 'Next: commit and push to `code`, then verify the raw URL returns 200.'
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -561,6 +561,11 @@ pub fn run() {
         std::process::exit(1);
     });
 
+    // The published client-integrity values are cached beside Config.xml;
+    // without this the hotfix layer is skipped and resolution falls
+    // through to the installed GGM or the compiled-in pair.
+    services::beanfun::ggm_hotfix::set_cache_dir(storage_root.clone());
+
     let log_path = init_tracing(Some(&storage_root));
     match log_path {
         Some(path) => tracing::info!(

--- a/src-tauri/src/services/beanfun/client_integrity.rs
+++ b/src-tauri/src/services/beanfun/client_integrity.rs
@@ -41,8 +41,11 @@
 //!
 //! # Resolution strategy
 //!
-//! [`ClientIntegrity::resolve`] prefers the **locally installed** GGM and
-//! only falls back to the bundled constants:
+//! [`ClientIntegrity::resolve`] describes the **locally installed** GGM,
+//! falling back to the bundled constants. Whether that description or a
+//! published one is used is decided by the caller — see
+//! `services::beanfun::otp::resolve_client_integrity`, which takes
+//! whichever names the newer build:
 //!
 //! 1. Locate `GGMWebStart.dll` — first via the `gamaniagames://` protocol
 //!    handler the installer registers (authoritative even for non-default
@@ -50,12 +53,18 @@
 //! 2. Hash it and read its version.
 //! 3. If either half cannot be obtained, use [`ClientIntegrity::fallback`].
 //!
-//! Reading the live file is what keeps us current: GGM self-updates (it
-//! polls `CheckVersion.ashx` on every launch and hands off to `Patcher.exe`
-//! when it is behind), so a user who can launch through the official site at
-//! all necessarily has an up-to-date DLL. The bundled constants exist only
-//! for users with no GGM installed, and go stale the next time Gamania ships
-//! a GGM build — refreshing them is a release-time chore, not a runtime one.
+//! Reading the live file keeps us current *if the file is current*. GGM
+//! self-updates — it polls `CheckVersion.ashx` on launch and hands off to
+//! `Patcher.exe` when it is behind — but only when it runs, and the people
+//! this app exists for are the ones who never run it: they launch from here,
+//! not from the official site. So an install can sit at whatever version it
+//! was when it was last opened, which may be the version beanfun has since
+//! stopped accepting.
+//!
+//! That is why the caller compares this against the published pair instead of
+//! taking it on sight. The bundled constants remain the answer for a machine
+//! with neither, and go stale the next time Gamania ships a GGM build —
+//! refreshing them is a release-time chore, not a runtime one.
 //!
 //! # Deliberately all-or-nothing
 //!

--- a/src-tauri/src/services/beanfun/client_integrity.rs
+++ b/src-tauri/src/services/beanfun/client_integrity.rs
@@ -127,7 +127,7 @@ impl ClientIntegrity {
     /// -plausible one gives the server a chance to accept where an absent
     /// one is guaranteed to be rejected.
     pub fn resolve() -> Self {
-        match locate_ggm_dll().as_deref().and_then(Self::from_ggm_dll) {
+        match Self::resolve_local() {
             Some(found) => found,
             None => {
                 tracing::debug!(
@@ -135,6 +135,29 @@ impl ClientIntegrity {
                 );
                 Self::fallback()
             }
+        }
+    }
+
+    /// The installed GGM's values, or `None` when there is no GGM to
+    /// read.
+    ///
+    /// Split out from [`Self::resolve`] so the caller can try the
+    /// published values in between rather than dropping straight to the
+    /// compiled-in pair.
+    pub fn resolve_local() -> Option<Self> {
+        locate_ggm_dll().as_deref().and_then(Self::from_ggm_dll)
+    }
+
+    /// Build the triple from a `CV` / `Hash` pair someone published or
+    /// pinned.
+    ///
+    /// `arch` is never published: it describes the binary asking, which
+    /// is this build, not whatever machine produced the values.
+    pub fn from_published(values: &crate::services::beanfun::ggm_hotfix::PublishedValues) -> Self {
+        Self {
+            cv: values.cv.clone(),
+            hash: values.hash.clone(),
+            arch: ARCH,
         }
     }
 

--- a/src-tauri/src/services/beanfun/ggm_hotfix.rs
+++ b/src-tauri/src/services/beanfun/ggm_hotfix.rs
@@ -1,0 +1,287 @@
+//! Where the client-integrity values come from, newest source first.
+//!
+//! beanfun's TW credential endpoint asks the caller to state which build
+//! of the Gamania Games Manager is asking: a version, and the SHA-256 of
+//! one of its files. Both are constants for a given GGM release, so we
+//! ship a known-good pair — but the day beanfun requires a newer one,
+//! that pair stops working **for everyone at once**, and only for the
+//! users who have no GGM installed to read real values from.
+//!
+//! Answering that with an emergency release means every affected user
+//! has to notice, download and install one, while unable to play. So the
+//! values are looked up in order:
+//!
+//! 1. a `ggm-client.json` the user pinned themselves — an explicit
+//!    choice, so nothing overrides it;
+//! 2. the GGM installed on this machine, which follows its own updates;
+//! 3. a small file published alongside the app, cached here — one commit
+//!    fixes every user without them doing anything;
+//! 4. the pair compiled in, so a machine with none of the above works.
+//!
+//! Layer 3 is the hotfix lever. See `docs/GGM-CLIENT-HOTFIX.md` for the
+//! runbook, including how to tell this failure apart from the ones that
+//! need a code change instead.
+//!
+//! # Failing quietly is the point
+//!
+//! Every step here is best-effort. A fetch that times out, a file that
+//! will not parse, a value that fails validation — each falls through to
+//! the next source rather than surfacing. The alternative is a network
+//! hiccup costing someone their password when a perfectly good compiled
+//! -in pair was sitting right there.
+
+use std::path::PathBuf;
+use std::sync::OnceLock;
+use std::time::{Duration, SystemTime};
+
+/// Where the published values live, and the mirrors that serve the same
+/// file where GitHub itself is unreachable — which is most of the
+/// mainland audience this exists for.
+const HOTFIX_URLS: &[&str] = &[
+    "https://raw.githubusercontent.com/pungin/Beanfun/code/ggm-client.json",
+    "https://cdn.jsdelivr.net/gh/pungin/Beanfun@code/ggm-client.json",
+    "https://fastly.jsdelivr.net/gh/pungin/Beanfun@code/ggm-client.json",
+    "https://ghproxy.net/https://raw.githubusercontent.com/pungin/Beanfun/code/ggm-client.json",
+];
+
+/// File name of both the published copy and the user's pin — the same
+/// name on purpose: whatever is fetched can be edited in place, and an
+/// edited file is simply one the fetch will not overwrite.
+const CACHE_FILE: &str = "ggm-client.json";
+
+/// How long a fetched copy is trusted before another fetch is tried.
+///
+/// Six hours is the lever's real latency: it is how long a bad published
+/// value keeps hurting after it is reverted, and how long a good one
+/// takes to reach everybody. Short enough to be a fix, long enough that
+/// the app is not pulling a file on every password.
+const CACHE_TTL: Duration = Duration::from_secs(6 * 60 * 60);
+
+/// Total budget for reaching a mirror. Missing the hotfix costs a
+/// fallback; waiting on it costs the user their password.
+const FETCH_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Directory holding the cached / pinned file. Set once at boot.
+static CACHE_DIR: OnceLock<PathBuf> = OnceLock::new();
+
+/// A published `CV` / `Hash` pair.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PublishedValues {
+    pub cv: String,
+    pub hash: String,
+}
+
+/// Record where the cached file lives (the storage root).
+///
+/// Called once during boot. Without it every layer here is skipped and
+/// resolution falls through to the installed GGM or the compiled-in
+/// pair, which is the pre-hotfix behaviour — degraded, never broken.
+pub fn set_cache_dir(dir: PathBuf) {
+    let _ = CACHE_DIR.set(dir);
+}
+
+fn cache_path() -> Option<PathBuf> {
+    Some(CACHE_DIR.get()?.join(CACHE_FILE))
+}
+
+/// Values the user pinned themselves, if any.
+///
+/// Told apart by an `override` flag rather than by living somewhere
+/// else: editing the fetched file in place is then all it takes to pin
+/// values — no second path to explain, and no way to "fix" the file and
+/// have the next fetch quietly undo you.
+pub fn pinned() -> Option<PublishedValues> {
+    let body = std::fs::read_to_string(cache_path()?).ok()?;
+    let value: serde_json::Value = serde_json::from_str(strip_bom(&body)).ok()?;
+    if value["override"].as_bool() != Some(true) {
+        return None;
+    }
+    let values = parse(&body)?;
+    tracing::info!(cv = %values.cv, "ggm-hotfix: using the pinned local values");
+    Some(values)
+}
+
+/// The published values: the cached copy while it is fresh, otherwise a
+/// fetch, otherwise whatever stale copy we still have.
+///
+/// A stale copy beats nothing: it was good enough to publish, and the
+/// alternative is the compiled-in pair that is by definition older.
+pub async fn published() -> Option<PublishedValues> {
+    if let Some((values, fetched_at)) = cached() {
+        if fetched_at.elapsed().unwrap_or(CACHE_TTL) < CACHE_TTL {
+            return Some(values);
+        }
+        return match fetch().await {
+            Some(fresh) => Some(fresh),
+            None => {
+                tracing::info!("ggm-hotfix: refresh failed; keeping the cached values");
+                Some(values)
+            }
+        };
+    }
+    fetch().await
+}
+
+/// Read the cached file and when it was written.
+fn cached() -> Option<(PublishedValues, SystemTime)> {
+    let path = cache_path()?;
+    let body = std::fs::read_to_string(&path).ok()?;
+    let values = parse(&body)?;
+    let written = std::fs::metadata(&path).ok()?.modified().ok()?;
+    Some((values, written))
+}
+
+/// Try each mirror in turn, caching the first usable answer.
+async fn fetch() -> Option<PublishedValues> {
+    let client = reqwest::Client::builder()
+        .timeout(FETCH_TIMEOUT)
+        .build()
+        .ok()?;
+
+    for url in HOTFIX_URLS {
+        let Ok(resp) = client.get(*url).send().await else {
+            continue;
+        };
+        if !resp.status().is_success() {
+            continue;
+        }
+        let Ok(body) = resp.text().await else {
+            continue;
+        };
+        let Some(values) = parse(&body) else {
+            // Reachable but unusable: worth saying which mirror, since
+            // a stale CDN copy looks exactly like a bad commit.
+            tracing::warn!(url, "ggm-hotfix: published file did not validate");
+            continue;
+        };
+        tracing::info!(url, cv = %values.cv, "ggm-hotfix: published values fetched");
+        write_cache(&body);
+        return Some(values);
+    }
+    tracing::info!("ggm-hotfix: no mirror answered; using local sources");
+    None
+}
+
+fn write_cache(body: &str) {
+    let Some(path) = cache_path() else { return };
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    if let Err(error) = std::fs::write(&path, body) {
+        tracing::warn!(%error, "ggm-hotfix: could not cache the published values");
+    }
+}
+
+/// Strip a UTF-8 byte-order mark.
+///
+/// Several Windows editors add one when saving, and a BOM makes the
+/// document fail to parse — which here means every user silently drops
+/// to the compiled-in pair. That is the worst possible failure for a
+/// hotfix: it looks like the fix was published, and nobody is helped.
+/// Cheaper to tolerate it than to document it away.
+fn strip_bom(body: &str) -> &str {
+    body.strip_prefix('\u{feff}').unwrap_or(body)
+}
+
+/// Parse and validate a published document.
+///
+/// Validation is not politeness: a malformed pair is sent to beanfun as
+/// the caller's identity and gets everyone refused. Anything that is not
+/// obviously a version and a SHA-256 is treated as if the file were
+/// absent.
+fn parse(body: &str) -> Option<PublishedValues> {
+    let value: serde_json::Value = serde_json::from_str(strip_bom(body)).ok()?;
+    let cv = value["cv"].as_str()?.trim().to_string();
+    let hash = value["hash"].as_str()?.trim().to_ascii_lowercase();
+
+    if !is_version(&cv) || !is_sha256(&hash) {
+        tracing::warn!(cv = %cv, hash_len = hash.len(), "ggm-hotfix: values failed validation");
+        return None;
+    }
+    Some(PublishedValues { cv, hash })
+}
+
+/// Digits and dots only, and at least one digit.
+fn is_version(cv: &str) -> bool {
+    !cv.is_empty()
+        && cv.chars().any(|c| c.is_ascii_digit())
+        && cv.chars().all(|c| c.is_ascii_digit() || c == '.')
+}
+
+/// Exactly sixty-four hex characters.
+fn is_sha256(hash: &str) -> bool {
+    hash.len() == 64 && hash.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const GOOD_HASH: &str = "dfd568a69d87abcd8f4a93d1a4481ebb57712d1d28ab0b6fc018fcf140101e06";
+
+    fn doc(cv: &str, hash: &str) -> String {
+        format!(r#"{{"cv":"{cv}","hash":"{hash}"}}"#)
+    }
+
+    #[test]
+    fn reads_a_published_pair() {
+        let values = parse(&doc("1.5.0.2", GOOD_HASH)).expect("parses");
+        assert_eq!(values.cv, "1.5.0.2");
+        assert_eq!(values.hash, GOOD_HASH);
+    }
+
+    #[test]
+    fn tolerates_a_byte_order_mark() {
+        // The failure this prevents is invisible: a BOM would drop every
+        // user to the compiled-in pair while the fix looks published.
+        let body = format!("\u{feff}{}", doc("1.5.0.2", GOOD_HASH));
+        assert!(parse(&body).is_some(), "a BOM must not defeat the hotfix");
+    }
+
+    #[test]
+    fn accepts_an_uppercase_hash_by_normalising_it() {
+        let values = parse(&doc("1.5.0.2", &GOOD_HASH.to_uppercase())).expect("parses");
+        assert_eq!(values.hash, GOOD_HASH, "beanfun is given lowercase hex");
+    }
+
+    #[test]
+    fn rejects_a_hash_that_is_not_a_sha256() {
+        // Sent as our identity, a malformed hash gets everyone refused —
+        // so it is treated as if the file were not there.
+        assert!(parse(&doc("1.5.0.2", "abc")).is_none());
+        assert!(parse(&doc("1.5.0.2", &"z".repeat(64))).is_none());
+        assert!(parse(&doc("1.5.0.2", &format!("{GOOD_HASH}00"))).is_none());
+    }
+
+    #[test]
+    fn rejects_a_version_that_is_not_one() {
+        assert!(parse(&doc("", GOOD_HASH)).is_none());
+        assert!(parse(&doc("1.5.0.2-beta", GOOD_HASH)).is_none());
+        assert!(parse(&doc("...", GOOD_HASH)).is_none());
+    }
+
+    #[test]
+    fn rejects_a_document_that_is_not_the_document() {
+        assert!(parse("not json at all").is_none());
+        assert!(parse(r#"{"version":"1.5.0.2"}"#).is_none());
+    }
+
+    #[test]
+    fn the_shipped_file_validates() {
+        // The published file lives in the repo; if it stops parsing, the
+        // hotfix lever is broken before anyone needs to pull it.
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join(CACHE_FILE);
+        let body = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("{} must exist: {e}", path.display()));
+        assert!(
+            parse(&body).is_some(),
+            "the shipped {CACHE_FILE} must validate, or publishing it helps nobody"
+        );
+    }
+}

--- a/src-tauri/src/services/beanfun/ggm_hotfix.rs
+++ b/src-tauri/src/services/beanfun/ggm_hotfix.rs
@@ -22,6 +22,10 @@
 //! runbook, including how to tell this failure apart from the ones that
 //! need a code change instead.
 //!
+//! Nobody is expected to notice a new Game Manager by hand:
+//! `.github/workflows/ggm-watch.yml` asks beanfun hourly which build it
+//! ships and opens an issue with the new pair when that moves.
+//!
 //! # Failing quietly is the point
 //!
 //! Every step here is best-effort. A fetch that times out, a file that

--- a/src-tauri/src/services/beanfun/mod.rs
+++ b/src-tauri/src/services/beanfun/mod.rs
@@ -35,6 +35,7 @@ pub mod client;
 pub mod client_integrity;
 pub mod error;
 pub mod games;
+pub mod ggm_hotfix;
 pub mod login;
 pub mod otp;
 pub mod session;

--- a/src-tauri/src/services/beanfun/otp.rs
+++ b/src-tauri/src/services/beanfun/otp.rs
@@ -481,12 +481,41 @@ async fn step_4_long_poll(
 /// A join failure (runtime shutting down) degrades to the bundled
 /// constants rather than failing the OTP outright.
 async fn resolve_client_integrity() -> ClientIntegrity {
-    tokio::task::spawn_blocking(ClientIntegrity::resolve)
+    use crate::services::beanfun::ggm_hotfix;
+
+    // 1. What the user pinned. An explicit choice outranks everything,
+    //    including a newer published pair.
+    if let Some(pinned) = tokio::task::spawn_blocking(ggm_hotfix::pinned)
+        .await
+        .ok()
+        .flatten()
+    {
+        return ClientIntegrity::from_published(&pinned);
+    }
+
+    // 2. The GGM installed here. It follows its own updates, so these
+    //    values survive beanfun raising the bar without us doing
+    //    anything — and they are this machine's truth rather than a
+    //    guess about it.
+    let local = tokio::task::spawn_blocking(ClientIntegrity::resolve_local)
         .await
         .unwrap_or_else(|e| {
-            tracing::warn!(error = %e, "client-integrity resolve task failed; using bundled constants");
-            ClientIntegrity::fallback()
-        })
+            tracing::warn!(error = %e, "client-integrity resolve task failed");
+            None
+        });
+    if let Some(local) = local {
+        return local;
+    }
+
+    // 3. What we published. This is the hotfix lever: one commit fixes
+    //    every user with no GGM installed, with no release and nothing
+    //    for them to do. See `services::beanfun::ggm_hotfix`.
+    if let Some(published) = ggm_hotfix::published().await {
+        return ClientIntegrity::from_published(&published);
+    }
+
+    // 4. What we shipped with.
+    ClientIntegrity::fallback()
 }
 
 /// Body of the v2 OTP request. Field names are PascalCase on the wire

--- a/src-tauri/src/services/beanfun/otp.rs
+++ b/src-tauri/src/services/beanfun/otp.rs
@@ -493,29 +493,79 @@ async fn resolve_client_integrity() -> ClientIntegrity {
         return ClientIntegrity::from_published(&pinned);
     }
 
-    // 2. The GGM installed here. It follows its own updates, so these
-    //    values survive beanfun raising the bar without us doing
-    //    anything — and they are this machine's truth rather than a
-    //    guess about it.
+    // 2 and 3. The GGM installed here, and what we published — whichever
+    //    describes the newer build.
+    //
+    //    GGM updates itself, but only when it runs, and the people this
+    //    app exists for are precisely the ones who never run it: they
+    //    launch from here, not from the official site. An install that
+    //    has sat untouched since Gamania last shipped reports what it was
+    //    then, and those are the values beanfun stops accepting — so
+    //    preferring it unconditionally would make the stalest machines
+    //    the only ones the hotfix lever could never reach.
+    //
+    //    Preferring the published pair unconditionally trades that for
+    //    the opposite hazard: a bad publish takes down users whose own
+    //    install was fine. Comparing versions avoids both. A tie goes to
+    //    the installed file, which is this machine's own truth rather
+    //    than a claim about it.
     let local = tokio::task::spawn_blocking(ClientIntegrity::resolve_local)
         .await
         .unwrap_or_else(|e| {
             tracing::warn!(error = %e, "client-integrity resolve task failed");
             None
         });
-    if let Some(local) = local {
-        return local;
-    }
+    let published = ggm_hotfix::published().await;
 
-    // 3. What we published. This is the hotfix lever: one commit fixes
-    //    every user with no GGM installed, with no release and nothing
-    //    for them to do. See `services::beanfun::ggm_hotfix`.
-    if let Some(published) = ggm_hotfix::published().await {
-        return ClientIntegrity::from_published(&published);
+    match (local, published) {
+        (Some(local), Some(published)) => {
+            if names_a_newer_build(&published.cv, &local.cv) {
+                tracing::info!(
+                    local = %local.cv,
+                    published = %published.cv,
+                    "published client-integrity is newer than the installed GGM"
+                );
+                ClientIntegrity::from_published(&published)
+            } else {
+                local
+            }
+        }
+        (Some(local), None) => local,
+        (None, Some(published)) => ClientIntegrity::from_published(&published),
+        // 4. What we shipped with.
+        (None, None) => ClientIntegrity::fallback(),
     }
+}
 
-    // 4. What we shipped with.
-    ClientIntegrity::fallback()
+/// Whether `candidate` names a strictly newer build than `current`.
+///
+/// Dotted numbers compared segment by segment, missing segments read as
+/// zero so `1.5.1` beats `1.5`. Anything unparseable compares as zero,
+/// which makes a malformed version lose rather than win — the safe
+/// direction, since the loser is simply not used.
+///
+/// Not `core::version::is_newer`: that one answers a different question.
+/// It compares release tags carrying a build timestamp, and treats a
+/// matching timestamp as authoritative regardless of the numbers. A GGM
+/// file version is four plain numbers with no stamp to match on.
+fn names_a_newer_build(candidate: &str, current: &str) -> bool {
+    fn parts(v: &str) -> Vec<u64> {
+        v.split('.')
+            .map(|p| p.trim().parse().unwrap_or(0))
+            .collect()
+    }
+    let (a, b) = (parts(candidate), parts(current));
+    let width = a.len().max(b.len());
+    for i in 0..width {
+        let (x, y) = (
+            a.get(i).copied().unwrap_or(0),
+            b.get(i).copied().unwrap_or(0),
+        );
+        if x != y {
+            return x > y;
+        }
+    }
+    false
 }
 
 /// Body of the v2 OTP request. Field names are PascalCase on the wire
@@ -999,6 +1049,36 @@ fn snippet_for_diagnostics(body: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn a_newer_published_version_wins() {
+        // The case that motivated comparing at all: an install left alone
+        // since before Gamania's last release.
+        assert!(names_a_newer_build("1.5.0.2", "1.4.9.9"));
+        assert!(names_a_newer_build("1.5.1", "1.5.0.2"));
+        assert!(names_a_newer_build("2.0", "1.9.9.9"));
+    }
+
+    #[test]
+    fn an_equal_or_older_published_version_does_not() {
+        // A tie goes to the installed file, and a publish that names an
+        // older build is a mistake that must not take working machines down.
+        assert!(!names_a_newer_build("1.5.0.2", "1.5.0.2"));
+        assert!(
+            !names_a_newer_build("1.5.0", "1.5.0.0"),
+            "missing segments read as zero"
+        );
+        assert!(!names_a_newer_build("1.4.0", "1.5.0.2"));
+    }
+
+    #[test]
+    fn an_unreadable_version_loses() {
+        // Whatever cannot be parsed compares as zero. Losing is the safe
+        // direction: the loser is simply not used.
+        assert!(!names_a_newer_build("", "1.0"));
+        assert!(!names_a_newer_build("not.a.version", "0.0.1"));
+        assert!(names_a_newer_build("0.0.1", "not.a.version"));
+    }
+
     use super::*;
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
TW password retrieval states which Gamania Games Manager is asking — a version
and the SHA-256 of `GGMWebStart.dll` — and beanfun refuses a pair it does not
accept. Users with GGM installed have real values to send. Everyone else sends
the pair compiled into the app, so the day beanfun raises the bar they all
break at once, and the fix is a release they must download while unable to
play.

This makes that pair fixable with a commit, and makes us the first to know it
needs fixing.

## The lever

`ggm-client.json` at the repository root is fetched by the app and cached for
six hours. Editing it and pushing to `code` reaches every affected user without
a release. Resolution order:

1. **Pinned** — a local `ggm-client.json` with `"override": true`. A deliberate
   choice by the user; nothing overrides it.
2. **Installed GGM** — read off this machine. Self-updating, so these users
   never touch the network for this and are immune to a bad publish.
3. **Published** — this file. The lever.
4. **Compiled in** — so a machine with none of the above still works.

Every layer is best-effort: a fetch that times out, a BOM, a hash that is not
64 hex characters — each falls through to the next source rather than
surfacing. A network hiccup must not cost someone their password when a good
compiled-in pair is sitting right there. Validation is not politeness either:
a malformed pair is sent as our identity and gets everyone refused, so anything
that is not obviously a version and a SHA-256 is treated as if the file were
absent.

Four mirrors (raw.githubusercontent, two jsDelivr, ghproxy) because most of the
audience this exists for cannot reach GitHub directly.

## The detector

The lever is worthless until someone knows the pair went stale, and the way we
would have found out is a user unable to get a password.

beanfun states which build it ships, in eighty bytes:

```
GET https://tw.beanfun.com/generic_handlers/CheckVersion.ashx
{"url": "https://tw.beanfun.com/ggm/GGMSetup_1.5.0.2.exe", "version": "1.5.0.2"}
```

`version` is exactly the `cv` we publish, so `.github/workflows/ggm-watch.yml`
runs an hourly equality test on that one GET. When it moves, a `windows-latest`
job installs the manager, reads the DLL's version and SHA-256, and opens a
single `ggm-version` issue containing the finished document, ready to paste.

The Windows runner is not laziness — the DLL is inside an Inno Setup 6.3
installer Ubuntu's `innoextract` cannot parse, and the version lives in a
Windows version resource no Linux runner can read. It starts only when the
version actually moved, so the hourly cost stays one Linux request, and public
repositories bill no Actions minutes.

The install is waited on with a limit rather than `-Wait` (a runner has no
desktop, so an installer that asks something hangs until the job times out) and
the DLL is looked for either way, since a partial install still writes the file
we want. If the read fails, the issue still goes out with the version — knowing
a new manager shipped is most of the value.

## Also here

- `scripts/ggm-client.ps1` — reads both values off an installed GGM and writes
  the document, UTF-8 **without** BOM. `Set-Content -Encoding utf8` writes one
  on Windows PowerShell, and a BOM used to make the fix look published while
  helping nobody. The app now tolerates one anyway.
- `docs/GGM-CLIENT-HOTFIX.md` — the runbook, leading with the symptoms that are
  **not** this. "The page changed" and "the response format changed" look
  identical from outside and cost a code change; swapping values there burns
  hours.

## Verification

- 1131 Rust tests pass, clippy clean.
- `the_shipped_file_validates` parses the real `ggm-client.json`, so the lever
  cannot be broken before anyone reaches for it.
- `scripts/ggm-client.ps1` on a machine with GGM 1.5.0.2 prints exactly the
  pair compiled into the app — the two paths agree today.
- The watcher's check step was rehearsed against the live endpoint: it reports
  `published=1.5.0.2 upstream=1.5.0.2 → changed=false`, and the JSON block in
  the issue body it would post parses as-is.

Nothing here changes behaviour for anyone until the file is edited: today all
four layers resolve to the same pair.
