### PR TITLE
fix(otp): restore TW password retrieval on the legacy launcher (#368) (#376)

### DIFF
--- a/Beanfun/API/LaunchData.cs
+++ b/Beanfun/API/LaunchData.cs
@@ -1,0 +1,218 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Beanfun
+{
+    /// <summary>舊 get_webstart_otp.ashx 需要的參數，由 blob 帶出來。</summary>
+    public class LegacyOtpParams
+    {
+        public string ppppp;
+        public string ServiceCode;
+        public string ServiceRegion;
+        public string ServiceAccount;
+        public string CreateTime;
+    }
+
+    public class LaunchPayload
+    {
+        /// <summary>非 null 表示走 get_webstart_otp_v2.ashx。</summary>
+        public string LaunchTicket;
+
+        /// <summary>非 null 表示走舊的 get_webstart_otp.ashx。</summary>
+        public LegacyOtpParams Legacy;
+    }
+
+    /// <summary>
+    /// game_start_step2.aspx 上 m_objData.data 這塊混淆資料的解碼器。
+    ///
+    /// 頁面會嵌入
+    /// <code>
+    /// var m_objData = { "region": "TW;Production", "sn": "...", "data": "..." };
+    /// </code>
+    /// 並用 gamaniagames:// 交給橘子的原生啟動器（GGM）。data 裡就是該遊戲取
+    /// 密碼所需的參數，只是被混淆過，所以沒裝 GGM 也還原得出來。
+    ///
+    /// 兩種 payload 都還活著：
+    ///   - LaunchTicket=...  → 給 get_webstart_otp_v2.ashx（楓之谷）
+    ///   - ppppp=...         → 給舊的 get_webstart_otp.ashx（新楓、CSO、艾爾之光、瑪奇…）
+    /// 兩種頁面從外面看完全一樣，都只宣告 m_objData，所以一定要先解出來才知道
+    /// 該走哪個端點。只認 LaunchTicket 會讓其他遊戲全部誤判成解密失敗（#376）。
+    ///
+    /// 格式：
+    ///   1. 第一個字元是十六進位數字 n，用來選替換表。
+    ///   2. 其餘每個字元換成它在替換表中的索引，再以十六進位字元輸出（normalized hex）。
+    ///   3. normalized hex 位移 n+1 起的 8 個字元就是 DES key（ASCII）。
+    ///   4. 拿掉那 8 個字元，剩下的就是密文 hex。
+    ///   5. DES-ECB、無 padding，解完去掉尾端的 \0。
+    ///   6. 明文是 key=value，以 &amp; 串接，遇到 ; 之後都是尾綴。
+    ///
+    /// 3~5 跟舊 OTP 信封（8 字元 ASCII key + hex 密文）是同一套，所以直接沿用
+    /// <see cref="WCDESComp.DecryStrHex"/>。
+    ///
+    /// 解碼演算法由 @takidog 發表於 pungin/Beanfun#368。
+    /// </summary>
+    public static class LaunchData
+    {
+        /// <summary>
+        /// 啟動器 Command.DecryptParam() 裡硬編碼的替換表。每一張都是 16 個
+        /// 十六進位字元的排列，第 2 步才可逆。
+        /// </summary>
+        private static readonly string[] Tables =
+        {
+            "bac987d65e432f10",
+            "3bc4d5e6f2a79108",
+            "cdbeaf9012456378",
+            "4e6fb81a3c5d7092",
+            "bdef1246789ac530",
+            "5f82cb4093e71d6a",
+            "df1468ace0357b92",
+            "b50c61a4f93e82d7",
+        };
+
+        private const string HexDigits = "0123456789abcdef";
+        private const int KeyLen = 8;
+
+        /// <summary>
+        /// 解出 blob 帶的是哪一種 payload；兩種都不是就回 null。
+        /// </summary>
+        public static LaunchPayload Decode(string data)
+        {
+            string plaintext = DecodeRaw(data);
+            if (plaintext == null)
+                return null;
+
+            var fields = ParseFields(plaintext);
+
+            string ticket;
+            if (fields.TryGetValue("LaunchTicket", out ticket) && ticket.Length > 0)
+            {
+                // 有沒有決定路線，長度不決定。釘死在目前看到的 64 字元，就是
+                // 讓 ppppp 那批遊戲全掛的那種過窄判斷。
+                return new LaunchPayload { LaunchTicket = ticket };
+            }
+
+            string ppppp,
+                serviceCode,
+                serviceRegion,
+                serviceAccount,
+                createTime;
+            if (
+                fields.TryGetValue("ppppp", out ppppp)
+                && fields.TryGetValue("ServiceCode", out serviceCode)
+                && fields.TryGetValue("ServiceRegion", out serviceRegion)
+                && fields.TryGetValue("ServiceAccount", out serviceAccount)
+                && fields.TryGetValue("CreateTime", out createTime)
+            )
+            {
+                return new LaunchPayload
+                {
+                    Legacy = new LegacyOtpParams
+                    {
+                        ppppp = ppppp,
+                        ServiceCode = serviceCode,
+                        ServiceRegion = serviceRegion,
+                        ServiceAccount = serviceAccount,
+                        CreateTime = createTime,
+                    },
+                };
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// 把明文切成 key=value。分隔符實際上是 &amp;&amp;&amp;&amp;，但用單一
+        /// &amp; 切再丟掉空段，兩種形式都吃得下。第一個 ; 之後是尾綴不是欄位。
+        /// </summary>
+        private static Dictionary<string, string> ParseFields(string plaintext)
+        {
+            var fields = new Dictionary<string, string>(StringComparer.Ordinal);
+            string body = plaintext.Split(';')[0];
+            foreach (string segment in body.Split('&'))
+            {
+                if (segment.Length == 0)
+                    continue;
+                int eq = segment.IndexOf('=');
+                if (eq <= 0)
+                    continue;
+                string key = segment.Substring(0, eq);
+                if (!fields.ContainsKey(key))
+                    fields[key] = segment.Substring(eq + 1);
+            }
+            return fields;
+        }
+
+        /// <summary>
+        /// 還原替換層並解密，回傳去掉尾端 \0 的明文。
+        ///
+        /// 選字元對應哪張表其實沒定案：n % 4 對目前看過的樣本都解得開，但表有
+        /// 八張，單一樣本分不出是 n % 4 還是表的排序跟啟動器不同。與其押一個
+        /// 規則然後對某些帳號猜錯，不如每張都試到解出帶 LaunchTicket= 或
+        /// ppppp= 的明文為止 — 錯的表只會給出雜訊，雜訊不會剛好拼出欄位名。
+        /// </summary>
+        private static string DecodeRaw(string data)
+        {
+            if (string.IsNullOrEmpty(data))
+                return null;
+
+            int selector = HexDigits.IndexOf(char.ToLowerInvariant(data[0]));
+            if (selector < 0)
+                return null;
+
+            string body = data.Substring(1);
+
+            var order = new List<int> { selector % 4, selector % Tables.Length };
+            for (int i = 0; i < Tables.Length; i++)
+                order.Add(i);
+
+            var tried = new HashSet<int>();
+            foreach (int tableIndex in order)
+            {
+                if (!tried.Add(tableIndex))
+                    continue;
+                string plaintext = DecodeWith(body, selector, tableIndex);
+                if (
+                    plaintext != null
+                    && (
+                        plaintext.Contains("LaunchTicket=")
+                        || plaintext.Contains("ppppp=")
+                    )
+                )
+                {
+                    return plaintext;
+                }
+            }
+            return null;
+        }
+
+        /// <summary>已經選好替換表的單次嘗試。</summary>
+        private static string DecodeWith(string body, int selector, int tableIndex)
+        {
+            string table = Tables[tableIndex];
+            var normalized = new StringBuilder(body.Length);
+            foreach (char c in body)
+            {
+                int idx = table.IndexOf(c);
+                if (idx < 0)
+                    return null;
+                normalized.Append(HexDigits[idx]);
+            }
+
+            int offset = selector + 1;
+            if (normalized.Length < offset + KeyLen)
+                return null;
+
+            string hex = normalized.ToString();
+            string key = hex.Substring(offset, KeyLen);
+            string cipherHex = hex.Substring(0, offset) + hex.Substring(offset + KeyLen);
+            // DES 區塊是 8 bytes = 16 個十六進位字元；不整除就是這張表不對，
+            // 先擋掉免得 DecryStrHex 為了錯的表噴一次例外。
+            if (cipherHex.Length == 0 || cipherHex.Length % 16 != 0)
+                return null;
+
+            string plaintext = WCDESComp.DecryStrHex(cipherHex, key);
+            return plaintext == null ? null : plaintext.Trim('\0');
+        }
+    }
+}

--- a/Beanfun/Tools/BeanfunClient.OTP.cs
+++ b/Beanfun/Tools/BeanfunClient.OTP.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Specialized;
 using System.Net;
-using System.Text;
 using System.Text.RegularExpressions;
 using Newtonsoft.Json.Linq;
 
@@ -9,6 +8,33 @@ namespace Beanfun
 {
     public partial class BeanfunClient : WebClient
     {
+        /// <summary>
+        /// game_start_step2.aspx 為原生啟動器（GGM）準備的 m_objData 交接資料。
+        /// region 成員固定是 "TW;Production"，我們送出的請求都不帶它，所以忽略。
+        /// </summary>
+        private class LaunchHandoff
+        {
+            public string Sn;
+            public string Data;
+
+            /// <summary>只有帶舊 payload 的頁面才會宣告這兩個。</summary>
+            public string WebToken;
+            public string SecretCode;
+        }
+
+        /// <summary>
+        /// 取遊戲密碼。
+        ///
+        /// 台服在 2026 年 8 月把開始遊戲流程搬到橘子遊戲大廳（GGM），頁面不再自己
+        /// 組 OTP 網址，而是丟出一個 m_objData 交接給啟動器（issue #368）。所以路線
+        /// 由「頁面自己的形狀」決定，不是由地區決定：頁面帶 m_objData 就走交接路線，
+        /// 其餘一律照舊。港服現在不必改，將來就算也搬過去了同樣不用改。
+        ///
+        /// 交接路線還要再分一次，而且一定要先解密才知道分到哪邊（issue #376）：
+        /// m_objData.data 有兩種 payload，楓之谷給的是 LaunchTicket，要送
+        /// get_webstart_otp_v2.ashx；其他遊戲給的是舊的 ppppp 參數組，還是送
+        /// get_webstart_otp.ashx。兩種頁面從外面看一模一樣。
+        /// </summary>
         public string GetOTP(
             ServiceAccount acc,
             string service_code = "610074",
@@ -30,113 +56,148 @@ namespace Beanfun
                     host = "bfweb.hk.beanfun.com";
                     loginHost = "login.hk.beanfun.com";
                 }
-                response = this.DownloadString(
-                    $"https://{host}/beanfun_block/game_zone/game_start_step2.aspx?service_code={service_code}&service_region={service_region}&sotp={acc.ssn}&dt={GetCurrentTime(2)}"
-                );
+                // generic_handlers 底下的處理器開始檢查 Referer，沒帶會回
+                // 「The URL referrer is null or from a different domain!」。
+                // 同源加上 beanfun 的 strict-origin-when-cross-origin 政策，
+                // 瀏覽器送的就是整串網址，所以我們也原樣送。
+                string pageUrl =
+                    $"https://{host}/beanfun_block/game_zone/game_start_step2.aspx?service_code={service_code}&service_region={service_region}&sotp={acc.ssn}&dt={GetCurrentTime(2)}";
+                response = this.DownloadString(pageUrl);
+
+                // 先讀交接資料：它決定這頁走哪條路線，也就決定了下面哪些字串
+                // 是必要的。已遷移的頁面根本不再有 GetResultByLongPolling&key=，
+                // 因為它不再輪詢而是開啟動器；先解那些會在讀到交接資料之前就
+                // 讓整個流程失敗，而且報的錯會指著一個「本來就該消失」的字串。
+                LaunchHandoff handoff = ParseLaunchHandoff(response);
+
                 Regex regex = new Regex("GetResultByLongPolling&key=(.*)\"");
-                if (!regex.IsMatch(response))
+                string longPollingKey = null;
+                if (regex.IsMatch(response))
+                {
+                    longPollingKey = regex.Match(response).Groups[1].Value;
+                }
+                else if (handoff == null)
                 {
                     this.errmsg = "OTPNoLongPollingKey:" + response;
                     return null;
                 }
-                string longPollingKey = regex.Match(response).Groups[1].Value;
+
                 string unkKey = null;
                 string unkValue = null;
                 if (App.LoginRegion == "TW")
                 {
                     regex = new Regex("MyAccountData.ServiceAccountCreateTime \\+ \"(.*)=(.*)\";");
-                    if (!regex.IsMatch(response))
+                    if (regex.IsMatch(response))
                     {
+                        unkKey = Uri.UnescapeDataString(regex.Match(response).Groups[1].Value);
+                        unkValue = Uri.UnescapeDataString(regex.Match(response).Groups[2].Value);
+                    }
+                    else if (handoff == null)
+                    {
+                        // 已遷移的頁面不必再帶這個防偽欄位，有就用，沒有不該
+                        // 讓使用者拿不到密碼。
                         this.errmsg = "OTPNoUnkData";
                         return null;
                     }
-                    unkKey = Uri.UnescapeDataString(regex.Match(response).Groups[1].Value);
-                    unkValue = Uri.UnescapeDataString(regex.Match(response).Groups[2].Value);
                 }
-                if (acc.screatetime == null)
+                if (string.IsNullOrEmpty(acc.screatetime))
                 {
                     regex = new Regex("ServiceAccountCreateTime: \"([^\"]+)\"");
-                    if (!regex.IsMatch(response))
+                    if (regex.IsMatch(response))
+                    {
+                        acc.screatetime = regex.Match(response).Groups[1].Value;
+                    }
+                    else if (handoff == null)
                     {
                         this.errmsg = "OTPNoCreateTime";
                         return null;
                     }
-                    acc.screatetime = regex.Match(response).Groups[1].Value;
                 }
-                response = this.DownloadString(
-                    $"https://{loginHost}/generic_handlers/get_cookies.ashx"
-                );
 
-                regex = new Regex("var m_strSecretCode = '(.*)';");
-                if (!regex.IsMatch(response))
+                if (handoff != null)
                 {
-                    this.errmsg = "OTPNoSecretCode";
+                    // 記錄開始遊戲是頁面開啟動器時順手做的事，後面沒有任何東西
+                    // 依賴它，所以已遷移頁面少帶一個欄位不該賠上使用者的密碼。
+                    try
+                    {
+                        RecordServiceStart(
+                            host,
+                            pageUrl,
+                            acc,
+                            service_code,
+                            service_region,
+                            unkKey,
+                            unkValue
+                        );
+                    }
+                    catch (Exception e)
+                    {
+                        Console.WriteLine("record_service_start failed, continuing: " + e.Message);
+                    }
+
+                    // 這條路線刻意不取 SecretCode 也不長輪詢：v2 請求不帶
+                    // SecretCode，而頁面那個 GetResultByLongPolling 是啟動器的
+                    // 安裝檢查，跟密碼無關又會把連線掛著。
+                    LaunchPayload payload = LaunchData.Decode(handoff.Data);
+                    if (payload == null)
+                    {
+                        this.errmsg = "DecryptOTPError";
+                        return null;
+                    }
+
+                    ClientIntegrity integrity = ClientIntegrity.Resolve();
+
+                    if (payload.LaunchTicket != null)
+                        return GetOtpV2(host, pageUrl, handoff, payload.LaunchTicket, integrity);
+
+                    // 頁面通常會跟 blob 一起宣告這兩個，但沒有觀察到保證；舊流程
+                    // 本來就各有來源，所以掉回去用而不是直接放棄。
+                    string webToken = handoff.WebToken ?? this.WebToken;
+                    string secretCode = handoff.SecretCode;
+                    if (secretCode == null)
+                    {
+                        secretCode = GetSecretCode(loginHost);
+                        if (secretCode == null)
+                            return null;
+                    }
+                    return GetOtpPreV2FromHandoff(
+                        host,
+                        pageUrl,
+                        handoff,
+                        payload.Legacy,
+                        webToken,
+                        secretCode,
+                        integrity
+                    );
+                }
+
+                string secretCodeLegacy = GetSecretCode(loginHost);
+                if (secretCodeLegacy == null)
                     return null;
-                }
-                string secretCode = regex.Match(response).Groups[1].Value;
 
-                NameValueCollection payload = new NameValueCollection();
-                payload.Add("service_code", service_code);
-                payload.Add("service_region", service_region);
-                payload.Add("service_account_id", acc.sid);
-                payload.Add("sotp", acc.ssn);
-                payload.Add("service_account_display_name", acc.sname);
-                payload.Add("service_account_create_time", acc.screatetime);
-                if (unkKey != null && unkValue != null)
-                {
-                    payload.Add(unkKey, unkValue);
-                }
-                // testing...
-                System.Net.ServicePointManager.Expect100Continue = false;
-                this.UploadString(
-                    $"https://{host}/beanfun_block/generic_handlers/record_service_start.ashx",
-                    payload
+                RecordServiceStart(
+                    host,
+                    pageUrl,
+                    acc,
+                    service_code,
+                    service_region,
+                    unkKey,
+                    unkValue
                 );
-                response = this.DownloadString(
+                this.DownloadString(
                     $"https://{host}/generic_handlers/get_result.ashx?meth=GetResultByLongPolling&key={longPollingKey}&_={GetCurrentTime()}"
                 );
-                //Thread.Sleep(5000);
-                //Console.WriteLine(Environment.TickCount);
-                response = this.DownloadString(
-                    $"https://{host}/beanfun_block/generic_handlers/get_webstart_otp.ashx?SN={longPollingKey}&WebToken={this.WebToken}&SecretCode={secretCode}&ppppp=1F552AEAFF976018F942B13690C990F60ED01510DDF89165F1658CCE7BC21DBA&ServiceCode={service_code}&ServiceRegion={service_region}&ServiceAccount={acc.sid}&CreateTime={acc.screatetime.Replace(" ", "%20")}&d={Environment.TickCount}"
-                );
-                if (response == null || response == "")
-                {
-                    this.errmsg = "OTPNoResponse";
-                    return null;
-                }
-                string[] responses = response.Split(';');
-                if (responses.Length < 2)
-                {
-                    this.errmsg = "OTPNoResponse";
-                    return null;
-                }
-                response = responses[1];
-                if (responses[0] != "1")
-                {
-                    this.errmsg =
-                        (
-                            System.Windows.Application.Current.TryFindResource("GetOtpError")
-                            as string
-                        )
-                        + "\r\n"
-                        + response;
-                    return null;
-                }
-                string key = response.Substring(0, 8);
-                string plain = response.Substring(8);
-                string otp = WCDESComp.DecryStrHex(plain, key);
-                if (otp != null)
-                {
-                    otp = otp.Trim('\0');
-                    this.errmsg = null;
-                }
-                else
-                {
-                    this.errmsg = "DecryptOTPError";
-                }
 
-                return otp;
+                string url =
+                    $"https://{host}/beanfun_block/generic_handlers/get_webstart_otp.ashx?SN={longPollingKey}&WebToken={this.WebToken}&SecretCode={secretCodeLegacy}&ppppp={PPPPP_LITERAL}&ServiceCode={service_code}&ServiceRegion={service_region}&ServiceAccount={acc.sid}&CreateTime={(acc.screatetime ?? "").Replace(" ", "%20")}&d={Environment.TickCount}";
+                if (App.LoginRegion == "TW")
+                {
+                    // CV/Hash/arch 是遊戲大廳的慣例，而遊戲大廳是台服的產品；
+                    // 港服的舊端點沒有觀察到需要它們，請求維持原樣。
+                    url += IntegritySuffix(ClientIntegrity.Resolve());
+                }
+                response = this.DownloadString(url);
+                return DecryptEnvelope(response);
             }
             catch (Exception e)
             {
@@ -148,6 +209,279 @@ namespace Beanfun
                     + e.StackTrace;
                 return null;
             }
+        }
+
+        /// <summary>
+        /// 送 ppppp= 的 64 字元常數。舊版 WPF 寫死的值，來源不明；已遷移的頁面
+        /// 會在 blob 裡給出當下真正的值（目前是 96 字元），所以那條路線不用它。
+        /// </summary>
+        private const string PPPPP_LITERAL =
+            "1F552AEAFF976018F942B13690C990F60ED01510DDF89165F1658CCE7BC21DBA";
+
+        /// <summary>取 m_strSecretCode；失敗時設好 errmsg 並回 null。</summary>
+        private string GetSecretCode(string loginHost)
+        {
+            string response = this.DownloadString(
+                $"https://{loginHost}/generic_handlers/get_cookies.ashx"
+            );
+            Regex regex = new Regex("var m_strSecretCode = '(.*)';");
+            if (!regex.IsMatch(response))
+            {
+                this.errmsg = "OTPNoSecretCode";
+                return null;
+            }
+            return regex.Match(response).Groups[1].Value;
+        }
+
+        private void RecordServiceStart(
+            string host,
+            string pageUrl,
+            ServiceAccount acc,
+            string service_code,
+            string service_region,
+            string unkKey,
+            string unkValue
+        )
+        {
+            NameValueCollection payload = new NameValueCollection();
+            payload.Add("service_code", service_code);
+            payload.Add("service_region", service_region);
+            payload.Add("service_account_id", acc.sid);
+            payload.Add("sotp", acc.ssn);
+            payload.Add("service_account_display_name", acc.sname);
+            payload.Add("service_account_create_time", acc.screatetime ?? "");
+            if (unkKey != null && unkValue != null)
+            {
+                payload.Add(unkKey, unkValue);
+            }
+            System.Net.ServicePointManager.Expect100Continue = false;
+            this.Headers.Set("Referer", pageUrl);
+            try
+            {
+                this.UploadString(
+                    $"https://{host}/beanfun_block/generic_handlers/record_service_start.ashx",
+                    payload
+                );
+            }
+            finally
+            {
+                this.Headers.Remove("Referer");
+            }
+        }
+
+        /// <summary>CV/Hash/arch 三件套，照 GGM 的 BuildOtpUrl 的順序附在最後。</summary>
+        private static string IntegritySuffix(ClientIntegrity integrity)
+        {
+            return "&CV="
+                + Uri.EscapeDataString(integrity.CV)
+                + "&Hash="
+                + Uri.EscapeDataString(integrity.Hash)
+                + "&arch="
+                + Uri.EscapeDataString(integrity.Arch);
+        }
+
+        /// <summary>
+        /// 交接路線的舊端點：同一個 get_webstart_otp.ashx，但每個值都來自頁面
+        /// 而不是我們自己的 session。最關鍵的是 ppppp — 舊版寫死的常數已經過時，
+        /// 現行的值就在 blob 裡。
+        /// </summary>
+        private string GetOtpPreV2FromHandoff(
+            string host,
+            string pageUrl,
+            LaunchHandoff handoff,
+            LegacyOtpParams p,
+            string webToken,
+            string secretCode,
+            ClientIntegrity integrity
+        )
+        {
+            // 跟舊組法一樣：這些值裡只有 CreateTime 的空白需要編碼。
+            string url =
+                $"https://{host}/beanfun_block/generic_handlers/get_webstart_otp.ashx?SN={handoff.Sn}&WebToken={webToken}&SecretCode={secretCode}&ppppp={p.ppppp}&ServiceCode={p.ServiceCode}&ServiceRegion={p.ServiceRegion}&ServiceAccount={p.ServiceAccount}&CreateTime={(p.CreateTime ?? "").Replace(" ", "%20")}&d={Environment.TickCount}"
+                + IntegritySuffix(integrity);
+
+            this.Headers.Set("Referer", pageUrl);
+            string response;
+            try
+            {
+                response = this.DownloadString(url);
+            }
+            finally
+            {
+                this.Headers.Remove("Referer");
+            }
+            return DecryptEnvelope(response);
+        }
+
+        /// <summary>
+        /// v2 端點：POST 一包 JSON，OTP 藏在回應的 data 裡，構造跟舊信封第二段
+        /// 相同（8 字元 ASCII key + hex 密文）。
+        ///
+        /// 它不是舊端點的替代品，只是同輩 — 遊戲交出哪種 payload 就找哪個端點。
+        /// 舊端點回 Query String Error 代表請求組錯了，不代表它不在了。
+        /// </summary>
+        private string GetOtpV2(
+            string host,
+            string pageUrl,
+            LaunchHandoff handoff,
+            string launchTicket,
+            ClientIntegrity integrity
+        )
+        {
+            var body = new JObject
+            {
+                ["SN"] = handoff.Sn,
+                ["LaunchTicket"] = launchTicket,
+                ["CV"] = integrity.CV,
+                ["Hash"] = integrity.Hash,
+                ["arch"] = integrity.Arch,
+            };
+
+            string url = $"https://{host}/beanfun_block/generic_handlers/get_webstart_otp_v2.ashx";
+            this.Headers.Set("User-Agent", userAgent);
+            this.Headers.Set("Accept-Encoding", "identity");
+            this.Headers.Set("Content-Type", "application/json; charset=utf-8");
+            this.Headers.Set("Referer", pageUrl);
+            string response;
+            try
+            {
+                response = base.UploadString(url, body.ToString(Newtonsoft.Json.Formatting.None));
+            }
+            finally
+            {
+                this.Headers.Remove("Referer");
+                this.Headers.Remove("Content-Type");
+            }
+
+            if (string.IsNullOrEmpty(response))
+            {
+                this.errmsg = "OTPNoResponse";
+                return null;
+            }
+
+            JObject parsed;
+            try
+            {
+                parsed = JObject.Parse(response);
+            }
+            catch
+            {
+                this.errmsg = "OTPNoResponse";
+                return null;
+            }
+
+            if (parsed.Value<int?>("result") != 1)
+            {
+                string message = parsed.Value<string>("message");
+                if (string.IsNullOrEmpty(message))
+                    message = "result=" + parsed.Value<string>("result");
+                this.errmsg =
+                    (System.Windows.Application.Current.TryFindResource("GetOtpError") as string)
+                    + "\r\n"
+                    + message;
+                return null;
+            }
+
+            string data = parsed.Value<string>("data");
+            if (string.IsNullOrEmpty(data))
+            {
+                this.errmsg = "OTPNoResponse";
+                return null;
+            }
+            return DecryptOtpPayload(data);
+        }
+
+        /// <summary>從 step 1 的回應抓出 m_objData；沒有就回 null（代表走舊路線）。</summary>
+        private static LaunchHandoff ParseLaunchHandoff(string html)
+        {
+            if (string.IsNullOrEmpty(html))
+                return null;
+            // 頁面會把這段排版成多行，所以要 Singleline；非貪婪的 .*? 停在第一個
+            // 右大括號，也就是這個扁平物件的結尾。
+            Match block = Regex.Match(
+                html,
+                @"var m_objData\s*=\s*\{(.*?)\}",
+                RegexOptions.Singleline
+            );
+            if (!block.Success)
+                return null;
+            string inner = block.Groups[1].Value;
+
+            string sn = MemberOf(inner, "sn");
+            string data = MemberOf(inner, "data");
+            if (string.IsNullOrEmpty(sn) || string.IsNullOrEmpty(data))
+                return null;
+
+            return new LaunchHandoff
+            {
+                Sn = sn,
+                Data = data,
+                WebToken = NullIfEmpty(MemberOf(inner, "webToken")),
+                SecretCode = NullIfEmpty(MemberOf(inner, "secretCode")),
+            };
+        }
+
+        /// <summary>只在物件字面值內部找，免得這種通用的鍵名比對到別的地方。</summary>
+        private static string MemberOf(string objectLiteral, string name)
+        {
+            Match m = Regex.Match(objectLiteral, "\"" + name + "\"\\s*:\\s*\"([^\"]*)\"");
+            return m.Success ? m.Groups[1].Value : null;
+        }
+
+        private static string NullIfEmpty(string value)
+        {
+            return string.IsNullOrEmpty(value) ? null : value;
+        }
+
+        /// <summary>拆 "1;{key}{密文hex}" 這個舊信封。</summary>
+        private string DecryptEnvelope(string response)
+        {
+            if (string.IsNullOrEmpty(response))
+            {
+                this.errmsg = "OTPNoResponse";
+                return null;
+            }
+            string[] responses = response.Split(';');
+            if (responses.Length < 2)
+            {
+                this.errmsg = "OTPNoResponse";
+                return null;
+            }
+            if (responses[0] != "1")
+            {
+                this.errmsg =
+                    (System.Windows.Application.Current.TryFindResource("GetOtpError") as string)
+                    + "\r\n"
+                    + responses[1];
+                return null;
+            }
+            return DecryptOtpPayload(responses[1]);
+        }
+
+        /// <summary>
+        /// 解 "{8 字元 ASCII key}{密文 hex}"。兩種協定共用：舊信封放在 "1;" 之後，
+        /// v2 則是 JSON 的 data 成員。
+        /// </summary>
+        private string DecryptOtpPayload(string payload)
+        {
+            if (payload == null || payload.Length < 8)
+            {
+                this.errmsg = "DecryptOTPError";
+                return null;
+            }
+            string key = payload.Substring(0, 8);
+            string plain = payload.Substring(8);
+            string otp = WCDESComp.DecryStrHex(plain, key);
+            if (otp != null)
+            {
+                otp = otp.Trim('\0');
+                this.errmsg = null;
+            }
+            else
+            {
+                this.errmsg = "DecryptOTPError";
+            }
+            return otp;
         }
     }
 }

--- a/Beanfun/Tools/BeanfunClient.OTP.cs
+++ b/Beanfun/Tools/BeanfunClient.OTP.cs
@@ -146,6 +146,14 @@ namespace Beanfun
                     }
 
                     ClientIntegrity integrity = ClientIntegrity.Resolve();
+                    Console.WriteLine(
+                        "[OTP] handoff route="
+                            + (payload.LaunchTicket != null ? "v2" : "pre-v2")
+                            + " CV="
+                            + integrity.CV
+                            + " arch="
+                            + integrity.Arch
+                    );
 
                     if (payload.LaunchTicket != null)
                         return GetOtpV2(host, pageUrl, handoff, payload.LaunchTicket, integrity);

--- a/Beanfun/Tools/ClientIntegrity.cs
+++ b/Beanfun/Tools/ClientIntegrity.cs
@@ -30,9 +30,15 @@ namespace Beanfun
     /// </summary>
     public class ClientIntegrity
     {
-        private static readonly log4net.ILog log = log4net.LogManager.GetLogger(
-            typeof(ClientIntegrity)
-        );
+        /// <summary>
+        /// 這個分支引用了 log4net 卻從來沒設定過 appender，寫進去等於沒寫，
+        /// 所以診斷訊息跟這支檔案其他地方一樣走 Console — 從主控台啟動
+        /// （dotnet run）就看得到。
+        /// </summary>
+        private static void Log(string message)
+        {
+            Console.WriteLine("[ClientIntegrity] " + message);
+        }
 
         public string CV;
         public string Hash;
@@ -86,7 +92,7 @@ namespace Beanfun
                 var pinned = ReadPinned();
                 if (pinned != null)
                 {
-                    log.Info("ggm-hotfix: 使用本機釘選的值 cv=" + pinned.CV);
+                    Log("ggm-hotfix: 使用本機釘選的值 cv=" + pinned.CV);
                     return pinned;
                 }
 
@@ -98,7 +104,7 @@ namespace Beanfun
                 {
                     if (NamesNewerBuild(published.CV, local.CV))
                     {
-                        log.Info(
+                        Log(
                             "ggm-hotfix: 線上值比本機 GGM 新 local="
                                 + local.CV
                                 + " published="
@@ -115,7 +121,7 @@ namespace Beanfun
             }
             catch (Exception e)
             {
-                log.Warn("ClientIntegrity 解析失敗，改用編譯進來的常數", e);
+                Log("解析失敗，改用編譯進來的常數: " + e.Message);
             }
 
             // 3. 編譯進來的那組。
@@ -356,17 +362,17 @@ namespace Beanfun
                     {
                         // 連得到但不能用，值得記是哪個鏡像：CDN 快取過期看起來
                         // 跟 commit 發錯值一模一樣。
-                        log.Warn("ggm-hotfix: 發佈檔驗證未過 " + url);
+                        Log("ggm-hotfix: 發佈檔驗證未過 " + url);
                         continue;
                     }
                     WriteCache(body);
-                    log.Info("ggm-hotfix: 已取得發佈值 cv=" + values.CV + " from " + url);
+                    Log("ggm-hotfix: 已取得發佈值 cv=" + values.CV + " from " + url);
                     return values;
                 }
                 catch { }
             }
             fetchFailedThisRun = true;
-            log.Info("ggm-hotfix: 沒有鏡像回應，改用本機來源");
+            Log("ggm-hotfix: 沒有鏡像回應，改用本機來源");
             return null;
         }
 
@@ -380,7 +386,7 @@ namespace Beanfun
             }
             catch (Exception e)
             {
-                log.Warn("ggm-hotfix: 無法寫入快取", e);
+                Log("ggm-hotfix: 無法寫入快取: " + e.Message);
             }
         }
 
