### PR TITLE
fix(window): change the target width with the DOM, not before it

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -598,6 +598,23 @@ export function installRouterGuards(router: Router, deps: RouterGuardDeps): void
    */
   const appWindow = getCurrentWindow()
   let currentWidth = 560
+  /**
+   * The width the route we are navigating *to* wants, held until the
+   * observer re-attaches.
+   *
+   * `afterEach` used to write `currentWidth` directly. That runs
+   * synchronously, while `attachObserver` — which disconnects the old
+   * observer and re-measures against the new DOM — is deferred to the
+   * next paint. In between, the *old* observer is still live and the old
+   * page (or a half-mounted new one) is still in the DOM, so a fit landing
+   * in that gap measured the new route's width against the previous
+   * route's content and applied a size belonging to neither.
+   *
+   * Only Settings makes that visible: it is the one route whose width
+   * changes on entry (420/480 → 660), so it is the one transition where
+   * the two values can disagree.
+   */
+  let pendingWidth: number | null = null
   let observer: ResizeObserver | null = null
 
   /**
@@ -872,6 +889,11 @@ export function installRouterGuards(router: Router, deps: RouterGuardDeps): void
    * (they fire in the same microtask as `observe()`).
    */
   function attachObserver(): void {
+    // Width and DOM change together, here — see `pendingWidth`.
+    if (pendingWidth !== null) {
+      currentWidth = pendingWidth
+      pendingWidth = null
+    }
     if (observer) observer.disconnect()
     const root = document.querySelector('[data-window-root]') as HTMLElement | null
     if (!root) return
@@ -925,7 +947,14 @@ export function installRouterGuards(router: Router, deps: RouterGuardDeps): void
     // A route that is not the whole window must not drive its size.
     if (to.meta.fitsWindow === false) return
     const w = to.meta.windowWidth as number | undefined
-    if (w) currentWidth = w
+    if (w) pendingWidth = w
+    /*
+     * Forget what we last applied: it describes the route we are leaving.
+     * Keeping it means a mid-transition size can land within the guard's
+     * one-pixel tolerance of the correct one and suppress it, leaving the
+     * window at a size nothing asked for.
+     */
+    lastApplied = null
     scheduleAttach(attachObserver)
   })
 }


### PR DESCRIPTION
Towards #381. **Unverified against the reported symptom** — see below.

## What

- `afterEach` no longer writes `currentWidth` directly. It records the incoming route's width, and `attachObserver` applies it at the moment it re-attaches to the new DOM.
- `afterEach` clears `lastApplied`.

## Why

`afterEach` runs synchronously; `attachObserver` — which disconnects the old observer and re-measures against the new page — is deferred to the next paint. In that gap the old observer is still live and the old page (or a half-mounted new one) is still in the DOM, so any fit landing there measured **the new route's width against the previous route's content** and applied a size belonging to neither.

Only Settings makes that reachable: it is the one route whose width changes on entry (420/480 → 660). Every other transition keeps the same width, so the two values cannot disagree.

Clearing `lastApplied` is the second half. It describes the route being left; keeping it lets a mid-transition size land within the guard's one-pixel tolerance of the correct one and suppress it, leaving the window at a size nothing asked for.

## What this does not claim

Neither of the two machines available here reproduces #381, with or without forcing the height cap to engage. This fixes a defect found by reading the transition path, and that defect is consistent with the report (Settings only, width visibly moving, survives #369's ±1 guard because that guard addresses rounding, not a stale width). It is not confirmed to be *the* cause.

#369 was also a reasoned fix and did not resolve it. Worth landing only if the reporter can confirm — otherwise the next step is their display scaling, text size and resolution, which is what separates their machine from ours.

## How to test

Regression only, since the bug does not reproduce here: boot sizing is unchanged (measured 435×299, 0 transitions over 4s, identical before and after).

1. Launch — the login window is its normal size.
2. Navigate login → accounts → settings → about; each lands at its own size with no visible step through a wrong one.

## Checklist

- [x] `cargo clippy -- -D warnings` passes (no Rust changes)
- [x] `npm run lint` passes
- [x] Tested locally with `cargo tauri dev` — regression only
- [x] No breaking changes to existing features
