### PR TITLE
feat(announcement): download-source notice, shown once for ten seconds

### DIFF
--- a/src/components/AnnouncementBody.vue
+++ b/src/components/AnnouncementBody.vue
@@ -16,7 +16,12 @@ import { useI18n } from 'vue-i18n'
 
 import { commands } from '../types/bindings'
 import { safeInvoke } from '../services/invoke'
-import { ANNOUNCEMENT_MAPLELINK_URL, ANNOUNCEMENT_MORE_INFO_URL } from '../constants/announcement'
+import {
+  ANNOUNCEMENT_BEANFUN_RELEASES_URL,
+  ANNOUNCEMENT_MAPLELINK_RELEASES_URL,
+  ANNOUNCEMENT_MAPLELINK_URL,
+  ANNOUNCEMENT_MORE_INFO_URL,
+} from '../constants/announcement'
 
 defineOptions({ name: 'AnnouncementBody' })
 
@@ -31,7 +36,36 @@ async function open(url: string): Promise<void> {
 
 <template>
   <div class="ann-body" :data-testid="`announcement-body-${id}`">
-    <template v-if="id === '2026-07-dual-line-development-notice'">
+    <template v-if="id === '2026-09-download-source'">
+      <p class="ann-body__intro">{{ t('announcement.downloadSource.intro') }}</p>
+
+      <div class="ann-body__rule">
+        <p class="ann-body__rule-text">{{ t('announcement.downloadSource.rule') }}</p>
+        <div class="ann-body__releases">
+          <a
+            class="ann-body__release"
+            data-testid="announcement-releases-beanfun"
+            @click="open(ANNOUNCEMENT_BEANFUN_RELEASES_URL)"
+          >
+            <span class="ann-body__release-name">Beanfun</span>
+            <span class="ann-body__release-url">{{ ANNOUNCEMENT_BEANFUN_RELEASES_URL }}</span>
+          </a>
+          <a
+            class="ann-body__release"
+            data-testid="announcement-releases-maplelink"
+            @click="open(ANNOUNCEMENT_MAPLELINK_RELEASES_URL)"
+          >
+            <span class="ann-body__release-name">MapleLink</span>
+            <span class="ann-body__release-url">{{ ANNOUNCEMENT_MAPLELINK_RELEASES_URL }}</span>
+          </a>
+        </div>
+      </div>
+
+      <p class="ann-body__intro">{{ t('announcement.downloadSource.tell') }}</p>
+      <p class="ann-body__act">{{ t('announcement.downloadSource.act') }}</p>
+    </template>
+
+    <template v-else-if="id === '2026-07-dual-line-development-notice'">
       <p class="ann-body__intro">{{ t('announcement.intro') }}</p>
 
       <div class="ann-body__tracks">
@@ -76,6 +110,58 @@ async function open(url: string): Promise<void> {
 </template>
 
 <style scoped>
+.ann-body__rule {
+  margin-bottom: 18px;
+  padding: 14px 16px;
+  border: 1px solid var(--bf-outline-variant, rgb(0 0 0 / 10%));
+  border-radius: 12px;
+  background: var(--bf-surface-variant, rgb(0 0 0 / 3%));
+}
+
+.ann-body__rule-text {
+  margin: 0;
+  font-size: 0.85rem;
+  line-height: 1.7;
+  color: var(--bf-on-surface, #54443a);
+}
+
+.ann-body__releases {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 12px;
+}
+
+.ann-body__release {
+  cursor: pointer;
+}
+
+.ann-body__release-name {
+  display: block;
+  font-size: 0.75rem;
+  color: var(--bf-on-surface-variant, #8a7a6c);
+}
+
+.ann-body__release-url {
+  display: block;
+  overflow-wrap: anywhere;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--bf-primary, #c8641e);
+}
+
+.ann-body__release:hover .ann-body__release-url {
+  text-decoration: underline;
+}
+
+.ann-body__act {
+  margin: 0 0 18px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  line-height: 1.7;
+  color: var(--bf-on-surface, #54443a);
+}
+
 .ann-body__intro {
   margin: 0 0 18px;
   font-size: 0.9rem;

--- a/src/constants/announcement.ts
+++ b/src/constants/announcement.ts
@@ -50,10 +50,31 @@ export const ANNOUNCEMENT_MAPLELINK_URL = 'https://github.com/lshw54/maplelink'
 export const ANNOUNCEMENT_MORE_INFO_URL = 'https://github.com/pungin/Beanfun/issues/323'
 
 /**
+ * The only places either project is published.
+ *
+ * Shown in full inside the download-source notice, not just linked: the
+ * address is the thing a reader compares their own copy against, and a
+ * button labelled "downloads page" gives them nothing to compare.
+ */
+export const ANNOUNCEMENT_BEANFUN_RELEASES_URL = 'https://github.com/pungin/Beanfun/releases'
+export const ANNOUNCEMENT_MAPLELINK_RELEASES_URL = 'https://github.com/lshw54/maplelink/releases'
+
+/**
  * Every announcement, **newest first**. The first entry is the one the
  * banner names.
  */
 export const ANNOUNCEMENTS: readonly AnnouncementDef[] = [
+  {
+    id: '2026-09-download-source',
+    // `pinned`: someone handed a repackaged build cannot tell it from
+    // ours, and the whole notice is one rule they need before they run
+    // it. Ten seconds, then closing counts as read — asked once, not
+    // every launch.
+    level: 'pinned',
+    date: '2026-09-03',
+    titleKey: 'announcement.downloadSource.title',
+    countdownSeconds: 10,
+  },
   {
     id: '2026-07-dual-line-development-notice',
     // Dropped from a 30-second lock to `info`: most people have read

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -328,6 +328,13 @@ const zhTW = {
     altHint: '若驗證一直無法通過，可改用 QR Code 或 Gama Pass 登入。',
   },
   announcement: {
+    downloadSource: {
+      title: '下載來源提醒',
+      intro: '我們接獲回報，有非官方、疑似被重新打包的 Beanfun 啟動器在外流傳。',
+      rule: '開發團隊每次發佈，只會提供 GitHub 上該版本 exe 的下載連結。我們給的永遠是連結，不是檔案。',
+      tell: '所以，如果有人直接把執行檔傳給你，或者你從網盤、論壇轉載、聊天群組附件取得，那就不是我們發出的。Beanfun 與 MapleLink 各自獨立發佈，任何一邊都不會代另一邊派發檔案。',
+      act: '下載與使用前，請先確認來源安全可靠。不是從上面兩個位置取得的，請立即刪除並重新下載 —— 重新打包的版本可能已被植入其他程式，而你的帳號密碼會經過它。',
+    },
     title: '📢 開發狀態與雙線更新公告',
     intro:
       '本專案目前正進行底層現代化重構（採用 Rust + Vue + Tauri）。為提供社群更具彈性的選擇，本專案將與另一開源啟動器 MapleLink 維持雙線並行開發：',
@@ -648,6 +655,13 @@ const zhCN = {
     altHint: '若验证始终无法通过，可改用 QR Code 或 Gama Pass 登录。',
   },
   announcement: {
+    downloadSource: {
+      title: '下载来源提醒',
+      intro: '我们接获回报，有非官方、疑似被重新打包的 Beanfun 启动器在外流传。',
+      rule: '开发团队每次发布，只会提供 GitHub 上该版本 exe 的下载连结。我们给的永远是连结，不是档案。',
+      tell: '所以，如果有人直接把执行档传给你，或者你从网盘、论坛转载、聊天群组附件取得，那就不是我们发出的。Beanfun 与 MapleLink 各自独立发布，任何一边都不会代另一边派发档案。',
+      act: '下载与使用前，请先确认来源安全可靠。不是从上面两个位置取得的，请立即删除并重新下载 —— 重新打包的版本可能已被植入其他程式，而你的帐号密码会经过它。',
+    },
     title: '📢 开发状态与双线更新公告',
     intro:
       '本项目目前正进行底层现代化重构（采用 Rust + Vue + Tauri）。为提供社群更具弹性的选择，本项目将与另一开源启动器 MapleLink 维持双线并行开发：',
@@ -971,6 +985,14 @@ const enUS = {
     altHint: 'If verification keeps failing, try QR Code or Gama Pass sign-in instead.',
   },
   announcement: {
+    downloadSource: {
+      title: 'Where to download this',
+      intro:
+        'We have had reports of unofficial, seemingly repackaged copies of the Beanfun launcher circulating.',
+      rule: 'For every release, the development team gives out one thing: a link to that version’s exe on GitHub. What we hand over is always a link, never a file.',
+      tell: 'So if someone sent you the executable itself, or you got it from a file locker, a forum repost or a chat attachment, it did not come from us. Beanfun and MapleLink publish separately, and neither hands out files on the other’s behalf.',
+      act: 'Before you download it and before you run it, make sure the source is one you can trust. If it did not come from one of the two addresses above, delete it and download it again — a repackaged build can carry anything, and your account and password go through it.',
+    },
     title: '📢 Project Status & Dual-Track Update',
     intro:
       'This project is undergoing a ground-up modernisation (Rust + Vue + Tauri). To give the community a more flexible choice, it now runs in parallel with another open-source launcher, MapleLink:',

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -63,6 +63,25 @@
  * pattern when running in the custom-titlebar shell.
  * ========================================================================= */
 
+/*
+ * The window root fills the window, always.
+ *
+ * This used to be set only by `fitWindow`, as the restore half of its
+ * `height: auto` → measure → `height: 100vh` dance. Anything that grew
+ * the window before that first fit ran therefore left the root at its
+ * natural content height, and the rest of the window — transparent, by
+ * design — showed the desktop straight through. The announcement
+ * overlay does exactly that: it suspends window fitting and then
+ * enlarges the window, on launch, before any fit has happened.
+ *
+ * As a rule rather than a leftover, it holds whether a fit has run or
+ * not. `fitWindow`'s inline `auto` still wins during measurement, and
+ * its inline `100vh` afterwards is now merely redundant.
+ */
+[data-window-root] {
+  height: 100vh;
+}
+
 .bf-glass-window {
   background:
     linear-gradient(180deg, rgba(255, 255, 255, 0.55) 0%, rgba(255, 255, 255, 0.45) 100%),

--- a/tests/unit/components/AnnouncementModal.spec.ts
+++ b/tests/unit/components/AnnouncementModal.spec.ts
@@ -27,6 +27,7 @@ import {
   ANNOUNCEMENT_BANNER_KEY,
   ANNOUNCEMENT_SEEN_KEY,
   LATEST_ANNOUNCEMENT,
+  serializeIds,
   LEGACY_ANNOUNCEMENT_SEEN_KEY,
 } from '../../../src/constants/announcement'
 import { closeAnnouncementList, openAnnouncementList } from '../../../src/services/announcementUi'
@@ -37,8 +38,33 @@ const ok = <T>(data: T): Promise<Result<T, CommandError>> => Promise.resolve({ s
 const mockOpenUrl = vi.mocked(commands.openUrl)
 const mockSetConfig = vi.mocked(commands.setConfig)
 
-/** The shipped notice — `info`, so it is closable at once. */
+/** The shipped notice: the one the overlay opens on launch. */
 const CURRENT = LATEST_ANNOUNCEMENT
+
+/**
+ * Every id, as the component stores them.
+ *
+ * "Read the current one" is not the same as "nothing left to show" once
+ * more than one notice exists — the overlay opens the newest *unread*
+ * one, so seeding only `CURRENT.id` leaves the older notice to pop.
+ */
+const ALL_SEEN = serializeIds(ANNOUNCEMENTS.map((def) => def.id))
+
+/**
+ * Advance past the countdown so the overlay can be closed.
+ *
+ * Most cases here are about what happens once it is closable, not about
+ * the shipped notice's level; advancing keeps them true whichever level
+ * ships.
+ */
+async function settle(): Promise<void> {
+  // A one-second interval, so step it a second at a time and let Vue
+  // flush between ticks rather than jumping the whole way at once.
+  for (let i = 0; i <= (CURRENT.countdownSeconds ?? 0); i += 1) {
+    vi.advanceTimersByTime(1000)
+    await flushPromises()
+  }
+}
 
 let pinia: ReturnType<typeof createPinia>
 
@@ -48,6 +74,10 @@ function mountModal() {
 
 describe('AnnouncementModal', () => {
   beforeEach(() => {
+    // Paired with the `useRealTimers` below, which had been left without a
+    // partner since the shipped notice stopped having a countdown. The
+    // current one has ten seconds, and `settle` steps through them.
+    vi.useFakeTimers()
     pinia = createPinia()
     setActivePinia(pinia)
     // The modal defers its read-check until Config.xml has loaded.
@@ -70,14 +100,20 @@ describe('AnnouncementModal', () => {
     expect(wrapper.find(`[data-testid="announcement-body-${CURRENT.id}"]`).exists()).toBe(true)
   })
 
-  it('is closable at once at info level, and closing counts as read', async () => {
+  it('holds every close affordance for the countdown, then closing counts as read', async () => {
     const wrapper = mountModal()
     await flushPromises()
 
-    // No countdown: the acknowledge button is live immediately…
+    // Locked: the acknowledge button is dead and the × is not offered.
+    expect(
+      (wrapper.get('[data-testid="announcement-dismiss"]').element as HTMLButtonElement).disabled,
+    ).toBe(true)
+    expect(wrapper.find('[data-testid="announcement-close"]').exists()).toBe(false)
+
+    await settle()
+
     const btn = wrapper.get('[data-testid="announcement-dismiss"]')
     expect((btn.element as HTMLButtonElement).disabled).toBe(false)
-    // …and the × is offered too.
     expect(wrapper.find('[data-testid="announcement-close"]').exists()).toBe(true)
 
     await btn.trigger('click')
@@ -88,9 +124,10 @@ describe('AnnouncementModal', () => {
     expect(localStorage.getItem(ANNOUNCEMENT_SEEN_KEY)).toBe(CURRENT.id)
   })
 
-  it('closes from the × and still counts as read at info level', async () => {
+  it('closes from the × and still counts as read', async () => {
     const wrapper = mountModal()
     await flushPromises()
+    await settle()
 
     await wrapper.get('[data-testid="announcement-close"]').trigger('click')
     await flushPromises()
@@ -102,6 +139,7 @@ describe('AnnouncementModal', () => {
   it('closes from the backdrop', async () => {
     const wrapper = mountModal()
     await flushPromises()
+    await settle()
 
     await wrapper.get('[data-testid="announcement"]').trigger('click')
     await flushPromises()
@@ -110,18 +148,23 @@ describe('AnnouncementModal', () => {
   })
 
   it('does not re-open once read', async () => {
-    useConfigStore().entries[ANNOUNCEMENT_SEEN_KEY] = CURRENT.id
+    useConfigStore().entries[ANNOUNCEMENT_SEEN_KEY] = ALL_SEEN
     const wrapper = mountModal()
     await flushPromises()
     expect(wrapper.find('[data-testid="announcement"]').exists()).toBe(false)
     expect(wrapper.find('[data-testid="announcement-banner"]').exists()).toBe(true)
   })
 
-  it('treats a legacy app-version value as acknowledging the inaugural notice', async () => {
+  it('treats a legacy app-version value as acknowledging the inaugural notice only', async () => {
     useConfigStore().entries[LEGACY_ANNOUNCEMENT_SEEN_KEY] = '6.0.5'
     const wrapper = mountModal()
     await flushPromises()
-    expect(wrapper.find('[data-testid="announcement"]').exists()).toBe(false)
+
+    // The inaugural notice counts as read; anything published since does
+    // not, so the newest unread one still opens.
+    const inaugural = ANNOUNCEMENTS[ANNOUNCEMENTS.length - 1]
+    expect(wrapper.find(`[data-testid="announcement-body-${inaugural.id}"]`).exists()).toBe(false)
+    expect(wrapper.find(`[data-testid="announcement-body-${CURRENT.id}"]`).exists()).toBe(true)
   })
 
   it('waits for Config.xml to load before the read-check', async () => {
@@ -131,7 +174,7 @@ describe('AnnouncementModal', () => {
     await flushPromises()
     expect(wrapper.find('[data-testid="announcement"]').exists()).toBe(false)
 
-    config.entries[ANNOUNCEMENT_SEEN_KEY] = CURRENT.id
+    config.entries[ANNOUNCEMENT_SEEN_KEY] = ALL_SEEN
     config.loaded = true
     await flushPromises()
 
@@ -141,13 +184,13 @@ describe('AnnouncementModal', () => {
   it('opens external links from the body via openUrl', async () => {
     const wrapper = mountModal()
     await flushPromises()
-    await wrapper.get('[data-testid="announcement-maplelink"]').trigger('click')
-    expect(commands.openUrl).toHaveBeenCalledWith('https://github.com/lshw54/maplelink')
+    await wrapper.get('[data-testid="announcement-releases-beanfun"]').trigger('click')
+    expect(commands.openUrl).toHaveBeenCalledWith('https://github.com/pungin/Beanfun/releases')
   })
 
   describe('banner', () => {
     beforeEach(() => {
-      useConfigStore().entries[ANNOUNCEMENT_SEEN_KEY] = CURRENT.id
+      useConfigStore().entries[ANNOUNCEMENT_SEEN_KEY] = ALL_SEEN
     })
 
     it('opens the notice itself — no intermediate list', async () => {
@@ -181,7 +224,7 @@ describe('AnnouncementModal', () => {
 
   describe('archive', () => {
     beforeEach(() => {
-      useConfigStore().entries[ANNOUNCEMENT_SEEN_KEY] = CURRENT.id
+      useConfigStore().entries[ANNOUNCEMENT_SEEN_KEY] = ALL_SEEN
     })
 
     it('opens from the shared opener (Settings uses this) and lists subject + date', async () => {


### PR DESCRIPTION
## What

A `pinned` notice about where this app is published: ten seconds, then closing counts as read, so each person is asked once. Both projects' releases pages are listed in full and clickable — the address is what a reader compares their own copy against.

Registry entry, body branch and three locales, per the procedure in `constants/announcement.ts`.

## Why

Reports of unofficial, repackaged Beanfun launchers circulating. The notice gives one rule that needs no technical skill to apply: we hand out links, never files. Anything that arrived as a file did not come from us. MapleLink is named too, because a repackage can claim to be either and someone who only knows one address cannot check the other.

## Spec changes this forced

Second announcement, so some fixtures that were true with one no longer are:

- `ANNOUNCEMENT_SEEN_KEY` was seeded with `CURRENT.id`. That means "read the newest", not "nothing left to show" — the overlay opens the newest *unread* notice, so the older one popped instead. Seeded with all ids now.
- The shipped notice has a countdown again, so `settle()` steps through it. `afterEach` had been calling `useRealTimers` with no `useFakeTimers` to pair with since the last notice lost its lock; armed.
- The legacy-value test asserted the overlay stays shut. A legacy acknowledgement covers the inaugural notice only, so it now asserts the newer one still opens — which is the behaviour we want.
- The external-link test clicked a testid from the dual-track body; it clicks the shipped body's link.

## How to test

1. Launch — the notice opens, the button counts down from ten, the × appears when it finishes.
2. Close it, relaunch — it does not come back; the banner remains.
3. Settings → announcements: both entries, each with its own title and body.
4. Both addresses open in a browser.

## Checklist

- [x] `cargo clippy -- -D warnings` passes (no Rust changes)
- [x] `npm run lint` passes
- [x] Tested locally with `cargo tauri dev`
- [x] No breaking changes to existing features