@@ -406,7 +412,7 @@ namespace Beanfun
                 string hash = (json.Value<string>("hash") ?? "").Trim().ToLowerInvariant();
                 if (!IsVersion(cv) || !IsSha256(hash))
                 {
-                    log.Warn("ggm-hotfix: 值未通過驗證 cv=" + cv + " hash_len=" + hash.Length);
+                    Log("ggm-hotfix: 值未通過驗證 cv=" + cv + " hash_len=" + hash.Length);
                     return null;
                 }
                 return new ClientIntegrity

--- a/Beanfun/Tools/ClientIntegrity.cs
+++ b/Beanfun/Tools/ClientIntegrity.cs
@@ -1,0 +1,484 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Net.Http;
+using System.Security.Cryptography;
+using System.Threading.Tasks;
+using Microsoft.Win32;
+using Newtonsoft.Json.Linq;
+
+namespace Beanfun
+{
+    /// <summary>
+    /// beanfun 台服取密碼時要求附上的 CV / Hash / arch — 也就是「是哪一版
+    /// 橘子遊戲大廳（GGM）在問」。缺這三個參數，伺服器只會回
+    /// <c>0;Query String Error</c>（issue #368）。
+    ///
+    /// 值的來源依序：
+    ///   1. 使用者自己釘的 %APPDATA%\Beanfun\ggm-client.json（帶 "override": true）
+    ///   2. 本機安裝的 GGM 與線上發佈的 ggm-client.json，取版本較新的那份
+    ///   3. 編譯進來的常數
+    ///
+    /// 為什麼不無條件相信本機那份：GGM 會自己更新，但只在它被開起來的時候。
+    /// 會用這個登入器的人正是從來不開 GGM 的人，所以放著沒動的安裝回報的
+    /// 就是 beanfun 已經不收的舊值 — 最需要救的機器反而是線上熱修永遠碰不到
+    /// 的那批。比版本、新的贏（同版本以本機為準），兩種風險都避開。
+    ///
+    /// 每一層都是盡力而為，失敗就往下一層掉。網路抖一下不該害使用者拿不到
+    /// 密碼，畢竟編譯進來的那組就在旁邊。
+    /// </summary>
+    public class ClientIntegrity
+    {
+        private static readonly log4net.ILog log = log4net.LogManager.GetLogger(
+            typeof(ClientIntegrity)
+        );
+
+        public string CV;
+        public string Hash;
+        public string Arch;
+
+        /// <summary>沒有本機 GGM 可讀時用的 CV，必須與 FallbackHash 成對。</summary>
+        private const string FallbackCV = "1.5.0.2";
+
+        /// <summary>GGM 1.5.0.2 所附 GGMWebStart.dll 的 SHA-256（小寫十六進位）。</summary>
+        private const string FallbackHash =
+            "dfd568a69d87abcd8f4a93d1a4481ebb57712d1d28ab0b6fc018fcf140101e06";
+
+        private const string GgmDllName = "GGMWebStart.dll";
+        private const string CacheFileName = "ggm-client.json";
+
+        /// <summary>
+        /// 發佈點，以及 GitHub 連不上時同一份檔案的鏡像（大陸使用者基本上都是）。
+        /// </summary>
+        private static readonly string[] HotfixUrls =
+        {
+            "https://raw.githubusercontent.com/pungin/Beanfun/code/ggm-client.json",
+            "https://cdn.jsdelivr.net/gh/pungin/Beanfun@code/ggm-client.json",
+            "https://fastly.jsdelivr.net/gh/pungin/Beanfun@code/ggm-client.json",
+            "https://ghproxy.net/https://raw.githubusercontent.com/pungin/Beanfun/code/ggm-client.json",
+        };
+
+        /// <summary>
+        /// 快取多久才再抓一次。六小時就是這條熱修線的實際延遲：發錯值要多久才
+        /// 止血、發對值要多久才傳到所有人。夠短算修好，夠長不會每次取密碼都拉檔。
+        /// </summary>
+        private static readonly TimeSpan CacheTtl = TimeSpan.FromHours(6);
+
+        private static readonly TimeSpan FetchTimeout = TimeSpan.FromSeconds(5);
+
+        /// <summary>編譯進來的那組，給兩邊都讀不到的機器。</summary>
+        public static ClientIntegrity Fallback()
+        {
+            return new ClientIntegrity
+            {
+                CV = FallbackCV,
+                Hash = FallbackHash,
+                Arch = Environment.Is64BitProcess ? "x64" : "x86",
+            };
+        }
+
+        public static ClientIntegrity Resolve()
+        {
+            try
+            {
+                // 1. 使用者自己釘的。明確選擇壓過一切，包含比較新的線上值。
+                var pinned = ReadPinned();
+                if (pinned != null)
+                {
+                    log.Info("ggm-hotfix: 使用本機釘選的值 cv=" + pinned.CV);
+                    return pinned;
+                }
+
+                // 2. 本機 GGM 與線上發佈值，取版本較新的。
+                var local = ResolveLocal();
+                var published = ReadPublished();
+
+                if (local != null && published != null)
+                {
+                    if (NamesNewerBuild(published.CV, local.CV))
+                    {
+                        log.Info(
+                            "ggm-hotfix: 線上值比本機 GGM 新 local="
+                                + local.CV
+                                + " published="
+                                + published.CV
+                        );
+                        return published;
+                    }
+                    return local;
+                }
+                if (local != null)
+                    return local;
+                if (published != null)
+                    return published;
+            }
+            catch (Exception e)
+            {
+                log.Warn("ClientIntegrity 解析失敗，改用編譯進來的常數", e);
+            }
+
+            // 3. 編譯進來的那組。
+            return Fallback();
+        }
+
+        #region 本機 GGM
+
+        /// <summary>本機 GGM 的值；沒有可讀的 GGM 就回 null。</summary>
+        private static ClientIntegrity ResolveLocal()
+        {
+            string dll = LocateGgmDll();
+            if (dll == null)
+                return null;
+
+            string hash = Sha256LowerHex(dll);
+            string cv = FileVersion(dll);
+            // CV 跟 Hash 描述的是同一個檔案，混搭會描述出一個不存在的用戶端，
+            // 所以有一半讀不到就整組不要。
+            if (hash == null || cv == null)
+                return null;
+
+            return new ClientIntegrity
+            {
+                CV = cv,
+                Hash = hash,
+                Arch = Environment.Is64BitProcess ? "x64" : "x86",
+            };
+        }
+
+        private static string LocateGgmDll()
+        {
+            foreach (string dir in GgmDirectories())
+            {
+                try
+                {
+                    string candidate = Path.Combine(dir, GgmDllName);
+                    if (File.Exists(candidate))
+                        return candidate;
+                }
+                catch { }
+            }
+            return null;
+        }
+
+        /// <summary>候選安裝目錄，最可信的排前面。</summary>
+        private static IEnumerable<string> GgmDirectories()
+        {
+            var dirs = new List<string>();
+
+            // 安裝程式寫的 gamaniagames:// 協定處理器，就算裝在非預設路徑也追得到。
+            string fromHandler = GgmDirFromProtocolHandler();
+            if (fromHandler != null)
+                dirs.Add(fromHandler);
+
+            // 預設安裝位置，涵蓋登錄檔被清掉但檔案還在的情況。
+            foreach (string envVar in new[] { "ProgramFiles", "ProgramFiles(x86)" })
+            {
+                string root = Environment.GetEnvironmentVariable(envVar);
+                if (!string.IsNullOrEmpty(root))
+                    dirs.Add(Path.Combine(root, "gamania Games", "gamania Games Manager"));
+            }
+            return dirs;
+        }
+
+        /// <summary>
+        /// 讀 HKCR\gamaniagames\shell\open\command，值長得像
+        /// <c>"C:\...\GGMWebStart.exe" "%1"</c>，取出它的目錄。
+        /// </summary>
+        private static string GgmDirFromProtocolHandler()
+        {
+            try
+            {
+                using (
+                    RegistryKey key = Registry.ClassesRoot.OpenSubKey(
+                        @"gamaniagames\shell\open\command"
+                    )
+                )
+                {
+                    if (key == null)
+                        return null;
+                    string command = key.GetValue("") as string;
+                    if (string.IsNullOrWhiteSpace(command))
+                        return null;
+
+                    command = command.Trim();
+                    string exe;
+                    if (command.StartsWith("\""))
+                    {
+                        int end = command.IndexOf('"', 1);
+                        if (end <= 1)
+                            return null;
+                        exe = command.Substring(1, end - 1);
+                    }
+                    else
+                    {
+                        exe = command.Split(' ')[0];
+                    }
+                    return string.IsNullOrEmpty(exe) ? null : Path.GetDirectoryName(exe);
+                }
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static string Sha256LowerHex(string path)
+        {
+            try
+            {
+                using (var sha = SHA256.Create())
+                using (var stream = File.OpenRead(path))
+                {
+                    return BitConverter
+                        .ToString(sha.ComputeHash(stream))
+                        .Replace("-", "")
+                        .ToLowerInvariant();
+                }
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// 讀 Win32 版本資源的 FileVersion。GGM 送的是組件版本，但目前看過的
+        /// 每個 GGM 版本兩者都一致；真的分歧時上層會掉回編譯常數。
+        /// </summary>
+        private static string FileVersion(string path)
+        {
+            try
+            {
+                var info = FileVersionInfo.GetVersionInfo(path);
+                if (info.FileMajorPart == 0 && info.FileMinorPart == 0 && info.FileBuildPart == 0)
+                    return null;
+                return string.Format(
+                    "{0}.{1}.{2}.{3}",
+                    info.FileMajorPart,
+                    info.FileMinorPart,
+                    info.FileBuildPart,
+                    info.FilePrivatePart
+                );
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        #endregion
+
+        #region 線上發佈值
+
+        private static string CachePath()
+        {
+            return Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                "Beanfun",
+                CacheFileName
+            );
+        }
+
+        /// <summary>
+        /// 使用者釘的值。用 "override": true 這個旗標分辨，而不是換個檔案放 —
+        /// 直接改抓下來的那份就能釘住，不必解釋第二條路徑，也不會被下次抓檔蓋掉。
+        /// </summary>
+        private static ClientIntegrity ReadPinned()
+        {
+            try
+            {
+                string path = CachePath();
+                if (!File.Exists(path))
+                    return null;
+                string body = File.ReadAllText(path);
+                var json = JObject.Parse(StripBom(body));
+                if (json.Value<bool?>("override") != true)
+                    return null;
+                return Parse(body);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        /// <summary>快取還新鮮就用快取，否則重抓；抓不到就用舊的那份。</summary>
+        private static ClientIntegrity ReadPublished()
+        {
+            try
+            {
+                string path = CachePath();
+                if (File.Exists(path))
+                {
+                    var cached = Parse(File.ReadAllText(path));
+                    if (cached != null && DateTime.UtcNow - File.GetLastWriteTimeUtc(path) < CacheTtl)
+                        return cached;
+
+                    var refreshed = Fetch();
+                    if (refreshed != null)
+                        return refreshed;
+                    // 舊的也比沒有好：它至少曾經好到被發佈出來，而替代品是
+                    // 編譯進來那組，照定義更舊。
+                    return cached;
+                }
+                return Fetch();
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// 這次執行已經整輪抓失敗過。連不上任何鏡像的人（例如整條 GitHub 都被
+        /// 擋掉）每次取密碼都要先卡滿四次逾時，而答案不會變，所以一次執行只試
+        /// 一輪。重開程式就會再試。
+        /// </summary>
+        private static bool fetchFailedThisRun;
+
+        private static ClientIntegrity Fetch()
+        {
+            if (fetchFailedThisRun)
+                return null;
+
+            foreach (string url in HotfixUrls)
+            {
+                try
+                {
+                    string body;
+                    using (var http = new HttpClient { Timeout = FetchTimeout })
+                    {
+                        body = Task.Run(() => http.GetStringAsync(url)).GetAwaiter().GetResult();
+                    }
+                    var values = Parse(body);
+                    if (values == null)
+                    {
+                        // 連得到但不能用，值得記是哪個鏡像：CDN 快取過期看起來
+                        // 跟 commit 發錯值一模一樣。
+                        log.Warn("ggm-hotfix: 發佈檔驗證未過 " + url);
+                        continue;
+                    }
+                    WriteCache(body);
+                    log.Info("ggm-hotfix: 已取得發佈值 cv=" + values.CV + " from " + url);
+                    return values;
+                }
+                catch { }
+            }
+            fetchFailedThisRun = true;
+            log.Info("ggm-hotfix: 沒有鏡像回應，改用本機來源");
+            return null;
+        }
+
+        private static void WriteCache(string body)
+        {
+            try
+            {
+                string path = CachePath();
+                Directory.CreateDirectory(Path.GetDirectoryName(path));
+                File.WriteAllText(path, body);
+            }
+            catch (Exception e)
+            {
+                log.Warn("ggm-hotfix: 無法寫入快取", e);
+            }
+        }
+
+        /// <summary>
+        /// 去掉 UTF-8 BOM。Windows 上不少編輯器存檔會加，而 BOM 會讓解析失敗 —
+        /// 那是熱修最糟的失敗方式：看起來發佈了，實際上每個人都掉回舊常數。
+        /// </summary>
+        private static string StripBom(string body)
+        {
+            return body != null && body.Length > 0 && body[0] == '\uFEFF' ? body.Substring(1) : body;
+        }
+
+        /// <summary>
+        /// 解析並驗證發佈檔。驗證不是客氣：格式壞掉的值會被當成我們的身分送給
+        /// beanfun，然後所有人被拒。不像版本號和 SHA-256 的一律視同檔案不存在。
+        /// </summary>
+        private static ClientIntegrity Parse(string body)
+        {
+            try
+            {
+                var json = JObject.Parse(StripBom(body));
+                string cv = (json.Value<string>("cv") ?? "").Trim();
+                string hash = (json.Value<string>("hash") ?? "").Trim().ToLowerInvariant();
+                if (!IsVersion(cv) || !IsSha256(hash))
+                {
+                    log.Warn("ggm-hotfix: 值未通過驗證 cv=" + cv + " hash_len=" + hash.Length);
+                    return null;
+                }
+                return new ClientIntegrity
+                {
+                    CV = cv,
+                    Hash = hash,
+                    // arch 從不發佈：它描述的是誰在問，也就是這支程式，不是產出
+                    // 這組值的那台機器。
+                    Arch = Environment.Is64BitProcess ? "x64" : "x86",
+                };
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static bool IsVersion(string cv)
+        {
+            if (string.IsNullOrEmpty(cv))
+                return false;
+            bool hasDigit = false;
+            foreach (char c in cv)
+            {
+                if (c >= '0' && c <= '9')
+                    hasDigit = true;
+                else if (c != '.')
+                    return false;
+            }
+            return hasDigit;
+        }
+
+        private static bool IsSha256(string hash)
+        {
+            if (hash == null || hash.Length != 64)
+                return false;
+            foreach (char c in hash)
+            {
+                bool hex = (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f');
+                if (!hex)
+                    return false;
+            }
+            return true;
+        }
+
+        #endregion
+
+        /// <summary>
+        /// candidate 是否比 current 新。逐段比數字，缺的段當 0，所以 1.5.1 大於
+        /// 1.5；解析不出來的當 0，讓格式壞掉的那邊輸 — 輸了只是不被採用，安全。
+        /// </summary>
+        internal static bool NamesNewerBuild(string candidate, string current)
+        {
+            string[] a = (candidate ?? "").Split('.');
+            string[] b = (current ?? "").Split('.');
+            int width = Math.Max(a.Length, b.Length);
+            for (int i = 0; i < width; i++)
+            {
+                long x = SegmentAt(a, i);
+                long y = SegmentAt(b, i);
+                if (x != y)
+                    return x > y;
+            }
+            return false;
+        }
+
+        private static long SegmentAt(string[] parts, int index)
+        {
+            long value;
+            if (index >= parts.Length || !long.TryParse(parts[index].Trim(), out value))
+                return 0;
+            return value;
+        }
+    }
+}


### PR DESCRIPTION
Ports the #368 / #376 fix to the legacy WPF launcher. Without it, 5.9.1 fails every 獲取密碼 on TW with `Query String Error`.

> **Base branch is `old-version-5.9.1`, not `code`.** This branch has no equivalent of the Tauri client's code, so nothing here is a cherry-pick — it is a re-implementation of the same protocol change in C#.

## What changed on beanfun

Same as #372 and #377, in short: `game_start_step2.aspx` no longer builds an OTP URL. It emits an `m_objData` handoff for the Gamania Games Manager, and the obfuscated `data` blob inside carries whatever that game's own OTP request needs. The full write-up lives in those two PRs; only the parts that shaped this port are repeated below.

## What was ported

**1. The launch-data decoder** — `Beanfun/API/LaunchData.cs` (new)

Eight substitution tables, an 8-character ASCII DES key lifted out of the normalized hex, then DES-ECB with no padding. Steps 3–5 are the same construction the pre-v2 OTP envelope used, so the existing `WCDESComp.DecryStrHex` handles them unchanged; only the substitution layer and the field parse are new.

Which table the selector names is not settled — `n % 4` decodes every sample seen so far, but there are eight tables and one sample cannot tell that apart from the table order simply differing. So each table is tried until one yields a plaintext carrying a known marker. A wrong table gives noise, and noise does not spell a field name by accident.

**2. Two payloads, two endpoints** — the #376 half

`m_objData.data` carries either a `LaunchTicket` for `get_webstart_otp_v2.ashx` or the pre-v2 `ppppp` parameters for `get_webstart_otp.ashx`, and **both are live**. Both kinds of page declare `m_objData` and are indistinguishable from outside, so the blob has to be decoded before the route is known. Accepting a decode only when it held a `LaunchTicket` would make a correct decode of the second kind look like a wrong table — which is how every game but MapleStory ended in a decryption error for data that had decrypted perfectly.

`ppppp` is the value that matters most here: this client pinned a 64-character constant whose provenance nobody knew, and the live one arrives in the blob at 96 characters. `webToken` and `secretCode` are taken from the page when it declares them, and fall back to the session and to `get_cookies.ashx` when it does not.

**3. The three things that move with the endpoint** — `Beanfun/Tools/ClientIntegrity.cs` (new)

- Handlers under `generic_handlers` began checking `Referer`, and answer a complaint about a null referrer without one. Every such request now sends the game-start page's own URL.
- The request has to name which launcher build is asking: `CV`, `Hash`, `arch`. Read from the installed Game Manager when there is one — located via the `gamaniagames://` protocol handler, then the conventional install roots — and from compiled-in constants otherwise, which is the case for most users of this app.
- The page's `GetResultByLongPolling` call is the launcher's installation check, unrelated to the password and holding the connection open, so the handoff path does not wait on it. `record_service_start` is best-effort there for the same reason.

Those values also resolve without a release, same order as #374: a pin the user set, then the newer of the installed Game Manager and the published `ggm-client.json` cached for six hours, then the compiled-in pair. This branch reads the same `ggm-client.json` from `code`, so a hotfix published there reaches these users too.

Preferring the installed copy outright looked right, since the Game Manager self-updates — but it self-updates when it runs, and the people this app exists for are the ones who never run it. An install untouched since Gamania's last release reports exactly the values beanfun stops accepting, so the machines most likely to be refused would be the only ones the lever could never reach. Comparing versions and letting the newer build win, with a tie going to the installed file, avoids that.

Every layer is best-effort and falls through on failure. One addition over the Rust version: a run that reaches no mirror stops retrying for the rest of the process, so someone behind a block that reaches none of them does not pay four timeouts on every password.

**Routing reads the handoff first.** A migrated page has dropped the literals the old flow read — there is no `GetResultByLongPolling&key=` on it any more. Demanding them up front would fail the retrieval before the handoff in the same page had been read, naming a literal that is *meant* to be gone.

The route is chosen by the page's own shape rather than by region, so a page carrying the handoff takes the new path and everything else keeps the old one. HK needs no change now, and none later if it migrates.

## Verification

Built on Windows with .NET 8 and run against the live service. Retrieval succeeds on 新楓之谷, 新龍之谷, 瑪奇, CSO and 艾爾之光.

Both payload kinds are covered by that set, per the characterisation on #376 — which is the point of testing more than MapleStory.

Before that, the decoder was checked by round-tripping both payload shapes through all 16 selectors, plus the malformed-input and block-alignment cases, and confirmed to fail with the #376 acceptance test reverted.

**Not tested: HK.** No account to try it with. Its page carries no `m_objData`, so it takes the unchanged branch — but that is reasoning, not a measurement.

This branch has no test project, so the round-trip check was a scratch script rather than something committed; the live run above is the real evidence.

## Notes

- The second commit swaps this file's `log4net` calls for `Console`. This branch references log4net but never configures an appender, so those lines wrote to nothing — silent exactly when someone is trying to find out which route ran and which `CV` was sent. It also prints the chosen route once per retrieval.
- No new i18n keys: every failure reuses an existing `errmsg` string.

Decoding algorithm published by @takidog on #368. The four-title characterisation of the two payloads by @ToooAir on #376.
