### PR TITLE
chore(deps): bump @humanfs/node to 0.16.8 to clear GHSA-p498-v437-472g

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -973,25 +973,39 @@
       "license": "MIT"
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
       "engines": {
         "node": ">=18.18.0"
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.1",
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
         "@humanwhocodes/retry": "^0.4.0"
       },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
       }


### PR DESCRIPTION
Closes Dependabot alert 43 (GHSA-p498-v437-472g).

## What

`@humanfs/node` 0.16.7 → 0.16.8 in the lockfile. `@humanfs/core` came along as 0.19.1 → 0.19.2.

## Why

Recursive copy in humanfs followed symlinked files and copied data from outside the source tree. Fixed in 0.16.8.

It reaches us through `eslint`, which asks for `^0.16.6` — so `npm update @humanfs/node` was enough. No override, no eslint bump, nothing outside `package-lock.json`.

Exposure here is close to nil either way: this is a dev dependency that only runs during `npm run lint`, and the flaw needs eslint to recursively copy a tree someone else controls. Cheap to clear, so cleared.

`npm audit` now reports zero vulnerabilities.

## How to test

`npm ci && npm run lint` — eslint runs as before.

## Checklist

- [x] `cargo clippy -- -D warnings` passes (no Rust changes)
- [x] `npm run lint` passes
- [x] Tested locally with `cargo tauri dev` — lockfile only; lint, typecheck and 685 unit tests pass
- [x] No breaking changes to existing features
