### PR TITLE
fix(game): stop refusing to launch a game under a Chinese folder name

### DIFF
--- a/src-tauri/src/commands/error.rs
+++ b/src-tauri/src/commands/error.rs
@@ -184,7 +184,6 @@
 //! | --------------------------------------- | -------------------------------------- | --------------------------------------------- |
 //! | `PathEmpty`                             | `game.path_empty`                      | —                                             |
 //! | `PathNotFound { path }`                 | `game.path_not_found`                  | `path`                                        |
-//! | `PathNonAscii { path, ch, position }`   | `game.path_non_ascii`                  | `path` / `char` / `position`                  |
 //! | `LocaleRemulatorRelease { name, .. }`   | `game.locale_remulator_release_failed` | `resource`                                    |
 //! | `LocaleRemulatorSha256Mismatch { .. }`  | `game.locale_remulator_sha256_mismatch`| `resource`                                    |
 //! | `ShellExecute { code, .. }` (windows)   | `game.shellexecute_failed`             | `shellexecute_code`                           |
@@ -748,15 +747,6 @@ impl From<GameError> for CommandError {
             GameError::PathEmpty => CommandError::new("game.path_empty", message),
             GameError::PathNotFound { path } => CommandError::new("game.path_not_found", message)
                 .with_details(json!({ "path": path.display().to_string() })),
-            GameError::PathNonAscii {
-                path,
-                offending_char,
-                position,
-            } => CommandError::new("game.path_non_ascii", message).with_details(json!({
-                "path": path.display().to_string(),
-                "char": offending_char.to_string(),
-                "position": position,
-            })),
             GameError::LocaleRemulatorRelease { name, .. } => {
                 CommandError::new("game.locale_remulator_release_failed", message)
                     .with_details(json!({ "resource": name }))

--- a/src-tauri/src/commands/launcher.rs
+++ b/src-tauri/src/commands/launcher.rs
@@ -201,10 +201,11 @@
 //! `executable_path` is `Option<String>` (rather than `PathBuf`) to
 //! avoid leaking the specta `PathBuf` quirks to the frontend and to
 //! let the UI treat missing paths uniformly. The conversion uses
-//! [`std::path::Path::to_string_lossy`] — in practice every game
-//! install path is ASCII so this is lossless; the docstring on
-//! [`GameProcessInfo::executable_path`] spells that out for
-//! pathological inputs.
+//! [`std::path::Path::to_string_lossy`], which is lossless for any
+//! path Windows can represent in UTF-16 — Chinese install paths
+//! included, and they are common (upstream #378). Only a genuinely
+//! ill-formed path substitutes replacement characters; the docstring
+//! on [`GameProcessInfo::executable_path`] spells that out.
 //!
 //! ## Blocking isolation (D5c)
 //!

--- a/src-tauri/src/services/game/error.rs
+++ b/src-tauri/src/services/game/error.rs
@@ -13,7 +13,6 @@
 //! | ------------------------------- | ---------------------------------------------------------------------------------- |
 //! | [`PathEmpty`]                   | `MainWindow.xaml.cs` L1748 — `gamePath == ""` short-circuit                        |
 //! | [`PathNotFound`]                | `MainWindow.xaml.cs` L1748 — `!File.Exists(gamePath)` short-circuit                |
-//! | [`PathNonAscii`]                | `MainWindow.xaml.cs` L1753-1762 — UTF-16 code-unit `> 128` → `MsgGamePathHaveWChar`|
 //! | [`LocaleRemulatorRelease`]      | `App.xaml.cs` L144-151 + `MainWindow.xaml.cs` L1905-1909 (`ReleaseResource == -1`)  |
 //! | [`LocaleRemulatorSha256Mismatch`] | **Beanfun exclusive** — WPF only length-checked; SHA-256 rejection is new    |
 //! | [`ShellExecute`]                | `MainWindow.xaml.cs` L1935 `proc.Start()` throwing via `UseShellExecute = runas`   |
@@ -21,7 +20,6 @@
 //!
 //! [`PathEmpty`]: GameError::PathEmpty
 //! [`PathNotFound`]: GameError::PathNotFound
-//! [`PathNonAscii`]: GameError::PathNonAscii
 //! [`LocaleRemulatorRelease`]: GameError::LocaleRemulatorRelease
 //! [`LocaleRemulatorSha256Mismatch`]: GameError::LocaleRemulatorSha256Mismatch
 //! [`ShellExecute`]: GameError::ShellExecute
@@ -48,24 +46,6 @@ pub enum GameError {
     /// to the same dialog at L1748).
     #[error("game path does not exist: {}", .path.display())]
     PathNotFound { path: PathBuf },
-
-    /// Game path contains a non-ASCII character; the WPF game loader
-    /// refuses paths with any UTF-16 code unit > 128 because the
-    /// game binary passes the path through ANSI/CP950 code pages
-    /// internally and blows up on wide characters.
-    ///
-    /// `offending_char` and `position` are diagnostic: the UI can
-    /// show "position 3: '遊'" to help the user understand which
-    /// character triggered the refusal.
-    #[error(
-        "game path contains non-ASCII character {offending_char:?} at position {position}: {}",
-        .path.display()
-    )]
-    PathNonAscii {
-        path: PathBuf,
-        offending_char: char,
-        position: usize,
-    },
 
     /// Writing one of the five LocaleRemulator resource files to disk
     /// failed (permission denied, disk full, antivirus lock, …).

--- a/src-tauri/src/services/game/launcher.rs
+++ b/src-tauri/src/services/game/launcher.rs
@@ -132,47 +132,38 @@ pub enum ResolvedMode {
 // Path validation
 // ---------------------------------------------------------------------------
 
-/// Verify `path` is non-empty, exists, and contains no non-ASCII
-/// characters.
+/// Verify `path` is non-empty and exists.
 ///
-/// Implements the three preflight guards WPF runs before the
-/// process / kill / launch phase (`MainWindow.xaml.cs` L1748 +
-/// L1753-1762). Returning the offending character + position means
-/// the UI layer can produce a helpful error message like
-/// "position 12: '遊' is not ASCII — rename the folder or move the
-/// game to an ASCII-only path."
+/// The two preflight guards WPF runs before the process / kill /
+/// launch phase (`MainWindow.xaml.cs` L1748).
+///
+/// # Why a non-ASCII path is not a third guard
+///
+/// It used to be, and it stopped anyone whose game lived under a
+/// Chinese folder name from launching at all (upstream #378). WPF
+/// checks the same thing at L1753-1762, but what it does about it is
+/// show `MsgGamePathHaveWChar` and `break` — a warning, then the
+/// launch proceeds. Porting the check but not the `break` turned a
+/// caveat into a refusal, on a path the 5.x client would have started.
+///
+/// Nothing here needs the restriction either: the Normal path spawns
+/// through `std::process::Command` and the LocaleRemulator path
+/// through `ShellExecuteW`, both of which take UTF-16 and neither of
+/// which cares what code page the characters would have needed. If the
+/// game itself chokes further in, that is the game's error to give,
+/// and the frontend has already said so — `useGameLauncher` warns
+/// before it ever calls us.
 pub fn validate_path(path: &Path) -> Result<(), GameError> {
-    let as_str = match path.to_str() {
-        // `Path` can technically hold non-UTF8 bytes on Unix, but
-        // Windows paths round-trip UTF-8 cleanly and the game binary
-        // is Windows-only. An empty path also lands here.
-        Some(s) => s,
-        None => {
-            return Err(GameError::PathNonAscii {
-                path: path.to_path_buf(),
-                offending_char: '\u{FFFD}',
-                position: 0,
-            });
-        }
-    };
-
-    if as_str.is_empty() {
+    // Compared as `OsStr`: a Windows path that is not valid UTF-8 is
+    // still a perfectly good path to hand to a wide API, and asking it
+    // for a `&str` first would fail it for the wrong reason.
+    if path.as_os_str().is_empty() {
         return Err(GameError::PathEmpty);
     }
 
     if !path.exists() {
         return Err(GameError::PathNotFound {
             path: path.to_path_buf(),
-        });
-    }
-
-    if let Some((position, offending_char)) =
-        as_str.chars().enumerate().find(|(_, c)| (*c as u32) > 128)
-    {
-        return Err(GameError::PathNonAscii {
-            path: path.to_path_buf(),
-            offending_char,
-            position,
         });
     }
 
@@ -542,36 +533,34 @@ mod tests {
         assert_matches!(validate_path(&p), Ok(()));
     }
 
+    /// A Chinese folder name is where the game actually lives for a
+    /// large part of this audience, and refusing it stopped the launch
+    /// on paths the 5.x client started (upstream #378). WPF warns and
+    /// carries on; so do we.
     #[test]
-    fn validate_path_rejects_non_ascii_traditional_chinese() {
+    fn validate_path_accepts_a_traditional_chinese_path() {
         let dir = TempDir::new().unwrap();
-        let p = tempfile_with_name(&dir, "遊戲.exe");
-        let err = validate_path(&p).unwrap_err();
-        match err {
-            GameError::PathNonAscii { offending_char, .. } => {
-                assert!(
-                    (offending_char as u32) > 128,
-                    "offending char must have codepoint > 128"
-                );
-            }
-            other => panic!("expected PathNonAscii, got {other:?}"),
+        let p = tempfile_with_name(&dir, "楓之谷.exe");
+        assert_matches!(validate_path(&p), Ok(()));
+    }
+
+    #[test]
+    fn validate_path_accepts_other_non_ascii_paths() {
+        let dir = TempDir::new().unwrap();
+        for name in ["ゲーム.exe", "게임.exe", "game🎮.exe"] {
+            let p = tempfile_with_name(&dir, name);
+            assert_matches!(validate_path(&p), Ok(()));
         }
     }
 
+    /// A non-ASCII path that does not exist still fails, and fails as
+    /// *missing* — the reason a launch is refused has to be the real
+    /// one, or the user renames a folder that was never the problem.
     #[test]
-    fn validate_path_rejects_non_ascii_japanese() {
+    fn validate_path_still_reports_a_missing_non_ascii_path_as_missing() {
         let dir = TempDir::new().unwrap();
-        let p = tempfile_with_name(&dir, "ゲーム.exe");
-        let err = validate_path(&p).unwrap_err();
-        assert_matches!(err, GameError::PathNonAscii { .. });
-    }
-
-    #[test]
-    fn validate_path_rejects_non_ascii_emoji() {
-        let dir = TempDir::new().unwrap();
-        let p = tempfile_with_name(&dir, "game🎮.exe");
-        let err = validate_path(&p).unwrap_err();
-        assert_matches!(err, GameError::PathNonAscii { .. });
+        let p = dir.path().join("楓之谷").join("MapleStory.exe");
+        assert_matches!(validate_path(&p), Err(GameError::PathNotFound { .. }));
     }
 
     // ---- GameStartMode::try_from ----------------------------------------
@@ -793,19 +782,47 @@ mod tests {
         assert_matches!(launch_game(&req), Err(GameError::PathEmpty));
     }
 
+    /// The report in #378, run for real: a game under a Chinese folder
+    /// name, launched.
+    ///
+    /// `cmd.exe` copied into `楓之谷\` stands in for the game, so this
+    /// is an actual `CreateProcessW` against a non-ASCII path rather
+    /// than an assertion about the guard that used to stop it.
+    #[cfg(windows)]
     #[test]
-    fn launch_game_rejects_non_ascii_game_path() {
-        // Create a real file with a non-ASCII name so we reach the
-        // non-ASCII guard rather than the earlier PathNotFound arm.
+    fn launch_game_starts_a_game_under_a_chinese_folder_name() {
         let dir = TempDir::new().unwrap();
-        let game = tempfile_with_name(&dir, "遊戲.exe");
+        let folder = dir.path().join("楓之谷安裝檔").join("楓之谷");
+        std::fs::create_dir_all(&folder).unwrap();
+        let game = folder.join("MapleStory.exe");
+        std::fs::copy(r"C:\Windows\System32\cmd.exe", &game).expect("cmd.exe is copyable");
+
+        let req = LaunchRequest {
+            game_path: game,
+            command_line: "/c exit 0".to_string(),
+            mode: GameStartMode::Normal,
+            target_dir: std::env::temp_dir(),
+        };
+        launch_game(&req).expect("a Chinese path must not stop the launch");
+    }
+
+    /// Same claim where there is no `cmd.exe` to copy: the launch has
+    /// to get as far as trying to spawn, rather than being refused for
+    /// the name.
+    #[cfg(not(windows))]
+    #[test]
+    fn launch_game_does_not_refuse_a_non_ascii_game_path() {
+        let dir = TempDir::new().unwrap();
+        let game = tempfile_with_name(&dir, "楓之谷.exe");
         let req = LaunchRequest {
             game_path: game,
             command_line: String::new(),
             mode: GameStartMode::Normal,
             target_dir: PathBuf::from("."),
         };
-        assert_matches!(launch_game(&req), Err(GameError::PathNonAscii { .. }));
+        // A stub file is not executable, so a spawn failure is the
+        // expected outcome — what matters is that it reached the spawn.
+        assert_matches!(launch_game(&req), Ok(()) | Err(GameError::Spawn(_)));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #378 — a game installed under a Chinese folder name cannot be launched from the UI, where 5.x launched it after showing the same warning.

## What went wrong

WPF checks the path for characters above ASCII, and on finding one shows `MsgGamePathHaveWChar` and `break`s — a warning, then the launch proceeds (`MainWindow.xaml.cs` L1753-1762). The port kept the check and dropped the `break`: `validate_path` returned `PathNonAscii` and the launch stopped there. The reporter recognised the message from 5.x but not the outcome, which is exactly what that mis-port looks like from outside.

The frontend was never in on it. `useGameLauncher.pathHasWideChar` documents itself as "purely advisory — we surface `MsgGamePathHaveWChar` but continue with the launch (matching WPF's `break`)", warns, and calls the backend, which then refuses.

## Why the restriction was not needed

Nothing in this crate goes through a code page. Normal mode spawns via `std::process::Command`, LocaleRemulator via `ShellExecuteW` with UTF-16 arguments, and the working directory and argument string travel the same way. `C:\Users\Tako\Desktop\楓之谷安裝檔\楓之谷\MapleStory.exe` is an ordinary path to every API involved.

If the game itself objects further in — which is what WPF's warning was about — that is the game's error to give. Ours was a guess made before trying, on behalf of a launcher that would have tried.

## What changed

- `validate_path` keeps the two guards WPF actually enforces, empty and missing, and drops the third.
- `GameError::PathNonAscii` and its `game.path_non_ascii` mapping go with it. So does the `to_str()` conversion at the top, which existed only to scan for those characters: emptiness is an `OsStr` question and existence is a filesystem one, and a path Windows can hold but UTF-8 cannot was never a reason to refuse a launch either.
- The frontend keeps its warning, unchanged.

## Testing

The Windows test copies `cmd.exe` into `楓之谷安裝檔\楓之谷\MapleStory.exe` and launches it — a real `CreateProcessW` against the reported path shape rather than an assertion about the guard that used to stop it. Reinstating the refusal turns it and `validate_path_accepts_a_traditional_chinese_path` red.

Also pinned: a non-ASCII path that does not exist still fails as *missing*. The reason a launch is refused has to be the real one, or the user renames a folder that was never the problem.

896 lib tests pass, clippy and fmt clean.
