### PR TITLE
fix(otp): route the pre-v2 launch payload to the endpoint that answers it (#376)

### DIFF
--- a/src-tauri/src/core/launch_data.rs
+++ b/src-tauri/src/core/launch_data.rs
@@ -11,10 +11,26 @@
 //! ```
 //!
 //! and hands it to the native launcher over the `gamaniagames://` URL
-//! scheme. `data` carries the `LaunchTicket` that
-//! `get_webstart_otp_v2.ashx` requires — obfuscated, but present, so
-//! the value can be recovered without the launcher being installed.
-//! See `docs/OTP-PROTOCOL-CHANGE.md` for how this was established.
+//! scheme. `data` carries whatever that game's OTP request needs —
+//! obfuscated, but present, so it can be recovered without the
+//! launcher being installed. See `docs/OTP-PROTOCOL-CHANGE.md` for how
+//! this was established.
+//!
+//! # Two payloads
+//!
+//! There are two, and both are live:
+//!
+//! - **`LaunchTicket=…`** — a ticket for `get_webstart_otp_v2.ashx`.
+//!   Observed on MapleStory, whose page declares no `webToken` or
+//!   `secretCode`.
+//! - **`ppppp=…`** — the query parameters for the pre-v2
+//!   `get_webstart_otp.ashx`, alongside `ServiceCode`,
+//!   `ServiceRegion`, `ServiceAccount` and `CreateTime`. Observed on
+//!   Mabinogi and Elsword, whose pages do declare those two.
+//!
+//! Treating a `ppppp` payload as a failed `LaunchTicket` decode is
+//! what broke every game but MapleStory (upstream issue #376): the
+//! decode was fine, the acceptance test was too narrow.
 //!
 //! # Format
 //!
@@ -75,7 +91,7 @@ pub enum LaunchDataError {
     #[error("DES decryption of launch data failed: {0}")]
     Decrypt(String),
 
-    #[error("decrypted launch data has no LaunchTicket field")]
+    #[error("decrypted launch data carries neither a LaunchTicket nor a ppppp payload")]
     MissingTicket,
 
     #[error("LaunchTicket is not 64 hex characters (got {0})")]
@@ -88,29 +104,96 @@ impl From<wcdes::WcdesError> for LaunchDataError {
     }
 }
 
-/// Recover the `LaunchTicket` from a `m_objData.data` blob.
+/// The two payloads a `m_objData.data` blob is known to carry.
 ///
-/// The other decoded fields (`ServiceCode`, `ServiceRegion`,
-/// `ServiceAccount`, `BeanfunUrl`, `WebStartPatch`) are discarded —
-/// the v2 OTP request needs none of them, and the caller already holds
-/// its own copies.
-//
-// ponytail: returns the one field the caller uses. Widen to the full
-// field map if a future call site needs more than the ticket.
-pub fn decode_launch_ticket(data: &str) -> Result<String, LaunchDataError> {
+/// Which one a page hands over is not a property of the account or the
+/// region — it is per game. A page that also declares `webToken` and
+/// `secretCode` carries [`LaunchPayload::Legacy`]; one that declares
+/// neither carries [`LaunchPayload::Ticket`]. That matches `ggm.js`,
+/// which forwards those two to the launcher only when they exist, and
+/// it matches the launcher having two OTP URL builders.
+#[derive(Debug, PartialEq, Eq)]
+pub enum LaunchPayload {
+    /// A ticket `get_webstart_otp_v2.ashx` takes directly.
+    Ticket(String),
+    /// The query parameters the pre-v2 `get_webstart_otp.ashx` wants.
+    Legacy(Box<LegacyOtpParams>),
+}
+
+/// Pre-v2 OTP query parameters, as carried inside the blob.
+///
+/// `ppppp` is the interesting one. The WPF client hardcoded a
+/// 64-character constant for it and nobody knew where the value came
+/// from; it is in fact supplied here, and the current one is 96
+/// characters. Reading it from the blob is correct whether it is
+/// global, per-session or per-launch, which is why nothing here caches
+/// or pins it.
+#[derive(Debug, PartialEq, Eq)]
+pub struct LegacyOtpParams {
+    pub ppppp: String,
+    pub service_code: String,
+    pub service_region: String,
+    pub service_account: String,
+    pub create_time: String,
+}
+
+/// Decode a `m_objData.data` blob into whichever payload it carries.
+pub fn decode_launch_data(data: &str) -> Result<LaunchPayload, LaunchDataError> {
     let plaintext = decode(data)?;
-    let ticket = plaintext
+    let fields = parse_fields(&plaintext);
+    let field = |name: &str| {
+        fields
+            .iter()
+            .find(|(k, _)| *k == name)
+            .map(|(_, v)| (*v).to_owned())
+    };
+
+    if let Some(ticket) = field("LaunchTicket") {
+        if ticket.len() != 64 || !ticket.chars().all(|c| c.is_ascii_hexdigit()) {
+            return Err(LaunchDataError::MalformedTicket(ticket));
+        }
+        return Ok(LaunchPayload::Ticket(ticket));
+    }
+
+    match (
+        field("ppppp"),
+        field("ServiceCode"),
+        field("ServiceRegion"),
+        field("ServiceAccount"),
+        field("CreateTime"),
+    ) {
+        (
+            Some(ppppp),
+            Some(service_code),
+            Some(service_region),
+            Some(service_account),
+            Some(create_time),
+        ) => Ok(LaunchPayload::Legacy(Box::new(LegacyOtpParams {
+            ppppp,
+            service_code,
+            service_region,
+            service_account,
+            create_time,
+        }))),
+        _ => Err(LaunchDataError::MissingTicket),
+    }
+}
+
+/// Split the decoded plaintext into `key=value` pairs.
+///
+/// The separator is `&&&&`, but splitting on a single `&` and dropping
+/// the empty runs handles that and the single-`&` form alike, so one
+/// parser covers both payloads. Everything from the first `;` on is a
+/// trailer, not a field.
+fn parse_fields(plaintext: &str) -> Vec<(&str, &str)> {
+    plaintext
         .split(';')
         .next()
         .unwrap_or_default()
         .split('&')
-        .find_map(|pair| pair.strip_prefix("LaunchTicket="))
-        .ok_or(LaunchDataError::MissingTicket)?;
-
-    if ticket.len() != 64 || !ticket.chars().all(|c| c.is_ascii_hexdigit()) {
-        return Err(LaunchDataError::MalformedTicket(ticket.to_owned()));
-    }
-    Ok(ticket.to_owned())
+        .filter(|segment| !segment.is_empty())
+        .filter_map(|pair| pair.split_once('='))
+        .collect()
 }
 
 /// Undo the substitution layer and decrypt, returning the raw
@@ -147,7 +230,14 @@ fn decode(data: &str) -> Result<String, LaunchDataError> {
         }
         tried.push(table_index);
         match decode_with(&rest, selector, table_index) {
-            Ok(plaintext) if plaintext.contains("LaunchTicket=") => {
+            // Either marker means the table was right. Testing only for
+            // `LaunchTicket=` silently discarded a perfectly good
+            // decode of the other payload as "wrong table", which is
+            // what made every `ppppp` game fail with a decryption
+            // error while MapleStory worked.
+            Ok(plaintext)
+                if plaintext.contains("LaunchTicket=") || plaintext.contains("ppppp=") =>
+            {
                 tracing::debug!(selector, table = table_index, "launch data table");
                 return Ok(plaintext);
             }
@@ -250,11 +340,55 @@ mod tests {
         for selector in 0..16 {
             let blob = encode(selector, key, &cipher_hex);
             assert_eq!(
-                decode_launch_ticket(&blob).unwrap(),
-                "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+                decode_launch_data(&blob).unwrap(),
+                LaunchPayload::Ticket(
+                    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".to_owned()
+                ),
                 "selector {selector} failed"
             );
         }
+    }
+
+    /// The payload every non-MapleStory game was observed to hand over.
+    /// Field separator is `&&&&` and the `ppppp` is 96 characters, not
+    /// the 64-character constant the WPF client pinned — both shapes
+    /// taken from live blobs.
+    #[test]
+    fn legacy_payload_round_trips_through_every_selector() {
+        let ppppp = "F".repeat(96);
+        let plaintext = format!(
+            "ppppp={ppppp}&&&&ServiceCode=600309&&&&ServiceRegion=A2&&&&ServiceAccount=A205b371011500171132&&&&CreateTime=2010-08-18 20:28:29&&&&BeanfunUrl=https://tw.beanfun.com/&&&&WebStartPatch=http://tw.patch.beanfun.gamania.com/beanfun05/;"
+        );
+        let padded = format!("{plaintext}{}", "\0".repeat((8 - plaintext.len() % 8) % 8));
+        let key = "b034e744";
+        let cipher_hex = encrypt_hex(&padded, key).unwrap().to_lowercase();
+
+        for selector in 0..16 {
+            let blob = encode(selector, key, &cipher_hex);
+            let LaunchPayload::Legacy(params) = decode_launch_data(&blob).unwrap() else {
+                panic!("selector {selector}: expected the pre-v2 payload");
+            };
+            assert_eq!(params.ppppp, ppppp, "selector {selector}");
+            assert_eq!(params.service_code, "600309");
+            assert_eq!(params.service_region, "A2");
+            assert_eq!(params.service_account, "A205b371011500171132");
+            assert_eq!(params.create_time, "2010-08-18 20:28:29");
+        }
+    }
+
+    /// A decode that yields neither marker is a wrong table, and every
+    /// table being wrong is the one case that is genuinely a failure.
+    #[test]
+    fn a_payload_with_neither_marker_is_rejected() {
+        let plaintext = "SomethingElse=1&Other=2;xx";
+        let padded = format!("{plaintext}{}", "\0".repeat((8 - plaintext.len() % 8) % 8));
+        let key = "a1b2c3d4";
+        let cipher_hex = encrypt_hex(&padded, key).unwrap().to_lowercase();
+        let blob = encode(3, key, &cipher_hex);
+        assert_eq!(
+            decode_launch_data(&blob).unwrap_err(),
+            LaunchDataError::MissingTicket
+        );
     }
 
     /// The two real blob lengths observed in the wild — 553 from the
@@ -276,16 +410,13 @@ mod tests {
 
     #[test]
     fn empty_input_is_rejected() {
-        assert_eq!(
-            decode_launch_ticket("").unwrap_err(),
-            LaunchDataError::Empty
-        );
+        assert_eq!(decode_launch_data("").unwrap_err(), LaunchDataError::Empty);
     }
 
     #[test]
     fn non_hex_selector_is_rejected() {
         assert_eq!(
-            decode_launch_ticket("zzzz").unwrap_err(),
+            decode_launch_data("zzzz").unwrap_err(),
             LaunchDataError::BadSelector('z')
         );
     }
@@ -293,7 +424,7 @@ mod tests {
     #[test]
     fn character_outside_the_table_is_rejected() {
         // Selector 0 → table 0, which has no 'z'.
-        let err = decode_launch_ticket("0zzz").unwrap_err();
+        let err = decode_launch_data("0zzz").unwrap_err();
         assert!(
             matches!(err, LaunchDataError::UnmappableChar('z', 0)),
             "got {err:?}"
@@ -303,7 +434,7 @@ mod tests {
     #[test]
     fn blob_too_short_for_a_key_is_rejected() {
         // Table 0 characters only, but far fewer than offset + 8.
-        let err = decode_launch_ticket("0bac").unwrap_err();
+        let err = decode_launch_data("0bac").unwrap_err();
         assert!(
             matches!(err, LaunchDataError::TooShort { .. }),
             "got {err:?}"

--- a/src-tauri/src/core/launch_data.rs
+++ b/src-tauri/src/core/launch_data.rs
@@ -21,12 +21,14 @@
 //! There are two, and both are live:
 //!
 //! - **`LaunchTicket=…`** — a ticket for `get_webstart_otp_v2.ashx`.
-//!   Observed on MapleStory, whose page declares no `webToken` or
-//!   `secretCode`.
+//!   Observed on MapleStory.
 //! - **`ppppp=…`** — the query parameters for the pre-v2
 //!   `get_webstart_otp.ashx`, alongside `ServiceCode`,
-//!   `ServiceRegion`, `ServiceAccount` and `CreateTime`. Observed on
-//!   Mabinogi and Elsword, whose pages do declare those two.
+//!   `ServiceRegion`, `ServiceAccount` and `CreateTime`, joined by
+//!   `&&&&`. Observed on CSO, Elsword and Mabinogi.
+//!
+//! Both kinds of page declare `m_objData`, so only the decoded
+//! contents distinguish them.
 //!
 //! Treating a `ppppp` payload as a failed `LaunchTicket` decode is
 //! what broke every game but MapleStory (upstream issue #376): the
@@ -94,7 +96,7 @@ pub enum LaunchDataError {
     #[error("decrypted launch data carries neither a LaunchTicket nor a ppppp payload")]
     MissingTicket,
 
-    #[error("LaunchTicket is not 64 hex characters (got {0})")]
+    #[error("LaunchTicket field is present but empty")]
     MalformedTicket(String),
 }
 
@@ -106,12 +108,17 @@ impl From<wcdes::WcdesError> for LaunchDataError {
 
 /// The two payloads a `m_objData.data` blob is known to carry.
 ///
-/// Which one a page hands over is not a property of the account or the
-/// region — it is per game. A page that also declares `webToken` and
-/// `secretCode` carries [`LaunchPayload::Legacy`]; one that declares
-/// neither carries [`LaunchPayload::Ticket`]. That matches `ggm.js`,
-/// which forwards those two to the launcher only when they exist, and
-/// it matches the launcher having two OTP URL builders.
+/// Which one a page hands over is per game — whether that game has
+/// been migrated to the v2 endpoint yet. **From the outside the two
+/// pages look identical**: both declare `m_objData`, so the blob has to
+/// be decoded before the route is known. That is why routing on the
+/// mere presence of the literal sent every un-migrated game to an
+/// endpoint with nothing to give it (upstream #376).
+///
+/// Independently measured across four titles by @ToooAir on that
+/// issue: MapleStory (`610074_T9`) carries a ticket; CSO
+/// (`610153_TN`), Elsword (`300148_AF`) and Mabinogi (`600309_A2`)
+/// carry the pre-v2 parameters. All four declare `m_objData`.
 #[derive(Debug, PartialEq, Eq)]
 pub enum LaunchPayload {
     /// A ticket `get_webstart_otp_v2.ashx` takes directly.
@@ -149,7 +156,11 @@ pub fn decode_launch_data(data: &str) -> Result<LaunchPayload, LaunchDataError> 
     };
 
     if let Some(ticket) = field("LaunchTicket") {
-        if ticket.len() != 64 || !ticket.chars().all(|c| c.is_ascii_hexdigit()) {
+        // Presence decides the route; length does not. Pinning it to
+        // the 64 characters seen so far would be the same over-narrow
+        // acceptance that made every `ppppp` game fail, and #376
+        // reports observed lengths moving elsewhere in this protocol.
+        if ticket.is_empty() {
             return Err(LaunchDataError::MalformedTicket(ticket));
         }
         return Ok(LaunchPayload::Ticket(ticket));

--- a/src-tauri/src/services/beanfun/otp.rs
+++ b/src-tauri/src/services/beanfun/otp.rs
@@ -105,24 +105,35 @@
 //!
 //! # Two step 5s
 //!
-//! Beanfun replaced step 5. `GET get_webstart_otp.ashx` with its nine
-//! query parameters now answers `0;        Query String Error` no
-//! matter what it is sent; the live endpoint is
-//! `POST get_webstart_otp_v2.ashx` with a JSON body, and the OTP comes
-//! back in a JSON `data` member rather than a `1;…` envelope.
+//! Beanfun added a step 5; it did not retire the other one.
+//! `POST get_webstart_otp_v2.ashx` takes a JSON body and answers with a
+//! JSON `data` member. `GET get_webstart_otp.ashx` takes nine query
+//! parameters and answers with a `1;…` envelope. Both are live, and
+//! which one answers is per game rather than per region: MapleStory
+//! moved to v2, while CSO, Elsword and Mabinogi did not.
 //!
-//! Both paths live here. [`get_otp`] picks between them on whether
-//! step 1's page carries the `m_objData` launcher-handoff literal —
-//! the page's own shape, not the configured region, so a region that
-//! migrates later needs no code change. TW has migrated; HK has not
-//! been observed to.
+//! [`get_otp`] therefore picks in two stages, both on evidence rather
+//! than on configuration. A page carrying the `m_objData`
+//! launcher-handoff literal hands its OTP over through the launcher,
+//! and what that handoff's obfuscated blob decodes to names the
+//! endpoint: a `LaunchTicket` means v2, a `ppppp` payload means the
+//! older handler, answered with the blob's own parameters rather than
+//! with our session's. A page without the literal keeps the original
+//! flow, which is HK today. Neither stage needs changing when a game or
+//! a region moves.
 //!
-//! The v2 request needs a `LaunchTicket`, which is *not* a new
-//! server round-trip: it travels obfuscated inside `m_objData.data`,
-//! decoded by [`crate::core::launch_data`]. It also needs `CV`,
-//! `Hash` and `arch`, which identify the official launcher build and
-//! come from [`super::client_integrity`].
-//! `docs/OTP-PROTOCOL-CHANGE.md` has the full derivation.
+//! Either way the payload is *not* a new server round-trip: it travels
+//! obfuscated inside `m_objData.data`, decoded by
+//! [`crate::core::launch_data`]. Both requests also carry `CV`, `Hash`
+//! and `arch`, which identify the official launcher build and come from
+//! [`super::client_integrity`]. `docs/OTP-PROTOCOL-CHANGE.md` has the
+//! full derivation.
+//!
+//! Reading the old handler as dead is what broke every game but
+//! MapleStory (upstream #376). `0;        Query String Error` is what
+//! it answers a request built from the wrong values — which a request
+//! built from our session state is, on a page that handed over its
+//! own.
 //!
 //! # The same three values on the legacy path
 //!
@@ -198,11 +209,11 @@ pub async fn get_otp(
     let step1 = step_1_init(client, account, service_code, service_region).await?;
 
     // Branch on the page's own shape rather than on the region: a page
-    // that carries `m_objData` is one whose OTP now comes from the v2
-    // endpoint, and the pre-v2 handler answers every request with
-    // `Query String Error`. Observed migrated on TW; HK's page has no
-    // such literal and keeps the legacy path. If HK migrates later this
-    // needs no change.
+    // that carries `m_objData` hands its OTP over through the launcher,
+    // and the blob decides which endpoint answers — not this branch,
+    // and not the game. Observed on TW; HK's page has no such literal
+    // and keeps the original flow. If HK changes later this needs no
+    // change.
     if let Some(handoff) = &step1.launch {
         // Recording the start is what the page does alongside opening
         // the launcher, and nothing downstream depends on it — so a
@@ -286,28 +297,42 @@ pub async fn get_otp(
 
     let result = step_6_decrypt(&envelope);
     if let Err(err) = &result {
-        // `OtpDecryptionFailed` is the one failure that reaches here
-        // holding a *successful* `1;…` envelope — its payload carries
-        // the live OTP key + ciphertext, which must never be logged.
-        // The other variants only ever carry a rejection message.
-        // The body is server-controlled and could echo back a parameter
-        // we sent, so it goes through `scrub` even though its field name
-        // is outside the leak guard's list. `scrub` only rewrites
-        // credential-shaped `k=v` pairs, leaving a plain rejection
-        // message like `0;  Query String Error` intact.
-        let raw_response = match err {
-            LoginError::OtpDecryptionFailed { .. } => "<redacted: success envelope>".to_owned(),
-            _ => scrub(&envelope),
-        };
-        tracing::warn!(
-            error = %err,
-            request_url = %redact_otp_url(&url),
-            raw_response,
-            raw_response_len = envelope.len(),
-            "OTP step 5 failed — server response logged for diagnosis"
-        );
+        log_step_5_failure(err, "legacy", &url, &envelope);
     }
     result
+}
+
+/// Report a step 5 failure without putting the user's password in the
+/// log.
+///
+/// [`LoginError::OtpDecryptionFailed`] is the one failure that arrives
+/// holding a *successful* `1;…` envelope — its payload carries the live
+/// OTP key and ciphertext, which must never be written down. Every
+/// other variant carries only a rejection message.
+///
+/// That message is server-controlled and could echo back a parameter we
+/// sent, so it goes through [`scrub`] even though its field name is
+/// outside the leak guard's list. `scrub` only rewrites
+/// credential-shaped `k=v` pairs, leaving a plain rejection like
+/// `0;  Query String Error` intact.
+///
+/// Both `GET` routes share this rather than each keeping a copy: the
+/// rule about the success envelope is exactly the kind that gets fixed
+/// in one place and left wrong in the other. `route` says which one is
+/// speaking, which the shared message otherwise loses.
+fn log_step_5_failure(err: &LoginError, route: &str, url: &str, envelope: &str) {
+    let raw_response = match err {
+        LoginError::OtpDecryptionFailed { .. } => "<redacted: success envelope>".to_owned(),
+        _ => scrub(envelope),
+    };
+    tracing::warn!(
+        error = %err,
+        route,
+        request_url = %redact_otp_url(url),
+        raw_response,
+        raw_response_len = envelope.len(),
+        "OTP step 5 failed — server response logged for diagnosis"
+    );
 }
 
 // -----------------------------------------------------------------------------
@@ -633,11 +658,6 @@ struct OtpV2Response {
     message: Option<String>,
 }
 
-/// Step 5 (v2) — `POST get_webstart_otp_v2.ashx` and decrypt the OTP
-/// out of the JSON reply.
-///
-/// Replaces the pre-v2 `GET get_webstart_otp.ashx`, which now answers
-/// `0;        Query String Error` regardless of what it is sent.
 /// Step 5 (pre-v2, driven by the handoff) — `GET
 /// get_webstart_otp.ashx` with the parameters the blob supplied.
 ///
@@ -685,21 +705,20 @@ async fn step_5_get_otp_from_handoff(
 
     let result = step_6_decrypt(&envelope);
     if let Err(err) = &result {
-        let raw_response = match err {
-            LoginError::OtpDecryptionFailed { .. } => "<redacted: success envelope>".to_owned(),
-            _ => scrub(&envelope),
-        };
-        tracing::warn!(
-            error = %err,
-            request_url = %redact_otp_url(&url),
-            raw_response,
-            raw_response_len = envelope.len(),
-            "OTP step 5 (handoff, pre-v2) failed — server response logged for diagnosis"
-        );
+        log_step_5_failure(err, "handoff/pre-v2", &url, &envelope);
     }
     result
 }
 
+/// Step 5 (v2) — `POST get_webstart_otp_v2.ashx` and decrypt the OTP
+/// out of the JSON reply.
+///
+/// Not a replacement for the pre-v2 `GET`, though it read like one
+/// while MapleStory was the only game anyone tested: the two are
+/// siblings, and a game hands over whichever payload its own endpoint
+/// wants ([`step_5_get_otp_from_handoff`] is the other half). So a
+/// `Query String Error` from the old handler means the request was
+/// built wrong, not that the handler is gone.
 async fn step_5_post_otp_v2(
     client: &BeanfunClient,
     handoff: &LaunchHandoff,
@@ -1113,17 +1132,27 @@ fn build_get_webstart_otp_url(
 
 /// Secret-bearing query parameters of step 5's URL. Their values are
 /// replaced with a length when the URL is logged.
-const OTP_URL_SECRET_PARAMS: [&str; 4] = ["SN", "WebToken", "SecretCode", "ServiceAccount"];
+///
+/// `ppppp` is here because it stopped being a constant. It was exempt
+/// while the only one we ever sent was [`PPPPP_LITERAL`], printed a few
+/// lines above in this same file — nothing was disclosed by logging a
+/// value the reader could already see. The handoff route takes it from
+/// the launch blob instead, and that one may be per-session or
+/// per-launch, so on that path the exemption would write a live value
+/// to disk.
+const OTP_URL_SECRET_PARAMS: [&str; 5] =
+    ["SN", "WebToken", "SecretCode", "ServiceAccount", "ppppp"];
 
 /// Rewrite step 5's URL so it is safe to put in a log line.
 ///
 /// Every parameter *name* survives, and the non-secret values stay
-/// verbatim on purpose — a rotated `ppppp` constant, a reformatted
-/// `CreateTime` or a wrong `ServiceCode` are exactly what a rejection
-/// diagnosis needs to see, and `ppppp` is a hardcoded constant already
-/// visible in this file. The four session-scoped values collapse to
-/// `<N chars>`, which still distinguishes "absent", "truncated" and
-/// "present" without putting a live token on disk.
+/// verbatim on purpose — a reformatted `CreateTime` or a wrong
+/// `ServiceCode` are exactly what a rejection diagnosis needs to see.
+/// The session-scoped values collapse to `<N chars>`, which still
+/// distinguishes "absent", "truncated" and "present" without putting a
+/// live token on disk. A length is enough for `ppppp` too: what a
+/// diagnosis wants from it is whether it is the 64-character constant
+/// or the 96-character value the blob now supplies.
 fn redact_otp_url(url: &str) -> String {
     let Some((base, query)) = url.split_once('?') else {
         return url.to_string();
@@ -1780,11 +1809,17 @@ mod tests {
         assert!(redacted.contains("WebToken=<11 chars>"), "got: {redacted}");
         assert!(redacted.contains("SN=<3 chars>"), "got: {redacted}");
 
-        // The values a rejection diagnosis actually needs stay verbatim.
+        // `ppppp` goes the same way. On the handoff route its value
+        // comes from the launch blob rather than from this file, and a
+        // per-launch value must not be written to a log — while the
+        // length still tells the two known shapes apart.
         assert!(
-            redacted.contains(&format!("ppppp={PPPPP_LITERAL}")),
-            "got: {redacted}"
+            !redacted.contains(PPPPP_LITERAL),
+            "a live ppppp must not survive redaction, got: {redacted}"
         );
+        assert!(redacted.contains("ppppp=<64 chars>"), "got: {redacted}");
+
+        // The values a rejection diagnosis actually needs stay verbatim.
         assert!(
             redacted.contains("CreateTime=2024-01-15%2012:34:56"),
             "got: {redacted}"

--- a/src-tauri/src/services/beanfun/otp.rs
+++ b/src-tauri/src/services/beanfun/otp.rs
@@ -139,7 +139,7 @@ use chrono::Local;
 use percent_encoding::{percent_decode_str, utf8_percent_encode, AsciiSet, NON_ALPHANUMERIC};
 use regex::Regex;
 
-use crate::core::launch_data::decode_launch_ticket;
+use crate::core::launch_data::{decode_launch_data, LaunchPayload, LegacyOtpParams};
 use crate::core::parser::{capture_first, extract_service_account_create_time};
 use crate::core::redact::scrub;
 use crate::core::time::{dt_compact_now, dt_iso_now};
@@ -220,7 +220,24 @@ pub async fn get_otp(
         // check — unrelated to the password, and it holds the
         // connection open.
         let integrity = resolve_client_integrity().await;
-        return step_5_post_otp_v2(client, handoff, &integrity, &step1.page_url).await;
+
+        // Which endpoint answers is decided by what the blob turned out
+        // to carry, not by the game or the region. Both payloads are
+        // live: MapleStory hands over a `LaunchTicket`, while Mabinogi,
+        // Elsword and others hand over the pre-v2 parameters.
+        let payload =
+            decode_launch_data(&handoff.data).map_err(|e| LoginError::OtpDecryptionFailed {
+                cause: format!("launch data: {e}"),
+            })?;
+        return match payload {
+            LaunchPayload::Ticket(ticket) => {
+                step_5_post_otp_v2(client, handoff, &ticket, &integrity, &step1.page_url).await
+            }
+            LaunchPayload::Legacy(params) => {
+                step_5_get_otp_from_handoff(client, handoff, &params, &integrity, &step1.page_url)
+                    .await
+            }
+        };
     }
 
     let secret_code = step_2_get_secret_code(client).await?;
@@ -311,11 +328,16 @@ struct Step1Data {
 /// Its `region` member is ignored: it is the constant
 /// `"TW;Production"` and no request we make carries it.
 struct LaunchHandoff {
-    /// 36-character GUID, sent as `SN` on the v2 OTP request.
+    /// 36-character GUID, sent as `SN` on either OTP request.
     sn: String,
-    /// Obfuscated blob carrying the `LaunchTicket`, decoded by
-    /// [`decode_launch_ticket`].
+    /// Obfuscated blob carrying the OTP payload, decoded by
+    /// [`decode_launch_data`].
     data: String,
+    /// Present only on pages whose blob carries the pre-v2 payload —
+    /// `ggm.js` forwards these to the launcher exactly when they exist,
+    /// and the pre-v2 OTP URL is the one that needs them.
+    web_token: Option<String>,
+    secret_code: Option<String>,
 }
 
 /// Step 1 — fetch `game_start_step2.aspx`, extract the long-polling
@@ -596,17 +618,82 @@ struct OtpV2Response {
 ///
 /// Replaces the pre-v2 `GET get_webstart_otp.ashx`, which now answers
 /// `0;        Query String Error` regardless of what it is sent.
-async fn step_5_post_otp_v2(
+/// Step 5 (pre-v2, driven by the handoff) — `GET
+/// get_webstart_otp.ashx` with the parameters the blob supplied.
+///
+/// This is the same endpoint the non-migrated path uses, but every
+/// value comes from the page rather than from our own session state.
+/// That matters most for `ppppp`: the WPF-era constant is stale, and
+/// the live one arrives in the blob.
+async fn step_5_get_otp_from_handoff(
     client: &BeanfunClient,
     handoff: &LaunchHandoff,
+    params: &LegacyOtpParams,
     integrity: &ClientIntegrity,
     referer: &str,
 ) -> Result<String, LoginError> {
-    let launch_ticket =
-        decode_launch_ticket(&handoff.data).map_err(|e| LoginError::OtpDecryptionFailed {
-            cause: format!("launch data: {e}"),
-        })?;
+    // `ggm.js` only forwards these two when the page declares them, and
+    // a page that hands over this payload always does. Their absence
+    // means the page shape changed under us, which is worth naming
+    // rather than sending a request that cannot succeed.
+    let (Some(web_token), Some(secret_code)) = (&handoff.web_token, &handoff.secret_code) else {
+        return Err(LoginError::OtpDecryptionFailed {
+            cause: "launch data carries the pre-v2 payload but the page declared no webToken/secretCode".to_owned(),
+        });
+    };
 
+    let base = client.portal_url("beanfun_block/generic_handlers/get_webstart_otp.ashx")?;
+    // As in the WPF builder: only the space in `CreateTime` needs
+    // encoding; every other character in these values is URL-safe.
+    let create_time = params.create_time.replace(' ', "%20");
+    let url = format!(
+        "{base}?SN={sn}&WebToken={web_token}&SecretCode={secret_code}&ppppp={ppppp}\
+         &ServiceCode={sc}&ServiceRegion={sr}&ServiceAccount={sa}&CreateTime={create_time}\
+         &d={tick}&CV={cv}&Hash={hash}&arch={arch}",
+        sn = handoff.sn,
+        ppppp = params.ppppp,
+        sc = params.service_code,
+        sr = params.service_region,
+        sa = params.service_account,
+        tick = tick_count_ms(),
+        cv = utf8_percent_encode(&integrity.cv, ESCAPE_DATA_STRING),
+        hash = utf8_percent_encode(&integrity.hash, ESCAPE_DATA_STRING),
+        arch = utf8_percent_encode(integrity.arch, ESCAPE_DATA_STRING),
+    );
+
+    let resp = client
+        .http()
+        .get(&url)
+        .header(reqwest::header::REFERER, referer)
+        .send()
+        .await?;
+    ensure_success(&resp, "get_webstart_otp.ashx")?;
+    let envelope = client.bounded_text(resp).await?;
+
+    let result = step_6_decrypt(&envelope);
+    if let Err(err) = &result {
+        let raw_response = match err {
+            LoginError::OtpDecryptionFailed { .. } => "<redacted: success envelope>".to_owned(),
+            _ => scrub(&envelope),
+        };
+        tracing::warn!(
+            error = %err,
+            request_url = %redact_otp_url(&url),
+            raw_response,
+            raw_response_len = envelope.len(),
+            "OTP step 5 (handoff, pre-v2) failed — server response logged for diagnosis"
+        );
+    }
+    result
+}
+
+async fn step_5_post_otp_v2(
+    client: &BeanfunClient,
+    handoff: &LaunchHandoff,
+    launch_ticket: &str,
+    integrity: &ClientIntegrity,
+    referer: &str,
+) -> Result<String, LoginError> {
     let url = client.portal_url("beanfun_block/generic_handlers/get_webstart_otp_v2.ashx")?;
     let resp = client
         .http()
@@ -614,7 +701,7 @@ async fn step_5_post_otp_v2(
         .header(reqwest::header::REFERER, referer)
         .json(&OtpV2Request {
             sn: &handoff.sn,
-            launch_ticket: &launch_ticket,
+            launch_ticket,
             cv: &integrity.cv,
             hash: &integrity.hash,
             arch: integrity.arch,
@@ -813,7 +900,12 @@ fn parse_launch_handoff(html: &str) -> Option<LaunchHandoff> {
     if sn.is_empty() || data.is_empty() {
         return None;
     }
-    Some(LaunchHandoff { sn, data })
+    Some(LaunchHandoff {
+        sn,
+        data,
+        web_token: capture_first(launch_web_token_regex(), &block).filter(|v| !v.is_empty()),
+        secret_code: capture_first(launch_secret_code_regex(), &block).filter(|v| !v.is_empty()),
+    })
 }
 
 /// Extract the `m_strSecretCode` JS literal from step 2's response.
@@ -886,6 +978,24 @@ fn launch_data_regex() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
     RE.get_or_init(|| {
         Regex::new(r#""data"\s*:\s*"([^"]*)""#).expect("launch data regex must compile")
+    })
+}
+
+/// `"webToken"` inside that literal. Only pages carrying the pre-v2
+/// payload declare it.
+fn launch_web_token_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r#""webToken"\s*:\s*"([^"]*)""#).expect("launch web token regex must compile")
+    })
+}
+
+/// `"secretCode"` inside that literal. As above.
+fn launch_secret_code_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r#""secretCode"\s*:\s*"([^"]*)""#)
+            .expect("launch secret code regex must compile")
     })
 }
 
@@ -1521,11 +1631,47 @@ mod tests {
         var ggmCallback = false;
     "#;
 
+    /// The shape every non-MapleStory game was observed to serve: the
+    /// same literal plus the two values the pre-v2 OTP URL needs.
+    const LAUNCH_LITERAL_WITH_TOKENS: &str = r#"
+        var m_objData = {
+            "region": "TW;Production",
+            "sn": "c65aa8c4-ff3a-4372-a842-7e69990f8bee",
+            "webToken": "aaaabbbbccccddddeeeeffff00001111",
+            "secretCode": "1111000fffeeeeddddccccbbbbaaaa22",
+            "data": "7abcdef0123456789"
+        };
+    "#;
+
     #[test]
     fn launch_handoff_extracts_sn_and_data() {
         let handoff = parse_launch_handoff(LAUNCH_LITERAL).expect("literal should parse");
         assert_eq!(handoff.sn, "11111111-2222-3333-4444-555555555555");
         assert_eq!(handoff.data, "5abcdef0123456789");
+    }
+
+    /// A page that declares neither token is the `LaunchTicket` shape;
+    /// nothing may invent values it did not send.
+    #[test]
+    fn launch_handoff_without_tokens_leaves_them_absent() {
+        let handoff = parse_launch_handoff(LAUNCH_LITERAL).expect("literal should parse");
+        assert!(handoff.web_token.is_none());
+        assert!(handoff.secret_code.is_none());
+    }
+
+    #[test]
+    fn launch_handoff_extracts_the_tokens_when_the_page_declares_them() {
+        let handoff =
+            parse_launch_handoff(LAUNCH_LITERAL_WITH_TOKENS).expect("literal should parse");
+        assert_eq!(handoff.sn, "c65aa8c4-ff3a-4372-a842-7e69990f8bee");
+        assert_eq!(
+            handoff.web_token.as_deref(),
+            Some("aaaabbbbccccddddeeeeffff00001111")
+        );
+        assert_eq!(
+            handoff.secret_code.as_deref(),
+            Some("1111000fffeeeeddddccccbbbbaaaa22")
+        );
     }
 
     #[test]

--- a/src-tauri/src/services/beanfun/otp.rs
+++ b/src-tauri/src/services/beanfun/otp.rs
@@ -234,8 +234,28 @@ pub async fn get_otp(
                 step_5_post_otp_v2(client, handoff, &ticket, &integrity, &step1.page_url).await
             }
             LaunchPayload::Legacy(params) => {
-                step_5_get_otp_from_handoff(client, handoff, &params, &integrity, &step1.page_url)
-                    .await
+                // The page usually declares these two alongside the
+                // blob, but nothing observed guarantees it — and the
+                // pre-v2 flow already had its own sources for both, so
+                // fall back to those rather than refuse to try.
+                let web_token = match &handoff.web_token {
+                    Some(token) => token.clone(),
+                    None => session.web_token.clone(),
+                };
+                let secret_code = match &handoff.secret_code {
+                    Some(code) => code.clone(),
+                    None => step_2_get_secret_code(client).await?,
+                };
+                step_5_get_otp_from_handoff(
+                    client,
+                    handoff,
+                    &params,
+                    &web_token,
+                    &secret_code,
+                    &integrity,
+                    &step1.page_url,
+                )
+                .await
             }
         };
     }
@@ -625,23 +645,16 @@ struct OtpV2Response {
 /// value comes from the page rather than from our own session state.
 /// That matters most for `ppppp`: the WPF-era constant is stale, and
 /// the live one arrives in the blob.
+#[allow(clippy::too_many_arguments)]
 async fn step_5_get_otp_from_handoff(
     client: &BeanfunClient,
     handoff: &LaunchHandoff,
     params: &LegacyOtpParams,
+    web_token: &str,
+    secret_code: &str,
     integrity: &ClientIntegrity,
     referer: &str,
 ) -> Result<String, LoginError> {
-    // `ggm.js` only forwards these two when the page declares them, and
-    // a page that hands over this payload always does. Their absence
-    // means the page shape changed under us, which is worth naming
-    // rather than sending a request that cannot succeed.
-    let (Some(web_token), Some(secret_code)) = (&handoff.web_token, &handoff.secret_code) else {
-        return Err(LoginError::OtpDecryptionFailed {
-            cause: "launch data carries the pre-v2 payload but the page declared no webToken/secretCode".to_owned(),
-        });
-    };
-
     let base = client.portal_url("beanfun_block/generic_handlers/get_webstart_otp.ashx")?;
     // As in the WPF builder: only the space in `CreateTime` needs
     // encoding; every other character in these values is URL-safe.

--- a/src-tauri/tests/otp.rs
+++ b/src-tauri/tests/otp.rs
@@ -816,3 +816,168 @@ async fn tw_v2_works_on_a_page_that_kept_only_the_handoff() {
         "the v2 request carries no secret code, so fetching one is a wasted round trip"
     );
 }
+
+// -----------------------------------------------------------------------------
+// Group G — the pre-v2 route, reached through the handoff
+// -----------------------------------------------------------------------------
+
+/// A page that hands over the pre-v2 parameters instead of a ticket.
+///
+/// Same `m_objData` literal as the migrated shape — the two are
+/// indistinguishable until the blob is decoded, which is the whole
+/// reason routing on the page's fields was wrong.
+fn step1_body_tw_handoff(payload: &str, tokens: Option<(&str, &str)>) -> String {
+    let tokens = match tokens {
+        Some((web_token, secret_code)) => {
+            format!("\"webToken\": \"{web_token}\", \"secretCode\": \"{secret_code}\", ")
+        }
+        None => String::new(),
+    };
+    format!(
+        "<script>\nvar m_objData = {{ \"region\": \"TW;Production\", \"sn\": \"SN-1234\", {tokens}\"data\": \"{payload}\" }};\n</script>"
+    )
+}
+
+/// The payload the un-migrated games hand over: `&&&&` between fields,
+/// and a `ppppp` that is 96 characters rather than the 64-character
+/// constant the WPF client pinned.
+fn legacy_plaintext(ppppp: &str) -> String {
+    format!(
+        "ppppp={ppppp}&&&&ServiceCode=600309&&&&ServiceRegion=A2&&&&ServiceAccount=A2_ACCT&&&&CreateTime=2010-08-18 20:28:29&&&&BeanfunUrl=https://tw.beanfun.com/;"
+    )
+}
+
+/// The blob's values reach the wire, and the retired-looking endpoint
+/// is the one asked.
+///
+/// This is the shape of upstream #376: every game but MapleStory hands
+/// over these parameters, and sending them to the v2 endpoint — or
+/// sending our own session's values to this one — is what produced a
+/// decryption error for data that had decrypted perfectly. The
+/// assertions are on the request as sent, because the decoder was never
+/// what was broken.
+#[tokio::test]
+async fn tw_handoff_with_the_pre_v2_payload_asks_the_endpoint_that_answers_it() {
+    let server = MockServer::start().await;
+    let client = client_for(&server, LoginRegion::TW);
+    let session = test_session(LoginRegion::TW);
+    let account = account_with(Some("2024-01-15 12:34:56"));
+
+    let ppppp = "F".repeat(96);
+    // Selector 6 with a table `n % 4` cannot reach, as in the v2 tests.
+    let payload = launch_payload(&legacy_plaintext(&ppppp), "1a2b3c4d", 6, TABLES[5]);
+
+    mount_step1(&server, &step1_body_tw_handoff(&payload, None)).await;
+    mount_step2(&server, "var m_strSecretCode = 'SECRET_OK';").await;
+    mount_step3_ok(&server).await;
+    mount_step5(&server, &make_envelope("ABCDEFGH", "OTP55555")).await;
+
+    let otp = get_otp(&client, &session, &account, SERVICE_CODE, SERVICE_REGION)
+        .await
+        .expect("a pre-v2 payload must still yield a password");
+    assert_eq!(otp, "OTP55555");
+
+    let requests = server.received_requests().await.unwrap_or_default();
+    assert!(
+        !requests
+            .iter()
+            .any(|r| r.url.path().ends_with("get_webstart_otp_v2.ashx")),
+        "a blob with no LaunchTicket has nothing to send to the v2 endpoint"
+    );
+
+    let step5 = requests
+        .iter()
+        .find(|r| r.url.path() == "/beanfun_block/generic_handlers/get_webstart_otp.ashx")
+        .expect("the pre-v2 endpoint was asked");
+    let query: std::collections::HashMap<_, _> = step5.url.query_pairs().into_owned().collect();
+
+    // Every value the blob supplied is the blob's, not ours.
+    assert_eq!(query["ppppp"], ppppp, "the live ppppp travels in the blob");
+    assert_eq!(
+        query["ServiceAccount"], "A2_ACCT",
+        "the account is the blob's, not the one we were called with"
+    );
+    assert_eq!(query["ServiceCode"], "600309");
+    assert_eq!(query["ServiceRegion"], "A2");
+    assert_eq!(query["CreateTime"], "2010-08-18 20:28:29");
+    assert_eq!(query["SN"], "SN-1234", "the handoff's sn keys the request");
+
+    // The space is `%20` on the wire, as WPF sends it — `query_pairs`
+    // would decode `+` to a space just the same, so the raw query is
+    // the only place this can be seen.
+    let raw = step5.url.query().unwrap_or_default();
+    assert!(
+        raw.contains("CreateTime=2010-08-18%2020:28:29"),
+        "CreateTime must be %20-encoded, got: {raw}"
+    );
+
+    // Without these the endpoint answers `Query String Error`, which is
+    // the failure this whole route was mistaken for.
+    for field in ["CV", "Hash", "arch"] {
+        assert!(
+            query.get(field).is_some_and(|v| !v.is_empty()),
+            "{field} must name the build asking"
+        );
+    }
+
+    // Nothing observed guarantees the page carries these, so they come
+    // from the flow that always had them.
+    assert_eq!(query["WebToken"], WEB_TOKEN, "falls back to the session");
+    assert_eq!(
+        query["SecretCode"], "SECRET_OK",
+        "falls back to step 2, which is what the pre-v2 flow always did"
+    );
+}
+
+/// When the page does declare them, they are used as declared.
+///
+/// The fallbacks above are a safety net, not the normal path: a page
+/// that says which token to use has more right to that answer than our
+/// session does, and fetching a secret code it already handed over is a
+/// round trip for nothing.
+#[tokio::test]
+async fn tw_handoff_prefers_the_tokens_the_page_declared() {
+    let server = MockServer::start().await;
+    let client = client_for(&server, LoginRegion::TW);
+    let session = test_session(LoginRegion::TW);
+    let account = account_with(Some("2024-01-15 12:34:56"));
+
+    let payload = launch_payload(&legacy_plaintext(&"a".repeat(96)), "1a2b3c4d", 3, TABLES[7]);
+    let page_token = "PAGE_WEB_TOKEN";
+    let page_secret = "PAGE_SECRET_CODE";
+
+    mount_step1(
+        &server,
+        &step1_body_tw_handoff(&payload, Some((page_token, page_secret))),
+    )
+    .await;
+    mount_step3_ok(&server).await;
+    mount_step5(&server, &make_envelope("ABCDEFGH", "OTP44444")).await;
+    // No step 2 mock on purpose: reaching for one would go unmatched
+    // and fail the exchange.
+
+    let otp = get_otp(&client, &session, &account, SERVICE_CODE, SERVICE_REGION)
+        .await
+        .expect("the page's own tokens must be enough");
+    assert_eq!(otp, "OTP44444");
+
+    let requests = server.received_requests().await.unwrap_or_default();
+    let step5 = requests
+        .iter()
+        .find(|r| r.url.path() == "/beanfun_block/generic_handlers/get_webstart_otp.ashx")
+        .expect("the pre-v2 endpoint was asked");
+    let query: std::collections::HashMap<_, _> = step5.url.query_pairs().into_owned().collect();
+
+    assert_eq!(query["WebToken"], page_token);
+    assert_eq!(query["SecretCode"], page_secret);
+    assert_ne!(
+        query["WebToken"], WEB_TOKEN,
+        "the session's token must not win over the page's"
+    );
+    assert!(
+        !requests
+            .iter()
+            .any(|r| r.url.path().ends_with("get_cookies.ashx")),
+        "the page already handed over a secret code"
+    );
+}


### PR DESCRIPTION
Fixes #376 — every game but MapleStory fails with 「遊戲密碼解密失敗」 (`auth.otp_decryption_failed`) since #372.

## What is actually wrong

The decoder is fine. Its acceptance test is too narrow.

`m_objData.data` carries **two** payloads, and both are live:

| decoded payload | endpoint | measured on |
|---|---|---|
| `LaunchTicket=<hex>` | `get_webstart_otp_v2.ashx` (POST) | MapleStory `610074_T9` |
| `ppppp=<96 hex>&&&&ServiceCode=…&&&&ServiceRegion=…&&&&ServiceAccount=…&&&&CreateTime=…` | `get_webstart_otp.ashx` (GET) | CSO `610153_TN`, Elsword `300148_AF`, Mabinogi `600309_A2` |

`decode` accepted a table only when the plaintext contained
`LaunchTicket=`. A *correct* decode of the second kind therefore looked
like a wrong table, every table was tried, and the flow ended in
`MissingTicket` → `OtpDecryptionFailed`. The user sees a decryption
error for data that decrypted perfectly.

**Both kinds of page declare `m_objData` and look identical from the
outside** — the blob has to be decoded before the route is known, which
is why routing on the presence of the literal sent every un-migrated
game to an endpoint with nothing to give it. That characterisation is
[@ToooAir's](https://github.com/pungin/Beanfun/issues/376#issuecomment-5318670827),
from an independent four-title measurement in a separate Node client;
an earlier revision of this branch inferred the split from whether the
page also declared `webToken` / `secretCode`, which held for the two
samples available here but is not the rule.

## `ppppp` was never a constant

The WPF client pinned `1F552AEA…21DBA` and this repo recorded its
provenance as unknown. It is supplied in the blob, and the current
value is **96** characters, not 64. It is read from the blob rather
than re-pinned — correct whether it turns out to be global,
per-session or per-launch.

## What changed

- `core::launch_data` returns a `LaunchPayload` — `Ticket` or
  `Legacy` — instead of only a ticket, and accepts either marker when
  choosing a table.
- A pre-v2 request built from the blob's own values, keeping the
  `CV`/`Hash`/`arch` suffix and `Referer` that #372 and #374
  established. `webToken` / `secretCode` are taken from the page when
  it declares them and fall back to `session.web_token` and step 2
  when it does not, so nothing depends on a field the page is not
  obliged to carry.
- No length check on `LaunchTicket`. Presence decides the route;
  pinning it to the 64 characters seen so far would be the same
  over-narrow acceptance this PR is fixing, and #376 reports OTP
  lengths varying where the docs pinned them.

## Testing

**Verified against the live service.** A build of this branch on top of
6.1.0 retrieves passwords on all four affected titles:

| game | result |
|---|---|
| Dragon Nest | ✅ |
| Elsword | ✅ |
| Mabinogi | ✅ |
| CSO | ✅ |
| MapleStory | ✅ unchanged — regression check; it takes the v2 path, untouched here |

CI green: 896 lib tests plus the integration suites,
`clippy --all-targets -- -D warnings`, `fmt`, and the frontend suite.

Two real blobs from #376 reporters were also decoded offline while
diagnosing. Both are structurally identical to the working ones — 665
characters, ≡ 9 (mod 16), hex-only, ciphertext a whole number of DES
blocks — and both confirm the existing `selector % 4` and
`offset = selector + 1` rules (selector 9 → table 1, selector 7 →
table 3). Neither needed the eight-table search.

Test fixtures are synthetic: the real blobs carry account identifiers,
so they are not committed. They reproduce the observed shape, including
the `&&&&` separator and the 96-character `ppppp`.

Worth noting for #368's `supportService` theory: `600309`, `300148` and
`610153` are all *in* that list, so it is not the discriminator.
